### PR TITLE
feat: MA設問のクロス集計対応

### DIFF
--- a/src/components/CrossConfig.ts
+++ b/src/components/CrossConfig.ts
@@ -1,34 +1,39 @@
+import type { QuestionDef } from "../lib/aggregator";
+
 export interface CrossConfigState {
+  questions: QuestionDef[];
   crossSelected: Record<string, boolean>;
 }
 
-let state: CrossConfigState = { crossSelected: {} };
+let state: CrossConfigState = { questions: [], crossSelected: {} };
 
 export function initCrossConfig(
-  saColumns: string[],
+  questions: QuestionDef[],
   questionLabels: Record<string, string>
 ): void {
-  state = { crossSelected: {} };
-  saColumns.forEach((col) => (state.crossSelected[col] = false));
+  state = { questions, crossSelected: {} };
+  questions.forEach((q) => (state.crossSelected[q.key] = false));
 
   const list = document.getElementById("cross-col-list")!;
   list.innerHTML = "";
 
-  saColumns.forEach((col) => {
+  questions.forEach((q) => {
     const label = document.createElement("label");
     label.className = "cross-col-item";
 
     const cb = document.createElement("input");
     cb.type = "checkbox";
     cb.className = "col-pick";
-    cb.dataset.col = col;
+    cb.dataset.col = q.key;
     cb.addEventListener("change", () => {
-      state.crossSelected[col] = cb.checked;
+      state.crossSelected[q.key] = cb.checked;
     });
 
-    const displayText = questionLabels[col]
-      ? `${col}: ${questionLabels[col]}`
-      : col;
+    const qLabel = questionLabels[q.key];
+    const typeTag = q.type === "MA" ? " [MA]" : "";
+    const displayText = qLabel
+      ? `${q.key}: ${qLabel}${typeTag}`
+      : `${q.key}${typeTag}`;
 
     label.appendChild(cb);
     label.appendChild(document.createTextNode(" " + displayText));
@@ -36,8 +41,6 @@ export function initCrossConfig(
   });
 }
 
-export function getCrossColsSelected(): string[] {
-  return Object.entries(state.crossSelected)
-    .filter(([, v]) => v)
-    .map(([k]) => k);
+export function getCrossColsSelected(): QuestionDef[] {
+  return state.questions.filter((q) => state.crossSelected[q.key]);
 }

--- a/src/components/ResultTable.ts
+++ b/src/components/ResultTable.ts
@@ -34,6 +34,16 @@ function resolveValueLabel(
   }
 }
 
+/** クロス軸ヘッダーのラベルを解決する。MAカラム名の場合valueLabelsで解決 */
+function resolveSubLabel(subLabel: string, meta?: LayoutMeta): string {
+  if (!meta) return subLabel;
+  // MAカラム名の場合: valueLabels[colName]["1"] にラベルがある
+  const maLabel = meta.valueLabels[subLabel]?.["1"];
+  if (maLabel) return maLabel;
+  // SA値の場合はそのまま返す
+  return subLabel;
+}
+
 export function renderResults(
   results: AggResult[],
   weightCol: string,
@@ -65,7 +75,7 @@ export function renderResults(
   csvBtn.style.cssText =
     "margin:0;width:auto;padding:0.4rem 1rem;font-size:0.8rem;";
   csvBtn.textContent = "全件CSV出力";
-  csvBtn.addEventListener("click", () => downloadAllCSV(results, weightCol));
+  csvBtn.addEventListener("click", () => downloadAllCSV(results, weightCol, layoutMeta));
   hdr.appendChild(csvBtn);
 
   area.appendChild(hdr);
@@ -213,7 +223,7 @@ function buildCrossTable(
     const th = document.createElement("th");
     th.className = "right cross-val-header";
     const nStr = weightCol ? sub.n.toFixed(1) : sub.n.toLocaleString();
-    th.innerHTML = `${escHtml(sub.label)}<br><span class="cross-n">n=${nStr}</span>`;
+    th.innerHTML = `${escHtml(resolveSubLabel(sub.label, layoutMeta))}<br><span class="cross-n">n=${nStr}</span>`;
     tr2.appendChild(th);
   });
 

--- a/src/lib/aggregator.ts
+++ b/src/lib/aggregator.ts
@@ -6,7 +6,7 @@ import type * as duckdb from "@duckdb/duckdb-wasm";
 
 export interface Cell {
   main: string;   // 選択肢ラベル（集計対象の設問値）
-  sub: string;    // "GT" or クロス集計軸の値 ("男", "女", ...)
+  sub: string;    // "GT" or クロス集計軸の値 ("男", "女", ...) or MAカラム名
   n: number;      // その sub の母数
   count: number;
   pct: number;
@@ -29,7 +29,7 @@ export interface QuestionDef {
 export interface Query {
   questions: QuestionDef[];
   weight_col: string;
-  cross_cols: string[];
+  cross_cols: QuestionDef[];
 }
 
 /** 集計のエントリポイント。conn上のsurveyビューに対して全設問を集計する */
@@ -54,7 +54,7 @@ export async function aggregate(
       );
     } else {
       results.push(
-        await aggregateMA(conn, q.key, q.columns, totalN, payload.weight_col)
+        await aggregateMA(conn, q.key, q.columns, totalN, payload.weight_col, crossCols, crossHeaderCache)
       );
     }
   }
@@ -72,6 +72,13 @@ function weightExpr(weightCol: string): string {
   return weightCol
     ? `SUM(TRY_CAST("${esc(weightCol)}" AS DOUBLE))`
     : `COUNT(*)::DOUBLE`;
+}
+
+/** MA列の重み付きカウント式 */
+function maWeightedCountExpr(maCol: string, weightCol: string): string {
+  return weightCol
+    ? `SUM(CASE WHEN "${esc(maCol)}" IN ('1','true') THEN TRY_CAST("${esc(weightCol)}" AS DOUBLE) ELSE 0 END)`
+    : `COUNT(CASE WHEN "${esc(maCol)}" IN ('1','true') THEN 1 END)::DOUBLE`;
 }
 
 async function computeTotalN(
@@ -92,29 +99,45 @@ type CrossHeaderCache = Map<
 
 async function fetchCrossHeaders(
   conn: duckdb.AsyncDuckDBConnection,
-  crossCols: string[],
+  crossCols: QuestionDef[],
   weightCol: string
 ): Promise<CrossHeaderCache> {
   const cache: CrossHeaderCache = new Map();
 
-  for (const crossCol of crossCols) {
-    const sql = `
-      SELECT
-        "${esc(crossCol)}" AS cv,
-        ${weightExpr(weightCol)} AS n
-      FROM survey
-      WHERE "${esc(crossCol)}" IS NOT NULL
-        AND "${esc(crossCol)}" != ''
-      GROUP BY "${esc(crossCol)}"
-      ORDER BY
-        TRY_CAST("${esc(crossCol)}" AS DOUBLE) NULLS LAST,
-        "${esc(crossCol)}" ASC
-    `;
-    const result = await conn.query(sql);
-    const headers = result
-      .toArray()
-      .map((r) => ({ label: String(r.cv), n: Number(r.n) }));
-    cache.set(crossCol, { headers, crossValues: headers.map((h) => h.label) });
+  for (const crossQ of crossCols) {
+    if (crossQ.type === "SA") {
+      const col = crossQ.columns[0];
+      const sql = `
+        SELECT
+          "${esc(col)}" AS cv,
+          ${weightExpr(weightCol)} AS n
+        FROM survey
+        WHERE "${esc(col)}" IS NOT NULL
+          AND "${esc(col)}" != ''
+        GROUP BY "${esc(col)}"
+        ORDER BY
+          TRY_CAST("${esc(col)}" AS DOUBLE) NULLS LAST,
+          "${esc(col)}" ASC
+      `;
+      const result = await conn.query(sql);
+      const headers = result
+        .toArray()
+        .map((r) => ({ label: String(r.cv), n: Number(r.n) }));
+      cache.set(crossQ.key, { headers, crossValues: headers.map((h) => h.label) });
+    } else {
+      // MA軸: 各itemカラムごとに該当者数を算出
+      const selectClauses = crossQ.columns.map((col, i) =>
+        `${maWeightedCountExpr(col, weightCol)} AS c${i}`
+      );
+      const sql = `SELECT ${selectClauses.join(", ")} FROM survey`;
+      const result = await conn.query(sql);
+      const row = result.toArray()[0];
+      const headers = crossQ.columns.map((col, i) => ({
+        label: col,
+        n: Number(row[`c${i}`] ?? 0),
+      }));
+      cache.set(crossQ.key, { headers, crossValues: headers.map((h) => h.label) });
+    }
   }
   return cache;
 }
@@ -124,7 +147,7 @@ async function aggregateSA(
   col: string,
   totalN: number,
   weightCol: string,
-  crossCols: string[],
+  crossCols: QuestionDef[],
   crossHeaderCache: CrossHeaderCache
 ): Promise<AggResult> {
   const sql = `
@@ -158,19 +181,27 @@ async function aggregateSA(
   // クロスセル
   if (crossCols.length > 0) {
     const mainValues = rowArr.map((r) => String(r.label));
-    for (const crossCol of crossCols) {
-      const cached = crossHeaderCache.get(crossCol)!;
-      const crossCells = await buildCrossCells(
-        conn, col, mainValues, crossCol, weightCol, cached
-      );
-      cells.push(...crossCells);
+    for (const crossQ of crossCols) {
+      const cached = crossHeaderCache.get(crossQ.key)!;
+      if (crossQ.type === "SA") {
+        const crossCells = await buildCrossCellsSA(
+          conn, col, mainValues, crossQ.columns[0], weightCol, cached
+        );
+        cells.push(...crossCells);
+      } else {
+        const crossCells = await buildCrossCellsMA(
+          conn, col, mainValues, crossQ.columns, weightCol, cached
+        );
+        cells.push(...crossCells);
+      }
     }
   }
 
   return { question: col, type: "SA", cells };
 }
 
-async function buildCrossCells(
+/** SA主軸 × SA軸クロスセル生成 */
+async function buildCrossCellsSA(
   conn: duckdb.AsyncDuckDBConnection,
   mainCol: string,
   mainValues: string[],
@@ -218,18 +249,73 @@ async function buildCrossCells(
   return cells;
 }
 
+/** SA主軸 × MA軸クロスセル生成 */
+async function buildCrossCellsMA(
+  conn: duckdb.AsyncDuckDBConnection,
+  mainCol: string,
+  mainValues: string[],
+  maCols: string[],
+  weightCol: string,
+  cached: { headers: Array<{ label: string; n: number }>; crossValues: string[] }
+): Promise<Cell[]> {
+  const { headers } = cached;
+
+  // 各MA itemごとの、主軸値別カウントを一括取得
+  const selectClauses = maCols.map((maCol, i) => {
+    const expr = weightCol
+      ? `SUM(CASE WHEN "${esc(maCol)}" IN ('1','true') THEN TRY_CAST("${esc(weightCol)}" AS DOUBLE) ELSE 0 END)`
+      : `COUNT(CASE WHEN "${esc(maCol)}" IN ('1','true') THEN 1 END)::DOUBLE`;
+    return `${expr} AS c${i}`;
+  });
+
+  const sql = `
+    SELECT
+      "${esc(mainCol)}" AS mv,
+      ${selectClauses.join(", ")}
+    FROM survey
+    WHERE "${esc(mainCol)}" IS NOT NULL
+      AND "${esc(mainCol)}" != ''
+    GROUP BY "${esc(mainCol)}"
+  `;
+
+  const result = await conn.query(sql);
+  const rowMap = new Map<string, Record<string, number>>();
+  for (const r of result.toArray()) {
+    const counts: Record<string, number> = {};
+    maCols.forEach((_, i) => { counts[`c${i}`] = Number(r[`c${i}`] ?? 0); });
+    rowMap.set(String(r.mv), counts);
+  }
+
+  const cells: Cell[] = [];
+  for (const mv of mainValues) {
+    const counts = rowMap.get(mv);
+    for (let i = 0; i < maCols.length; i++) {
+      const count = counts?.[`c${i}`] ?? 0;
+      const crossN = headers[i].n;
+      cells.push({
+        main: mv,
+        sub: maCols[i],
+        n: crossN,
+        count,
+        pct: crossN > 0 ? (count / crossN) * 100 : 0,
+      });
+    }
+  }
+
+  return cells;
+}
+
 async function aggregateMA(
   conn: duckdb.AsyncDuckDBConnection,
   prefix: string,
   cols: string[],
   totalN: number,
-  weightCol: string
+  weightCol: string,
+  crossCols: QuestionDef[],
+  crossHeaderCache: CrossHeaderCache
 ): Promise<AggResult> {
   const selectClauses = cols.map((col, i) => {
-    const expr = weightCol
-      ? `SUM(CASE WHEN "${esc(col)}" IN ('1','true') THEN TRY_CAST("${esc(weightCol)}" AS DOUBLE) ELSE 0 END)`
-      : `COUNT(CASE WHEN "${esc(col)}" IN ('1','true') THEN 1 END)::DOUBLE`;
-    return `${expr} AS c${i}`;
+    return `${maWeightedCountExpr(col, weightCol)} AS c${i}`;
   });
 
   const sql = `SELECT ${selectClauses.join(", ")} FROM survey`;
@@ -247,5 +333,119 @@ async function aggregateMA(
     };
   });
 
+  // クロスセル
+  if (crossCols.length > 0) {
+    for (const crossQ of crossCols) {
+      const cached = crossHeaderCache.get(crossQ.key)!;
+      if (crossQ.type === "SA") {
+        const crossCells = await buildMACrossCellsSA(
+          conn, cols, crossQ.columns[0], weightCol, cached
+        );
+        cells.push(...crossCells);
+      } else {
+        const crossCells = await buildMACrossCellsMA(
+          conn, cols, crossQ.columns, weightCol, cached
+        );
+        cells.push(...crossCells);
+      }
+    }
+  }
+
   return { question: prefix, type: "MA", cells };
+}
+
+/** MA主軸 × SA軸クロスセル生成 */
+async function buildMACrossCellsSA(
+  conn: duckdb.AsyncDuckDBConnection,
+  maCols: string[],
+  crossCol: string,
+  weightCol: string,
+  cached: { headers: Array<{ label: string; n: number }>; crossValues: string[] }
+): Promise<Cell[]> {
+  const { headers, crossValues } = cached;
+
+  // クロス軸値別に各MAアイテムのカウントを取得
+  const selectClauses = maCols.map((col, i) => {
+    return `${maWeightedCountExpr(col, weightCol)} AS c${i}`;
+  });
+
+  const sql = `
+    SELECT
+      "${esc(crossCol)}" AS cv,
+      ${selectClauses.join(", ")}
+    FROM survey
+    WHERE "${esc(crossCol)}" IS NOT NULL
+      AND "${esc(crossCol)}" != ''
+    GROUP BY "${esc(crossCol)}"
+  `;
+
+  const result = await conn.query(sql);
+  const rowMap = new Map<string, number[]>();
+  for (const r of result.toArray()) {
+    const counts = maCols.map((_, i) => Number(r[`c${i}`] ?? 0));
+    rowMap.set(String(r.cv), counts);
+  }
+
+  const cells: Cell[] = [];
+  for (const maCol of maCols) {
+    const maIdx = maCols.indexOf(maCol);
+    for (let i = 0; i < crossValues.length; i++) {
+      const sv = crossValues[i];
+      const counts = rowMap.get(sv);
+      const count = counts?.[maIdx] ?? 0;
+      const crossN = headers[i].n;
+      cells.push({
+        main: maCol,
+        sub: sv,
+        n: crossN,
+        count,
+        pct: crossN > 0 ? (count / crossN) * 100 : 0,
+      });
+    }
+  }
+
+  return cells;
+}
+
+/** MA主軸 × MA軸クロスセル生成 */
+async function buildMACrossCellsMA(
+  conn: duckdb.AsyncDuckDBConnection,
+  rowMaCols: string[],
+  crossMaCols: string[],
+  weightCol: string,
+  cached: { headers: Array<{ label: string; n: number }>; crossValues: string[] }
+): Promise<Cell[]> {
+  const { headers } = cached;
+
+  // 行MA × 列MAの交差カウントを一括取得
+  const selectClauses: string[] = [];
+  for (let r = 0; r < rowMaCols.length; r++) {
+    for (let c = 0; c < crossMaCols.length; c++) {
+      const expr = weightCol
+        ? `SUM(CASE WHEN "${esc(rowMaCols[r])}" IN ('1','true') AND "${esc(crossMaCols[c])}" IN ('1','true') THEN TRY_CAST("${esc(weightCol)}" AS DOUBLE) ELSE 0 END)`
+        : `COUNT(CASE WHEN "${esc(rowMaCols[r])}" IN ('1','true') AND "${esc(crossMaCols[c])}" IN ('1','true') THEN 1 END)::DOUBLE`;
+      selectClauses.push(`${expr} AS r${r}c${c}`);
+    }
+  }
+
+  const sql = `SELECT ${selectClauses.join(", ")} FROM survey`;
+  const result = await conn.query(sql);
+  const row = result.toArray()[0];
+
+  const cells: Cell[] = [];
+  for (let r = 0; r < rowMaCols.length; r++) {
+    for (let c = 0; c < crossMaCols.length; c++) {
+      const count = Number(row[`r${r}c${c}`] ?? 0);
+      const crossN = headers[c].n;
+      cells.push({
+        main: rowMaCols[r],
+        sub: crossMaCols[c],
+        n: crossN,
+        count,
+        pct: crossN > 0 ? (count / crossN) * 100 : 0,
+      });
+    }
+  }
+
+  return cells;
 }

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -1,9 +1,17 @@
 import type { AggResult } from "./aggregator";
+import type { LayoutMeta } from "./layout";
 import { pivot } from "./pivot";
+
+/** MAカラム名をラベルに解決する */
+function resolveSubLabel(subLabel: string, meta?: LayoutMeta): string {
+  if (!meta) return subLabel;
+  return meta.valueLabels[subLabel]?.["1"] ?? subLabel;
+}
 
 export function downloadAllCSV(
   results: AggResult[],
-  _weightCol: string
+  _weightCol: string,
+  layoutMeta?: LayoutMeta
 ): void {
   const hasCross = results.some((r) => {
     const { subs } = pivot(r.cells);
@@ -11,7 +19,7 @@ export function downloadAllCSV(
   });
 
   if (hasCross) {
-    downloadCrossCSV(results);
+    downloadCrossCSV(results, layoutMeta);
   } else {
     downloadGtCSV(results);
   }
@@ -41,7 +49,7 @@ function downloadGtCSV(results: AggResult[]): void {
   exportCSV(rows, `gt_result_${today()}.csv`);
 }
 
-function downloadCrossCSV(results: AggResult[]): void {
+function downloadCrossCSV(results: AggResult[], layoutMeta?: LayoutMeta): void {
   // 最初の結果からクロス軸構造を取得
   const firstResult = results.find((r) => {
     const { subs } = pivot(r.cells);
@@ -60,7 +68,7 @@ function downloadCrossCSV(results: AggResult[]): void {
   const headerRow2 = ["", "", "", "", ""];
   crossSubs.forEach((sub) => {
     headerRow1.push("");
-    headerRow2.push(`${sub.label}(n=${sub.n.toFixed(1)})`);
+    headerRow2.push(`${resolveSubLabel(sub.label, layoutMeta)}(n=${sub.n.toFixed(1)})`);
   });
 
   const rows: string[][] = [headerRow1, headerRow2];

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,9 +25,23 @@ initDuckDB().catch(() => {
 function initAfterBothLoaded(): void {
   if (headers.length === 0 || !layoutMeta) return;
 
-  // クロス集計軸候補: SA列のみ
-  const saColumns = headers.filter((col) => layoutMeta!.colTypes[col] === "sa");
-  initCrossConfig(saColumns, layoutMeta!.questionLabels);
+  // クロス集計軸候補: SA列 + MAグループ
+  const crossCandidates: QuestionDef[] = [];
+  const maAccumForCross: Record<string, string[]> = {};
+  for (const col of headers) {
+    const t = layoutMeta!.colTypes[col];
+    if (!t) continue;
+    if (t === "sa") {
+      crossCandidates.push({ key: col, columns: [col], type: "SA" });
+    } else if (t.startsWith("ma:")) {
+      const prefix = t.slice(3);
+      (maAccumForCross[prefix] ??= []).push(col);
+    }
+  }
+  for (const [prefix, cols] of Object.entries(maAccumForCross)) {
+    crossCandidates.push({ key: prefix, columns: cols, type: "MA" });
+  }
+  initCrossConfig(crossCandidates, layoutMeta!.questionLabels);
 
   document.getElementById("cross-config-section")!.classList.remove("hidden");
   document.getElementById("run-btn")!.classList.remove("hidden");
@@ -85,17 +99,21 @@ async function runAggregation(): Promise<void> {
   const crossCols = getCrossColsSelected();
 
   try {
+    // クロス軸に選ばれたキーを除外セットに
+    const crossKeys = new Set(crossCols.map((q) => q.key));
+
     // layoutMeta.colTypes から全SA/MA列を questions に変換
     const questions: QuestionDef[] = [];
     const maAccum: Record<string, string[]> = {};
     for (const col of headers) {
       const t = layoutMeta.colTypes[col];
       if (!t) continue;
-      if (crossCols.includes(col)) continue;
       if (t === "sa") {
+        if (crossKeys.has(col)) continue;
         questions.push({ key: col, columns: [col], type: "SA" });
       } else if (t.startsWith("ma:")) {
         const prefix = t.slice(3);
+        if (crossKeys.has(prefix)) continue;
         (maAccum[prefix] ??= []).push(col);
       }
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -99,9 +99,6 @@ async function runAggregation(): Promise<void> {
   const crossCols = getCrossColsSelected();
 
   try {
-    // クロス軸に選ばれたキーを除外セットに
-    const crossKeys = new Set(crossCols.map((q) => q.key));
-
     // layoutMeta.colTypes から全SA/MA列を questions に変換
     const questions: QuestionDef[] = [];
     const maAccum: Record<string, string[]> = {};
@@ -109,11 +106,9 @@ async function runAggregation(): Promise<void> {
       const t = layoutMeta.colTypes[col];
       if (!t) continue;
       if (t === "sa") {
-        if (crossKeys.has(col)) continue;
         questions.push({ key: col, columns: [col], type: "SA" });
       } else if (t.startsWith("ma:")) {
         const prefix = t.slice(3);
-        if (crossKeys.has(prefix)) continue;
         (maAccum[prefix] ??= []).push(col);
       }
     }


### PR DESCRIPTION
## Summary
- MA設問をクロス集計軸として選択可能にし、SA×MA / MA×SA / MA×MA の全組み合わせに対応
- `Query.cross_cols` を `QuestionDef[]` に変更し、SA/MAの型情報を保持
- クロス軸UIにMAグループを `[MA]` タグ付きで表示
- ResultTable・CSV出力でMA軸のラベル解決を追加

## Test plan
- [ ] SA設問をクロス軸に選択し、MA設問の集計結果にSA各値の%が表示されること
- [ ] MA設問をクロス軸に選択し、SA設問の集計結果にMA各項目の%が表示されること
- [ ] MA×MAのクロス集計が正しく動作すること
- [ ] ウェイトバック適用時も正しく集計されること
- [ ] CSV出力でMA軸ヘッダーがラベル表示されること
- [ ] `npm run build` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)