### PR TITLE
Phase 2: クロス集計を実装

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,12 @@
       </div>
     </div>
 
+    <!-- クロス集計軸 -->
+    <div class="section hidden" id="cross-config-section">
+      <div class="section-label">04 / クロス集計軸（任意）</div>
+      <div class="cross-col-list" id="cross-col-list"></div>
+    </div>
+
     <div id="error-msg" class="hidden"></div>
 
     <button class="run-btn hidden" id="run-btn" disabled>▶ GT集計を実行</button>

--- a/src/components/CrossConfig.ts
+++ b/src/components/CrossConfig.ts
@@ -1,0 +1,36 @@
+export interface CrossConfigState {
+  crossSelected: Record<string, boolean>;
+}
+
+let state: CrossConfigState = { crossSelected: {} };
+
+export function initCrossConfig(saColumns: string[]): void {
+  state = { crossSelected: {} };
+  saColumns.forEach((col) => (state.crossSelected[col] = false));
+
+  const list = document.getElementById("cross-col-list")!;
+  list.innerHTML = "";
+
+  saColumns.forEach((col) => {
+    const label = document.createElement("label");
+    label.className = "cross-col-item";
+
+    const cb = document.createElement("input");
+    cb.type = "checkbox";
+    cb.className = "col-pick";
+    cb.dataset.col = col;
+    cb.addEventListener("change", () => {
+      state.crossSelected[col] = cb.checked;
+    });
+
+    label.appendChild(cb);
+    label.appendChild(document.createTextNode(" " + col));
+    list.appendChild(label);
+  });
+}
+
+export function getCrossColsSelected(): string[] {
+  return Object.entries(state.crossSelected)
+    .filter(([, v]) => v)
+    .map(([k]) => k);
+}

--- a/src/components/ResultTable.ts
+++ b/src/components/ResultTable.ts
@@ -18,11 +18,13 @@ export function renderResults(
   area.classList.remove("hidden");
   area.innerHTML = "";
 
+  const hasCross = results.some((r) => r.cross && r.cross.length > 0);
+
   // ヘッダー
   const hdr = document.createElement("div");
   hdr.className = "results-header";
   hdr.innerHTML = `
-    <h2>GT集計結果</h2>
+    <h2>${hasCross ? "クロス集計結果" : "GT集計結果"}</h2>
     <span class="results-meta">
       ${results.length} 問  ／  ${weightCol ? "ウェイトバック適用: " + escHtml(weightCol) : "実数集計"}
     </span>
@@ -39,14 +41,14 @@ export function renderResults(
   area.appendChild(hdr);
 
   const grid = document.createElement("div");
-  grid.className = "tables-grid";
+  grid.className = hasCross ? "tables-grid cross-mode" : "tables-grid";
   area.appendChild(grid);
 
   const maxPct = Math.max(...results.flatMap((r) => r.rows.map((row) => row.pct)));
 
   results.forEach((res) => {
     const card = document.createElement("div");
-    card.className = "gt-table-card";
+    card.className = res.cross ? "gt-table-card has-cross" : "gt-table-card";
 
     const nLabel = weightCol
       ? `n=${res.n.toFixed(1)}（ウェイト後）`
@@ -58,37 +60,155 @@ export function renderResults(
         <span class="q-type">${res.type}</span>
         <span class="q-n">${nLabel}</span>
       </div>
-      <table class="gt">
-        <thead>
-          <tr>
-            <th>選択肢</th>
-            <th class="right">件数</th>
-            <th class="right">%</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          ${res.rows
-            .map(
-              (row) => `
-            <tr>
-              <td>${escHtml(row.label)}</td>
-              <td class="num">${
-                res.type === "SA" && !weightCol
-                  ? row.count.toLocaleString()
-                  : row.count.toFixed(1)
-              }</td>
-              <td class="pct">${row.pct.toFixed(1)}%</td>
-              <td class="bar-cell">
-                <div class="bar" style="width:${((row.pct / Math.max(maxPct, 1)) * 72).toFixed(1)}px"></div>
-              </td>
-            </tr>
-          `
-            )
-            .join("")}
-        </tbody>
-      </table>
     `;
+
+    if (res.cross && res.cross.length > 0) {
+      card.appendChild(buildCrossTable(res, weightCol, maxPct));
+    } else {
+      card.appendChild(buildGtTable(res, weightCol, maxPct));
+    }
+
     grid.appendChild(card);
   });
