### PR TITLE
refactor: QuestionDefをtagged unionに変更

### DIFF
--- a/src/components/CrossConfig.ts
+++ b/src/components/CrossConfig.ts
@@ -1,4 +1,4 @@
-import type { QuestionDef } from "../lib/aggregator";
+import { questionKey, type QuestionDef } from "../lib/aggregator";
 
 export interface CrossConfigState {
   questions: QuestionDef[];
@@ -12,28 +12,29 @@ export function initCrossConfig(
   questionLabels: Record<string, string>
 ): void {
   state = { questions, crossSelected: {} };
-  questions.forEach((q) => (state.crossSelected[q.key] = false));
+  questions.forEach((q) => (state.crossSelected[questionKey(q)] = false));
 
   const list = document.getElementById("cross-col-list")!;
   list.innerHTML = "";
 
   questions.forEach((q) => {
+    const key = questionKey(q);
     const label = document.createElement("label");
     label.className = "cross-col-item";
 
     const cb = document.createElement("input");
     cb.type = "checkbox";
     cb.className = "col-pick";
-    cb.dataset.col = q.key;
+    cb.dataset.col = key;
     cb.addEventListener("change", () => {
-      state.crossSelected[q.key] = cb.checked;
+      state.crossSelected[key] = cb.checked;
     });
 
-    const qLabel = questionLabels[q.key];
+    const qLabel = questionLabels[key];
     const typeTag = q.type === "MA" ? " [MA]" : "";
     const displayText = qLabel
-      ? `${q.key}: ${qLabel}${typeTag}`
-      : `${q.key}${typeTag}`;
+      ? `${key}: ${qLabel}${typeTag}`
+      : `${key}${typeTag}`;
 
     label.appendChild(cb);
     label.appendChild(document.createTextNode(" " + displayText));
@@ -42,5 +43,5 @@ export function initCrossConfig(
 }
 
 export function getCrossColsSelected(): QuestionDef[] {
-  return state.questions.filter((q) => state.crossSelected[q.key]);
+  return state.questions.filter((q) => state.crossSelected[questionKey(q)]);
 }

--- a/src/lib/aggregator.ts
+++ b/src/lib/aggregator.ts
@@ -20,10 +20,21 @@ export interface AggResult {
 
 // --- 集計 payload ---
 
-export interface QuestionDef {
-  key: string;          // SA: カラム名 "q1", MA: グループプレフィックス "Q3"
-  columns: string[];    // SA: ["q1"],  MA: ["Q3_1","Q3_2","Q3_3"]
-  type: "SA" | "MA";
+export type QuestionDef = SAQuestion | MAQuestion;
+
+interface SAQuestion {
+  type: "SA";
+  column: string;       // カラム名 "q1"
+}
+
+interface MAQuestion {
+  type: "MA";
+  prefix: string;       // グループプレフィックス "Q3"
+  columns: string[];    // ["Q3_1","Q3_2","Q3_3"]
+}
+
+export function questionKey(q: QuestionDef): string {
+  return q.type === "SA" ? q.column : q.prefix;
 }
 
 export interface Query {
@@ -50,11 +61,11 @@ export async function aggregate(
   for (const q of payload.questions) {
     if (q.type === "SA") {
       results.push(
-        await aggregateSA(conn, q.columns[0], totalN, payload.weight_col, crossCols, crossHeaderCache)
+        await aggregateSA(conn, q.column, totalN, payload.weight_col, crossCols, crossHeaderCache)
       );
     } else {
       results.push(
-        await aggregateMA(conn, q.key, q.columns, totalN, payload.weight_col, crossCols, crossHeaderCache)
+        await aggregateMA(conn, q.prefix, q.columns, totalN, payload.weight_col, crossCols, crossHeaderCache)
       );
     }
   }
@@ -106,7 +117,7 @@ async function fetchCrossHeaders(
 
   for (const crossQ of crossCols) {
     if (crossQ.type === "SA") {
-      const col = crossQ.columns[0];
+      const col = crossQ.column;
       const sql = `
         SELECT
           "${esc(col)}" AS cv,
@@ -123,7 +134,7 @@ async function fetchCrossHeaders(
       const headers = result
         .toArray()
         .map((r) => ({ label: String(r.cv), n: Number(r.n) }));
-      cache.set(crossQ.key, { headers, crossValues: headers.map((h) => h.label) });
+      cache.set(crossQ.column, { headers, crossValues: headers.map((h) => h.label) });
     } else {
       // MA軸: 各itemカラムごとに該当者数を算出
       const selectClauses = crossQ.columns.map((col, i) =>
@@ -136,7 +147,7 @@ async function fetchCrossHeaders(
         label: col,
         n: Number(row[`c${i}`] ?? 0),
       }));
-      cache.set(crossQ.key, { headers, crossValues: headers.map((h) => h.label) });
+      cache.set(crossQ.prefix, { headers, crossValues: headers.map((h) => h.label) });
     }
   }
   return cache;
@@ -182,10 +193,10 @@ async function aggregateSA(
   if (crossCols.length > 0) {
     const mainValues = rowArr.map((r) => String(r.label));
     for (const crossQ of crossCols) {
-      const cached = crossHeaderCache.get(crossQ.key)!;
+      const cached = crossHeaderCache.get(questionKey(crossQ))!;
       if (crossQ.type === "SA") {
         const crossCells = await buildCrossCellsSA(
-          conn, col, mainValues, crossQ.columns[0], weightCol, cached
+          conn, col, mainValues, crossQ.column, weightCol, cached
         );
         cells.push(...crossCells);
       } else {
@@ -336,10 +347,10 @@ async function aggregateMA(
   // クロスセル
   if (crossCols.length > 0) {
     for (const crossQ of crossCols) {
-      const cached = crossHeaderCache.get(crossQ.key)!;
+      const cached = crossHeaderCache.get(questionKey(crossQ))!;
       if (crossQ.type === "SA") {
         const crossCells = await buildMACrossCellsSA(
-          conn, cols, crossQ.columns[0], weightCol, cached
+          conn, cols, crossQ.column, weightCol, cached
         );
         cells.push(...crossCells);
       } else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,14 +32,14 @@ function initAfterBothLoaded(): void {
     const t = layoutMeta!.colTypes[col];
     if (!t) continue;
     if (t === "sa") {
-      crossCandidates.push({ key: col, columns: [col], type: "SA" });
+      crossCandidates.push({ type: "SA", column: col });
     } else if (t.startsWith("ma:")) {
       const prefix = t.slice(3);
       (maAccumForCross[prefix] ??= []).push(col);
     }
   }
   for (const [prefix, cols] of Object.entries(maAccumForCross)) {
-    crossCandidates.push({ key: prefix, columns: cols, type: "MA" });
+    crossCandidates.push({ type: "MA", prefix, columns: cols });
   }
   initCrossConfig(crossCandidates, layoutMeta!.questionLabels);
 
@@ -106,14 +106,14 @@ async function runAggregation(): Promise<void> {
       const t = layoutMeta.colTypes[col];
       if (!t) continue;
       if (t === "sa") {
-        questions.push({ key: col, columns: [col], type: "SA" });
+        questions.push({ type: "SA", column: col });
       } else if (t.startsWith("ma:")) {
         const prefix = t.slice(3);
         (maAccum[prefix] ??= []).push(col);
       }
     }
     for (const [prefix, cols] of Object.entries(maAccum)) {
-      questions.push({ key: prefix, columns: cols, type: "MA" });
+      questions.push({ type: "MA", prefix, columns: cols });
     }
 
     const results = await runDuckDBAggregation({


### PR DESCRIPTION
## Summary
- `QuestionDef`を単一interfaceからtagged union (`SAQuestion | MAQuestion`) に変更
- SAの冗長な`key`/`columns`を`column`に統合、MAの`key`を`prefix`に明確化
- 共通キー取得用の`questionKey()`ヘルパーを追加

## Test plan
- [x] `npm run build` (`tsc` + Vite) 通過確認済み
- [ ] ブラウザでCSVアップロード → SA/MAのGT集計が正常動作すること
- [ ] クロス集計（SA×SA, SA×MA, MA×SA, MA×MA）が正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)