### PR TITLE
ui: データ読み込みセクションをタブ切り替えUIに改善

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,22 +23,24 @@
     <!-- データ読み込み -->
     <div class="section" id="file-section">
       <div class="section-label">01 / データ読み込み</div>
-      <div class="file-row">
-        <label class="file-label" for="file-input">CSV</label>
-        <input type="file" id="file-input" accept=".csv" class="file-input">
-        <span id="file-info" class="file-meta"></span>
+      <div class="load-tabs">
+        <button class="load-tab active" data-tab="file">ファイルから</button>
+        <button class="load-tab" data-tab="saved">保存データから</button>
       </div>
-      <div class="file-row">
-        <label class="file-label" for="layout-file-input">JSON</label>
-        <input type="file" id="layout-file-input" accept=".json" class="file-input">
-        <span id="layout-file-info" class="file-meta"></span>
+      <div class="load-tab-panel" id="tab-file">
+        <div class="file-row">
+          <label class="file-label" for="file-input">CSV</label>
+          <input type="file" id="file-input" accept=".csv" class="file-input">
+        </div>
+        <div class="file-row">
+          <label class="file-label" for="layout-file-input">JSON</label>
+          <input type="file" id="layout-file-input" accept=".json" class="file-input">
+        </div>
       </div>
-    </div>
-
-    <!-- 保存データ -->
-    <div class="section" id="saved-files-section">
-      <div class="section-label">SAVED DATA</div>
-      <div id="saved-files-list"></div>
+      <div class="load-tab-panel hidden" id="tab-saved">
+        <div id="saved-files-list"></div>
+      </div>
+      <div id="loaded-data-info" class="loaded-data-info hidden"></div>
     </div>
 
     <!-- クロス集計軸 -->

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,7 +65,7 @@ function updateLoadedInfo(): void {
   }
   const lines: string[] = [];
   if (lastCsvFileName) {
-    lines.push(`CSV: ${lastCsvFileName}  —  ${dataRowCount.toLocaleString()} 件 / ${headers.length} 列`);
+    lines.push(`CSV: ${lastCsvFileName}  —  ${dataRowCount.toLocaleString()} 行 / ${headers.length} 列`);
   }
   if (lastLayoutFileName && layoutMeta) {
     lines.push(`JSON: ${lastLayoutFileName}  —  ${Object.keys(layoutMeta.colTypes).length} 列定義`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,6 +56,24 @@ function initAfterBothLoaded(): void {
   (document.getElementById("run-btn") as HTMLButtonElement).disabled = false;
 }
 
+// 読み込み済みデータ情報を表示
+function updateLoadedInfo(): void {
+  const el = document.getElementById("loaded-data-info")!;
+  if (!lastCsvFileName && !lastLayoutFileName) {
+    el.classList.add("hidden");
+    return;
+  }
+  const lines: string[] = [];
+  if (lastCsvFileName) {
+    lines.push(`CSV: ${lastCsvFileName}  —  ${dataRowCount.toLocaleString()} 件 / ${headers.length} 列`);
+  }
+  if (lastLayoutFileName && layoutMeta) {
+    lines.push(`JSON: ${lastLayoutFileName}  —  ${Object.keys(layoutMeta.colTypes).length} 列定義`);
+  }
+  el.textContent = lines.join("\n");
+  el.classList.remove("hidden");
+}
+
 // CSV読み込みハンドラ: DuckDBにロードしてheaders/rowCountを取得
 async function onCSVLoaded(csvText: string, fileName: string): Promise<void> {
   try {
@@ -65,9 +83,7 @@ async function onCSVLoaded(csvText: string, fileName: string): Promise<void> {
     lastCsvText = csvText;
     lastCsvFileName = fileName;
 
-    document.getElementById("file-info")!.textContent =
-      `${fileName}  /  ${dataRowCount.toLocaleString()} 件  /  ${headers.length} 列`;
-
+    updateLoadedInfo();
     initAfterBothLoaded();
     trySaveToOPFS();
   } catch (e) {
@@ -86,9 +102,7 @@ function onLayoutLoaded(
   lastLayoutJson = rawText;
   lastLayoutFileName = fileName;
 
-  document.getElementById("layout-file-info")!.textContent =
-    `${fileName}  /  ${Object.keys(meta.colTypes).length} 列定義`;
-
+  updateLoadedInfo();
   initAfterBothLoaded();
   trySaveToOPFS();
 }
@@ -169,6 +183,18 @@ async function runAggregation(): Promise<void> {
     showError("集計エラー: " + (e as Error).message);
     console.error(e);
   }
+}
+
+// タブ切り替え
+for (const tab of document.querySelectorAll<HTMLButtonElement>(".load-tab")) {
+  tab.addEventListener("click", () => {
+    for (const t of document.querySelectorAll<HTMLButtonElement>(".load-tab")) {
+      t.classList.toggle("active", t === tab);
+    }
+    const target = tab.dataset.tab!;
+    document.getElementById("tab-file")!.classList.toggle("hidden", target !== "file");
+    document.getElementById("tab-saved")!.classList.toggle("hidden", target !== "saved");
+  });
 }
 
 // イベントバインド

--- a/src/style.css
+++ b/src/style.css
@@ -101,6 +101,36 @@ main {
   margin-bottom: 1rem;
 }
 
+/* 読み込みタブ */
+.load-tabs {
+  display: flex;
+  gap: 0;
+  margin-bottom: 0.75rem;
+}
+
+.load-tab {
+  flex: 1;
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--muted);
+  font-family: inherit;
+  font-size: 0.7rem;
+  padding: 0.4rem 0;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.load-tab:first-child { border-radius: 3px 0 0 3px; }
+.load-tab:last-child { border-radius: 0 3px 3px 0; border-left: none; }
+
+.load-tab.active {
+  background: var(--accent);
+  color: #0d0d0f;
+  border-color: var(--accent);
+}
+
+.load-tab-panel { }
+
 /* ファイル入力 */
 .file-row {
   display: flex;
@@ -122,12 +152,15 @@ main {
   color: var(--text);
 }
 
-.file-meta {
+.loaded-data-info {
+  margin-top: 0.75rem;
+  padding: 0.5rem 0.6rem;
+  background: var(--surface2);
+  border-radius: 3px;
   font-size: 0.7rem;
   color: var(--muted);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  white-space: pre-line;
+  line-height: 1.6;
 }
 
 /* 列設定 */


### PR DESCRIPTION
## Summary
- 「ファイルから」「保存データから」のタブ切り替えUIを導入し、データ読み込みの2つの入口を整理
- SAVED DATAセクションをデータ読み込みセクションに統合
- ファイル選択の横に表示していたメタ情報を、読み込み済みデータ情報として独立エリアに表示（ファイル名・行数・列数）

## Test plan
- [ ] 「ファイルから」タブでCSV/JSONを読み込み、読み込み済みデータ情報が表示されることを確認
- [ ] 「保存データから」タブで保存済みデータをクリックして読み込めることを確認
- [ ] タブ切り替え時にパネルが正しく表示/非表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)