+}
+
+function buildGtTable(
+  res: AggResult,
+  weightCol: string,
+  maxPct: number
+): HTMLTableElement {
+  const table = document.createElement("table");
+  table.className = "gt";
+  table.innerHTML = `
+    <thead>
+      <tr>
+        <th>選択肢</th>
+        <th class="right">件数</th>
+        <th class="right">%</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      ${res.rows
+        .map(
+          (row) => `
+        <tr>
+          <td>${escHtml(row.label)}</td>
+          <td class="num">${
+            res.type === "SA" && !weightCol
+              ? row.count.toLocaleString()
+              : row.count.toFixed(1)
+          }</td>
+          <td class="pct">${row.pct.toFixed(1)}%</td>
+          <td class="bar-cell">
+            <div class="bar" style="width:${((row.pct / Math.max(maxPct, 1)) * 72).toFixed(1)}px"></div>
+          </td>
+        </tr>
+      `
+        )
+        .join("")}
+    </tbody>
+  `;
+  return table;
+}
+
+function buildCrossTable(
+  res: AggResult,
+  weightCol: string,
+  _maxPct: number
+): HTMLTableElement {
+  const cross = res.cross!;
+  const table = document.createElement("table");
+  table.className = "gt cross-table";
+
+  // ヘッダー行1: 全体 | クロス軸グループ...
+  const tr1 = document.createElement("tr");
+
+  const thLabel = document.createElement("th");
+  thLabel.rowSpan = 2;
+  thLabel.textContent = "選択肢";
+  tr1.appendChild(thLabel);
+
+  // 全体列グループ
+  const thTotal = document.createElement("th");
+  thTotal.colSpan = 2;
+  thTotal.className = "cross-group-header gt-group";
+  thTotal.innerHTML = `全体<br><span class="cross-n">n=${weightCol ? res.n.toFixed(1) : res.n.toLocaleString()}</span>`;
+  tr1.appendChild(thTotal);
+
+  // クロス軸ごとのグループヘッダー
+  cross.forEach((section) => {
+    const th = document.createElement("th");
+    th.colSpan = section.headers.length;
+    th.className = "cross-group-header";
+    th.textContent = section.cross_col;
+    tr1.appendChild(th);
+  });
+
+  // ヘッダー行2: 件数 | % | 各クロス値(n=X)...
+  const tr2 = document.createElement("tr");
+
+  const thCount = document.createElement("th");
+  thCount.className = "right";
+  thCount.textContent = "件数";
+  tr2.appendChild(thCount);
+
+  const thPct = document.createElement("th");
+  thPct.className = "right";
+  thPct.textContent = "%";
+  tr2.appendChild(thPct);
+
+  cross.forEach((section) => {
+    section.headers.forEach((h) => {
+      const th = document.createElement("th");
+      th.className = "right cross-val-header";
+      const nStr = weightCol ? h.n.toFixed(1) : h.n.toLocaleString();
+      th.innerHTML = `${escHtml(h.label)}<br><span class="cross-n">n=${nStr}</span>`;
+      tr2.appendChild(th);
+    });
+  });
+
+  const thead = document.createElement("thead");
+  thead.appendChild(tr1);
+  thead.appendChild(tr2);
+  table.appendChild(thead);
+
+  // ボディ
+  const tbody = document.createElement("tbody");
+  res.rows.forEach((row, rowIdx) => {
+    const tr = document.createElement("tr");
+
+    const tdLabel = document.createElement("td");
+    tdLabel.textContent = row.label;
+    tr.appendChild(tdLabel);
+
+    const tdCount = document.createElement("td");
+    tdCount.className = "num";
+    tdCount.textContent =
+      res.type === "SA" && !weightCol
+        ? row.count.toLocaleString()
+        : row.count.toFixed(1);
+    tr.appendChild(tdCount);
+
+    const tdPct = document.createElement("td");
+    tdPct.className = "pct";
+    tdPct.textContent = row.pct.toFixed(1) + "%";
+    tr.appendChild(tdPct);
+
+    // クロスセル
+    cross.forEach((section) => {
+      const crossRow = section.rows[rowIdx];
+      crossRow.cells.forEach((cell) => {
+        const td = document.createElement("td");
+        td.className = "pct cross-pct";
+        td.textContent = cell.pct.toFixed(1) + "%";
+        tr.appendChild(td);
+      });
+    });
+
+    tbody.appendChild(tr);
+  });
+
+  table.appendChild(tbody);
+  return table;
 }

