### PR TITLE
feat: OPFSによるインポートデータの永続化

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,12 @@
       </div>
     </div>
 
+    <!-- 保存データ -->
+    <div class="section" id="saved-files-section">
+      <div class="section-label">SAVED DATA</div>
+      <div id="saved-files-list"></div>
+    </div>
+
     <!-- クロス集計軸 -->
     <div class="section hidden" id="cross-config-section">
       <div class="section-label">02 / クロス集計軸（任意）</div>

--- a/src/components/FileInput.ts
+++ b/src/components/FileInput.ts
@@ -23,7 +23,7 @@ export function initCsvInput(
 }
 
 export function initLayoutInput(
-  onLoad: (layout: Layout, meta: LayoutMeta, fileName: string) => void,
+  onLoad: (layout: Layout, meta: LayoutMeta, fileName: string, rawText: string) => void,
   onError: (msg: string) => void
 ): void {
   const fileInput = document.getElementById("layout-file-input") as HTMLInputElement;
@@ -38,7 +38,7 @@ export function initLayoutInput(
       const text = await file.text();
       const layout = parseLayout(text);
       const meta = buildLayoutMeta(layout);
-      onLoad(layout, meta, file.name);
+      onLoad(layout, meta, file.name, text);
     } catch (err) {
       onError("レイアウトファイルの読み込みエラー: " + (err as Error).message);
     }

--- a/src/components/SavedFiles.ts
+++ b/src/components/SavedFiles.ts
@@ -1,0 +1,57 @@
+import { listSaved, deleteSaved } from "../lib/opfs";
+
+type OnSelectCallback = (folderId: string) => void;
+
+let onSelect: OnSelectCallback = () => {};
+
+export function initSavedFiles(onSelectCb: OnSelectCallback): void {
+  onSelect = onSelectCb;
+  refreshList();
+}
+
+export async function refreshList(): Promise<void> {
+  const container = document.getElementById("saved-files-list")!;
+
+  let entries;
+  try {
+    entries = await listSaved();
+  } catch {
+    container.innerHTML = "";
+    return;
+  }
+
+  container.innerHTML = "";
+
+  if (entries.length === 0) {
+    container.innerHTML = `<div class="saved-empty">保存データなし</div>`;
+    return;
+  }
+
+  for (const entry of entries) {
+    const row = document.createElement("div");
+    row.className = "saved-item";
+
+    const loadBtn = document.createElement("button");
+    loadBtn.className = "saved-item-load";
+    loadBtn.type = "button";
+    const date = new Date(entry.timestamp);
+    const dateStr = `${date.getMonth() + 1}/${date.getDate()} ${date.getHours()}:${String(date.getMinutes()).padStart(2, "0")}`;
+    loadBtn.textContent = `${entry.csvName}  (${dateStr})`;
+    loadBtn.addEventListener("click", () => onSelect(entry.folderId));
+
+    const delBtn = document.createElement("button");
+    delBtn.className = "saved-item-del";
+    delBtn.type = "button";
+    delBtn.textContent = "×";
+    delBtn.title = "削除";
+    delBtn.addEventListener("click", async (e) => {
+      e.stopPropagation();
+      await deleteSaved(entry.folderId);
+      refreshList();
+    });
+
+    row.appendChild(loadBtn);
+    row.appendChild(delBtn);
+    container.appendChild(row);
+  }
+}

--- a/src/lib/opfs.ts
+++ b/src/lib/opfs.ts
@@ -1,0 +1,86 @@
+export interface SavedEntry {
+  folderId: string;
+  csvName: string;
+  layoutName: string;
+  timestamp: number;
+}
+
+async function getTallyDir(): Promise<FileSystemDirectoryHandle> {
+  const root = await navigator.storage.getDirectory();
+  return root.getDirectoryHandle("tally-data", { create: true });
+}
+
+export async function saveData(
+  csvName: string,
+  csvText: string,
+  layoutName: string,
+  layoutJson: string
+): Promise<SavedEntry> {
+  const ts = Date.now();
+  const folderId = String(ts);
+  const dir = await getTallyDir();
+  const folder = await dir.getDirectoryHandle(folderId, { create: true });
+
+  const csvHandle = await folder.getFileHandle(csvName, { create: true });
+  const csvW = await csvHandle.createWritable();
+  await csvW.write(csvText);
+  await csvW.close();
+
+  const jsonHandle = await folder.getFileHandle(layoutName, { create: true });
+  const jsonW = await jsonHandle.createWritable();
+  await jsonW.write(layoutJson);
+  await jsonW.close();
+
+  return { folderId, csvName, layoutName, timestamp: ts };
+}
+
+export async function listSaved(): Promise<SavedEntry[]> {
+  const dir = await getTallyDir();
+  const entries: SavedEntry[] = [];
+
+  for await (const [name, handle] of dir as any) {
+    if (handle.kind !== "directory") continue;
+    const ts = Number(name);
+    if (!Number.isFinite(ts)) continue;
+
+    let csvName = "";
+    let layoutName = "";
+    for await (const [fileName] of handle as any) {
+      if (fileName.endsWith(".csv")) csvName = fileName;
+      else if (fileName.endsWith(".json")) layoutName = fileName;
+    }
+    if (csvName && layoutName) {
+      entries.push({ folderId: name, csvName, layoutName, timestamp: ts });
+    }
+  }
+
+  entries.sort((a, b) => b.timestamp - a.timestamp);
+  return entries;
+}
+
+export async function loadSaved(
+  folderId: string
+): Promise<{ csvText: string; csvName: string; layoutJson: string; layoutName: string }> {
+  const dir = await getTallyDir();
+  const folder = await dir.getDirectoryHandle(folderId);
+
+  let csvName = "";
+  let layoutName = "";
+  for await (const [fileName] of folder as any) {
+    if (fileName.endsWith(".csv")) csvName = fileName;
+    else if (fileName.endsWith(".json")) layoutName = fileName;
+  }
+  if (!csvName || !layoutName) throw new Error("不完全な保存データです");
+
+  const csvFile = await (await folder.getFileHandle(csvName)).getFile();
+  const csvText = await csvFile.text();
+  const jsonFile = await (await folder.getFileHandle(layoutName)).getFile();
+  const layoutJson = await jsonFile.text();
+
+  return { csvText, csvName, layoutJson, layoutName };
+}
+
+export async function deleteSaved(folderId: string): Promise<void> {
+  const dir = await getTallyDir();
+  await dir.removeEntry(folderId, { recursive: true });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,12 +8,21 @@ import {
   loadCSV,
   runDuckDBAggregation,
 } from "./lib/duckdbBridge";
-import type { Layout, LayoutMeta } from "./lib/layout";
+import { parseLayout, buildLayoutMeta, type Layout, type LayoutMeta } from "./lib/layout";
+import { saveData, loadSaved } from "./lib/opfs";
+import { initSavedFiles, refreshList } from "./components/SavedFiles";
 
 // データストア
 let headers: string[] = [];
 let dataRowCount = 0;
 let layoutMeta: LayoutMeta | null = null;
+
+// OPFS保存用
+let lastCsvText = "";
+let lastCsvFileName = "";
+let lastLayoutJson = "";
+let lastLayoutFileName = "";
+let skipNextSave = false;
 
 // DuckDB Wasm をバックグラウンドで初期化開始
 initDuckDB().catch(() => {
@@ -53,11 +62,14 @@ async function onCSVLoaded(csvText: string, fileName: string): Promise<void> {
     const result = await loadCSV(csvText);
     headers = result.headers;
     dataRowCount = result.rowCount;
+    lastCsvText = csvText;
+    lastCsvFileName = fileName;
 
     document.getElementById("file-info")!.textContent =
       `${fileName}  /  ${dataRowCount.toLocaleString()} 件  /  ${headers.length} 列`;
 
     initAfterBothLoaded();
+    trySaveToOPFS();
   } catch (e) {
     showError("CSV読み込みエラー: " + (e as Error).message);
   }
@@ -67,14 +79,46 @@ async function onCSVLoaded(csvText: string, fileName: string): Promise<void> {
 function onLayoutLoaded(
   _layout: Layout,
   meta: LayoutMeta,
-  fileName: string
+  fileName: string,
+  rawText: string
 ): void {
   layoutMeta = meta;
+  lastLayoutJson = rawText;
+  lastLayoutFileName = fileName;
 
   document.getElementById("layout-file-info")!.textContent =
     `${fileName}  /  ${Object.keys(meta.colTypes).length} 列定義`;
 
   initAfterBothLoaded();
+  trySaveToOPFS();
+}
+
+// OPFS自動保存（CSV+レイアウト両方揃ったとき）
+async function trySaveToOPFS(): Promise<void> {
+  if (skipNextSave) return;
+  if (!lastCsvText || !lastLayoutJson) return;
+  try {
+    await saveData(lastCsvFileName, lastCsvText, lastLayoutFileName, lastLayoutJson);
+    refreshList();
+  } catch (e) {
+    console.warn("OPFS save failed:", e);
+  }
+}
+
+// 保存データから読み込み
+async function loadFromSaved(folderId: string): Promise<void> {
+  try {
+    skipNextSave = true;
+    const { csvText, csvName, layoutJson, layoutName } = await loadSaved(folderId);
+    const layout = parseLayout(layoutJson);
+    const meta = buildLayoutMeta(layout);
+    await onCSVLoaded(csvText, csvName);
+    onLayoutLoaded(layout, meta, layoutName, layoutJson);
+  } catch (e) {
+    showError("保存データの読み込みエラー: " + (e as Error).message);
+  } finally {
+    skipNextSave = false;
+  }
 }
 
 function showError(msg: string): void {
@@ -130,6 +174,7 @@ async function runAggregation(): Promise<void> {
 // イベントバインド
 initCsvInput(onCSVLoaded, (msg) => showError(msg));
 initLayoutInput(onLayoutLoaded, (msg) => showError(msg));
+initSavedFiles(loadFromSaved);
 
 document.getElementById("run-btn")!.addEventListener("click", () => {
   runAggregation().catch((e) => showError("集計エラー: " + (e as Error).message));

--- a/src/style.css
+++ b/src/style.css
@@ -506,6 +506,72 @@ table.gt td.cross-pct {
   letter-spacing: 0.05em;
 }
 
+/* 保存データリスト */
+.saved-empty {
+  font-size: 0.72rem;
+  color: var(--muted);
+  text-align: center;
+  padding: 0.5rem;
+}
+
+#saved-files-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.saved-item {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: var(--surface2);
+  border-radius: 3px;
+  border: 1px solid transparent;
+  transition: border-color 0.15s;
+}
+
+.saved-item:hover {
+  border-color: var(--border);
+}
+
+.saved-item-load {
+  flex: 1;
+  background: none;
+  border: none;
+  color: var(--text);
+  font-family: inherit;
+  font-size: 0.75rem;
+  padding: 0.45rem 0.6rem;
+  text-align: left;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.saved-item-load:hover {
+  color: var(--accent);
+}
+
+.saved-item-del {
+  background: none;
+  border: none;
+  color: var(--muted);
+  font-family: inherit;
+  font-size: 0.72rem;
+  padding: 0.3rem 0.5rem;
+  cursor: pointer;
+  transition: color 0.15s;
+  flex-shrink: 0;
+}
+
+.saved-item-del:hover {
+  color: var(--danger);
+}
+
+
 /* ユーティリティ */
 .hidden { display: none !important; }
 


### PR DESCRIPTION
## Summary
- CSV+レイアウトJSONのインポート時にOPFS（Origin Private File System）へ自動保存
- 左パネルに保存データ一覧を表示し、クリックで再読み込み可能
- 個別削除ボタン（×）で不要な保存データを削除可能

## 変更ファイル
- `src/lib/opfs.ts` (新規) — OPFS操作ヘルパー
- `src/components/SavedFiles.ts` (新規) — 保存データ一覧UIコンポーネント
- `index.html` — SAVED DATAセクション追加
- `src/style.css` — 保存データ一覧のスタイル
- `src/components/FileInput.ts` — レイアウトコールバックに生テキスト追加
- `src/main.ts` — OPFS自動保存・読み込みの配線

## Test plan
- [ ] CSV + レイアウトJSONをインポート → SAVED DATAに表示される
- [ ] ページリロード → 一覧が残っている
- [ ] 一覧からクリック → データが再読み込みされ集計可能
- [ ] ×ボタン → 個別削除される
- [ ] `npm run build` が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)