--- a/src/lib/aggregate.ts
+++ b/src/lib/aggregate.ts
@@ -6,11 +6,26 @@ export interface AggRow {
   pct: number;
 }
 
+export interface CrossHeader {
+  label: string;
+  n: number;
+}
+
+export interface CrossSection {
+  cross_col: string;
+  headers: CrossHeader[];
+  rows: {
+    label: string;
+    cells: { count: number; pct: number }[];
+  }[];
+}
+
 export interface AggResult {
   col: string;
   type: "SA" | "MA";
   n: number;
   rows: AggRow[];
+  cross?: CrossSection[];
 }
 
 function totalN(
@@ -21,16 +36,60 @@ function totalN(
   return data.reduce((s, r) => s + (parseFloat(r[weightCol]) || 0), 0);
 }
 
+function computeCrossSection(
+  data: Record<string, string>[],
+  rowCol: string,
+  rowValues: string[],
+  crossCol: string,
+  weightCol: string
+): CrossSection {
+  const crossValSet = new Set<string>();
+  data.forEach((r) => {
+    const v = r[crossCol];
+    if (v !== "" && v !== null && v !== undefined) crossValSet.add(v);
+  });
+  const crossValues = Array.from(crossValSet).sort((a, b) => {
+    const na = parseFloat(a), nb = parseFloat(b);
+    if (!isNaN(na) && !isNaN(nb)) return na - nb;
+    return a.localeCompare(b);
+  });
+
+  const headers: CrossHeader[] = crossValues.map((cv) => {
+    const subset = data.filter((r) => r[crossCol] === cv);
+    const n = weightCol
+      ? subset.reduce((s, r) => s + (parseFloat(r[weightCol]) || 0), 0)
+      : subset.length;
+    return { label: cv, n };
+  });
+
+  const rows = rowValues.map((rv) => {
+    const cells = crossValues.map((cv, i) => {
+      const subset = data.filter((r) => r[rowCol] === rv && r[crossCol] === cv);
+      const count = weightCol
+        ? subset.reduce((s, r) => s + (parseFloat(r[weightCol]) || 0), 0)
+        : subset.length;
+      const crossN = headers[i].n;
+      return { count, pct: crossN > 0 ? (count / crossN) * 100 : 0 };
+    });
+    return { label: rv, cells };
+  });
+
+  return { cross_col: crossCol, headers, rows };
+}
+
 export function aggregate(
   data: Record<string, string>[],
   headers: string[],
   colTypes: Record<string, string>,
-  weightCol: string
+  weightCol: string,
+  crossCols: string[] = []
 ): AggResult[] {
   const results: AggResult[] = [];
 
-  // SA集計
-  const saColumns = headers.filter((col) => colTypes[col] === "sa");
+  // SA集計（クロス軸列は除外）
+  const saColumns = headers.filter(
+    (col) => colTypes[col] === "sa" && !crossCols.includes(col)
+  );
   saColumns.forEach((col) => {
     const n = totalN(data, weightCol);
     const counts: Record<string, number> = {};
@@ -48,16 +107,21 @@ export function aggregate(
       return a.localeCompare(b);
     });
 
-    results.push({
-      col,
-      type: "SA",
-      n,
-      rows: sortedKeys.map((k) => ({
-        label: k,
-        count: counts[k],
-        pct: n > 0 ? (counts[k] / n) * 100 : 0,
-      })),
-    });
+    const rows: AggRow[] = sortedKeys.map((k) => ({
+      label: k,
+      count: counts[k],
+      pct: n > 0 ? (counts[k] / n) * 100 : 0,
+    }));
+
+    const result: AggResult = { col, type: "SA", n, rows };
+
+    if (crossCols.length > 0) {
+      result.cross = crossCols.map((cc) =>
+        computeCrossSection(data, col, sortedKeys, cc, weightCol)
+      );
+    }
+
+    results.push(result);
   });
 
   // MAグループ集計

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -4,6 +4,16 @@ export function downloadAllCSV(
   results: AggResult[],
   _weightCol: string
 ): void {
+  const hasCross = results.some((r) => r.cross && r.cross.length > 0);
+
+  if (hasCross) {
+    downloadCrossCSV(results);
+  } else {
+    downloadGtCSV(results);
+  }
+}
+
+function downloadGtCSV(results: AggResult[]): void {
   const rows: string[][] = [["変数名", "種別", "選択肢", "件数", "%"]];
 
   results.forEach((res) => {
@@ -20,6 +30,67 @@ export function downloadAllCSV(
     rows.push([]);
   });
 
+  exportCSV(rows, `gt_result_${today()}.csv`);
+}
+
+function downloadCrossCSV(results: AggResult[]): void {
+  // クロス集計全体のヘッダーを動的に構築
+  // 最初の cross 構造を使ってヘッダー行を作成
+  const firstCross = results.find((r) => r.cross && r.cross.length > 0)?.cross;
+  if (!firstCross) {
+    downloadGtCSV(results);
+    return;
+  }
+
+  // ヘッダー行1: 変数名 | 種別 | 選択肢 | 全体_件数 | 全体_% | [cross_col_val_pct...]
+  const headerRow1 = ["変数名", "種別", "選択肢", "全体_件数", "全体_%"];
+  const headerRow2 = ["", "", "", "", ""];
+  firstCross.forEach((section) => {
+    section.headers.forEach((h) => {
+      headerRow1.push(section.cross_col);
+      headerRow2.push(`${h.label}(n=${h.n.toFixed(1)})`);
+    });
+  });
+
+  const rows: string[][] = [headerRow1, headerRow2];
+
+  results.forEach((res) => {
+    const cross = res.cross;
+    res.rows.forEach((row, rowIdx) => {
+      const dataRow = [
+        res.col,
+        res.type,
+        row.label,
+        row.count.toFixed(1),
+        row.pct.toFixed(1),
+      ];
+      if (cross) {
+        cross.forEach((section) => {
+          const crossRow = section.rows[rowIdx];
+          crossRow.cells.forEach((cell) => {
+            dataRow.push(cell.pct.toFixed(1));
+          });
+        });
+      }
+      rows.push(dataRow);
+    });
+    // n行
+    const nRow = [res.col, res.type, "n", res.n.toFixed(1), ""];
+    if (res.cross) {
+      res.cross.forEach((section) => {
+        section.headers.forEach((h) => {
+          nRow.push(h.n.toFixed(1));
+        });
+      });
+    }
+    rows.push(nRow);
+    rows.push([]);
+  });
+
+  exportCSV(rows, `cross_result_${today()}.csv`);
+}
+
+function exportCSV(rows: string[][], filename: string): void {
   const bom = "\uFEFF";
   const csv =
     bom +
@@ -32,7 +103,11 @@ export function downloadAllCSV(
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
-  a.download = `gt_result_${new Date().toISOString().slice(0, 10)}.csv`;
+  a.download = filename;
   a.click();
   URL.revokeObjectURL(url);
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import "./style.css";
 import { initDropzone } from "./components/Dropzone";
 import { initColConfig, type ColConfigState } from "./components/ColConfig";
+import { initCrossConfig, getCrossColsSelected } from "./components/CrossConfig";
 import { renderResults } from "./components/ResultTable";
 import { aggregate, type AggResult } from "./lib/aggregate";
 import {
@@ -30,8 +31,16 @@ function onCSVLoaded(result: ParseResult, fileName: string): void {
 
   colConfig = initColConfig(headers);
 
+  // クロス集計軸候補: SA列（MA以外）
+  const saColumns = headers.filter((col) => {
+    const t = colConfig!.colTypes[col];
+    return t === "sa";
+  });
+  initCrossConfig(saColumns);
+
   document.getElementById("col-config-section")!.classList.remove("hidden");
   document.getElementById("weight-section")!.classList.remove("hidden");
+  document.getElementById("cross-config-section")!.classList.remove("hidden");
   document.getElementById("run-btn")!.classList.remove("hidden");
   (document.getElementById("run-btn") as HTMLButtonElement).disabled = false;
 }
@@ -70,20 +79,34 @@ function runAggregation(): void {
   const weightCol = (
     document.getElementById("weight-col-select") as HTMLSelectElement
   ).value;
+  const crossCols = getCrossColsSelected();
+
   const selectedColumns = headers.filter((col) => cfg.colSelected[col]);
   const selectedSet = new Set(selectedColumns);
   const effectiveWeightCol =
     weightCol && selectedSet.has(weightCol) ? weightCol : "";
 
+  // クロス軸列とウェイト列も投影に含める
+  const allNeededCols = [
+    ...new Set([
+      ...selectedColumns,
+      ...crossCols,
+      ...(effectiveWeightCol ? [effectiveWeightCol] : []),
+    ]),
+  ];
+
   try {
     let results: AggResult[];
 
     if (isWasmReady()) {
-      // Ruby Wasm で集計
+      // Ruby Wasm で集計（クロス軸列は columns に含めない）
       const columns = selectedColumns
         .filter((col) => {
           const t = cfg.colTypes[col];
-          return t === "sa" || (t && t.startsWith("ma:"));
+          return (
+            (t === "sa" || (t && t.startsWith("ma:"))) &&
+            !crossCols.includes(col)
+          );
         })
         .map((col) => {
           const t = cfg.colTypes[col];
@@ -93,12 +116,14 @@ function runAggregation(): void {
           return { name: col, type: "sa" };
         });
 
-      const projectedData = projectRowsForWasm(parsedData, selectedColumns);
+      const projectedData = projectRowsForWasm(parsedData, allNeededCols);
 
       const payload = {
         data: projectedData,
         columns,
         weight_col: effectiveWeightCol,
+        mode: crossCols.length > 0 ? "cross" : "gt",
+        cross_cols: crossCols,
       };
 
       results = runRubyAggregation(payload);
@@ -106,17 +131,18 @@ function runAggregation(): void {
       // JSフォールバック
       const effectiveColTypes = { ...cfg.colTypes };
       headers.forEach((col) => {
-        if (!selectedSet.has(col)) {
+        if (!selectedSet.has(col) && !crossCols.includes(col)) {
           effectiveColTypes[col] = "exclude";
         }
       });
 
-      const projectedData = projectRowsForWasm(parsedData, selectedColumns);
+      const projectedData = projectRowsForWasm(parsedData, allNeededCols);
       results = aggregate(
         projectedData,
         headers,
         effectiveColTypes,
-        effectiveWeightCol
+        effectiveWeightCol,
+        crossCols
       );
     }
 

--- a/src/ruby/aggregator.rb
+++ b/src/ruby/aggregator.rb
@@ -3,6 +3,8 @@ class Aggregator
     @data       = payload['data']
     @columns    = payload['columns']
     @weight_col = payload['weight_col']
+    @mode       = payload['mode'] || 'gt'
+    @cross_cols = payload['cross_cols'] || []
   end
 
   def run
@@ -19,6 +21,14 @@ class Aggregator
       @data.sum { |r| (r[@weight_col] || 0).to_f }
     else
       @data.size
+    end
+  end
+
+  def weighted_count(subset)
+    if @weight_col && !@weight_col.empty?
+      subset.sum { |r| (r[@weight_col] || 0).to_f }
+    else
+      subset.size.to_f
     end
   end
 
@@ -40,13 +50,46 @@ class Aggregator
         Float(k) rescue k.to_s
       end
 
-      {
+      row_values = sorted.map { |k, _| k }
+
+      result = {
         'col'  => col,
         'type' => 'SA',
         'n'    => n,
         'rows' => sorted.map { |k, v| { 'label' => k, 'count' => v, 'pct' => n > 0 ? v / n * 100 : 0 } }
       }
+
+      if @mode == 'cross' && @cross_cols.any?
+        result['cross'] = @cross_cols.map { |cc| cross_section(col, row_values, cc) }
+      end
+
+      result
     end
+  end
+
+  def cross_section(row_col, row_values, cross_col)
+    cross_values = @data
+      .map { |r| r[cross_col].to_s }
+      .reject(&:empty?)
+      .uniq
+      .sort_by { |v| Float(v) rescue v }
+
+    headers = cross_values.map do |cv|
+      subset = @data.select { |r| r[cross_col].to_s == cv }
+      { 'label' => cv, 'n' => weighted_count(subset) }
+    end
+
+    rows = row_values.map do |rv|
+      cells = cross_values.map.with_index do |cv, i|
+        subset = @data.select { |r| r[row_col].to_s == rv && r[cross_col].to_s == cv }
+        cross_n = headers[i]['n']
+        count = weighted_count(subset)
+        { 'count' => count, 'pct' => cross_n > 0 ? count / cross_n * 100.0 : 0 }
+      end
+      { 'label' => rv, 'cells' => cells }
+    end
+
+    { 'cross_col' => cross_col, 'headers' => headers, 'rows' => rows }
   end
 
   def aggregate_ma

--- a/src/style.css
+++ b/src/style.css
@@ -411,6 +411,75 @@ table.gt tr:hover td { background: rgba(232,255,71,0.03); }
 
 .download-btn:hover { border-color: var(--accent2); color: var(--accent2); }
 
+/* クロス集計軸 */
+.cross-col-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.cross-col-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.78rem;
+  padding: 0.3rem 0.4rem;
+  border-radius: 3px;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.cross-col-item:hover { background: var(--surface2); }
+
+/* クロス集計テーブル */
+.tables-grid.cross-mode {
+  grid-template-columns: 1fr;
+}
+
+.gt-table-card.has-cross {
+  overflow-x: auto;
+}
+
+table.gt.cross-table {
+  min-width: 400px;
+}
+
+table.gt th.cross-group-header {
+  text-align: center;
+  background: rgba(71,200,255,0.06);
+  border-left: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  color: var(--accent2);
+}
+
+table.gt th.gt-group {
+  background: rgba(232,255,71,0.06);
+  color: var(--accent);
+}
+
+table.gt th.cross-val-header {
+  text-align: right;
+  border-left: 1px solid rgba(42,42,53,0.6);
+  font-size: 0.62rem;
+  white-space: nowrap;
+}
+
+.cross-n {
+  color: var(--muted);
+  font-size: 0.6rem;
+  font-weight: normal;
+}
+
+table.gt td.cross-pct {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: var(--accent2);
+  border-left: 1px solid rgba(42,42,53,0.6);
+  opacity: 0.85;
+}
+
 /* ユーティリティ */
 .hidden { display: none !important; }
 


### PR DESCRIPTION
## 概要

Phase 2 としてクロス集計機能を実装しました。

## 変更内容

### UI
- 左パネルに **「04 / クロス集計軸（任意）」** セクションを追加
  - SA列を一覧表示し、チェックした列がクロス軸（列軸）になる
  - チェックなし → 従来通りのGT集計のみ
- 結果カードのテーブルを拡張
  - 全体列（件数 + %）の右側に、クロス軸ごとのカラムグループを追加
  - クロス軸ヘッダーに列名と各値のn数を表示

### ロジック
- `aggregator.rb` に `cross_section` メソッドを追加（Ruby Wasm パス）
- `aggregate.ts` に `computeCrossSection` 関数を追加（JS フォールバック）
- `CrossSection` / `CrossHeader` インターフェースを新規追加
- `AggResult` に `cross?: CrossSection[]` フィールドを追加

### CSV出力
- クロス集計時は `cross_result_YYYY-MM-DD.csv` で出力
- クロス軸の値ごとに列を追加（%のみ）

## 現フェーズの制約
- SA × SA クロスのみ対応（MA × クロス は Phase 3 以降）
- クロス軸に選択した列は、独自の集計カードに出力されない

## 確認方法

```
npm run dev
```

1. test用CSVをアップロード（`id, weight, q1, q2, q3_1, q3_2, q3_3, sex, age` など）
2. 「04 / クロス集計軸」で `sex`, `age` にチェック
3. 集計実行 → q1, q2 の結果カードにクロス列が表示されることを確認