### PR TITLE
feat: Chrome Built-in AI による集計結果AI分析コメント

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ npm run dev
 - **WEIGHT**: ウェイト列（ウェイトバック集計に使用）
 - **ID / EXCLUDE**: 集計除外列
 
+## AI分析コメント（Chrome Built-in AI）
+
+集計実行後、Chrome の組み込み AI（Gemini Nano）が結果の傾向を自動で要約し、画面右下に吹き出しで表示します。非対応ブラウザでは自動的に非表示になります。
+
+### 有効化手順（Chrome 138+）
+
+1. `chrome://flags/#optimization-guide-on-device-model` → **Enabled BypassPerfRequirement**
+2. `chrome://flags/#prompt-api-for-gemini-nano` → **Enabled**
+3. Chrome を再起動
+4. `chrome://components` → **Optimization Guide On Device Model** の「アップデートを確認」でモデルをダウンロード
+
 ## 技術スタック
 
 TypeScript + Vite + DuckDB Wasm（SQL集計エンジン）。UIフレームワークなし。

--- a/src/components/ResultTable.ts
+++ b/src/components/ResultTable.ts
@@ -2,6 +2,7 @@ import type { AggResult } from "../lib/aggregate";
 import type { LayoutMeta } from "../lib/layout";
 import { pivot } from "../lib/pivot";
 import { downloadAllCSV } from "../lib/download";
+import { isAIAvailable, generateComment } from "../lib/aiComment";
 
 function escHtml(str: string): string {
   return String(str)
@@ -123,6 +124,42 @@ export function renderResults(
 
     grid.appendChild(card);
   });
+
+  // AI分析コメントを自動生成（非同期、テーブル描画をブロックしない）
+  showAIBubble(results, weightCol, layoutMeta);
+}
+
+async function showAIBubble(
+  results: AggResult[],
+  weightCol: string,
+  layoutMeta?: LayoutMeta,
+): Promise<void> {
+  if (!(await isAIAvailable())) return;
+
+  // 既存の吹き出しがあれば除去
+  document.querySelector(".ai-bubble")?.remove();
+
+  const bubble = document.createElement("div");
+  bubble.className = "ai-bubble";
+  bubble.innerHTML = `
+    <button class="ai-bubble-close" aria-label="閉じる">\u00d7</button>
+    <div class="ai-bubble-header">\u2728 AI\u5206\u6790</div>
+    <div class="ai-bubble-body ai-bubble-loading">\u5206\u6790\u4e2d...</div>
+  `;
+  document.body.appendChild(bubble);
+
+  bubble
+    .querySelector(".ai-bubble-close")!
+    .addEventListener("click", () => bubble.remove());
+
+  const comment = await generateComment(results, weightCol, layoutMeta);
+  if (comment) {
+    const body = bubble.querySelector(".ai-bubble-body")!;
+    body.textContent = comment;
+    body.classList.remove("ai-bubble-loading");
+  } else {
+    bubble.remove();
+  }
 }
 
 function buildGtTable(

--- a/src/lib/aiComment.ts
+++ b/src/lib/aiComment.ts
@@ -1,0 +1,138 @@
+/** Chrome Built-in AI (Prompt API) によるAI分析コメント生成 */
+
+import type { AggResult } from "./aggregate";
+import type { LayoutMeta } from "./layout";
+
+// --- Chrome Prompt API 型宣言 ---
+
+declare global {
+  interface LanguageModelCreateOptions {
+    systemPrompt?: string;
+    expectedInputLanguages?: string[];
+    expectedOutputLanguages?: string[];
+    monitor?: (monitor: EventTarget) => void;
+  }
+  interface LanguageModelStatic {
+    availability(): Promise<string>;
+    create(options?: LanguageModelCreateOptions): Promise<LanguageModelSession>;
+  }
+  interface LanguageModelSession {
+    prompt(input: string): Promise<string>;
+    destroy(): void;
+  }
+  // eslint-disable-next-line no-var
+  var LanguageModel: LanguageModelStatic | undefined;
+}
+
+// --- Feature Detection ---
+
+export async function isAIAvailable(): Promise<boolean> {
+  try {
+    if (typeof LanguageModel === "undefined") return false;
+    const status = await LanguageModel.availability();
+    return status !== "no";
+  } catch {
+    return false;
+  }
+}
+
+// --- Prompt Payload ---
+
+const SYSTEM_PROMPT =
+  "あなたはアンケート分析の専門家です。回答は必ず日本語で2〜3文以内にしてください。";
+
+const MAX_PAYLOAD_CHARS = 3500;
+
+function resolveQLabel(col: string, meta?: LayoutMeta): string {
+  return meta?.questionLabels[col] ?? col;
+}
+
+function resolveVLabel(
+  type: "SA" | "MA",
+  col: string,
+  code: string,
+  meta?: LayoutMeta,
+): string {
+  if (!meta) return code;
+  if (type === "SA") return meta.valueLabels[col]?.[code] ?? code;
+  return meta.valueLabels[code]?.["1"] ?? code;
+}
+
+function summarizeResults(
+  results: AggResult[],
+  weightCol: string,
+  layoutMeta: LayoutMeta | undefined,
+  topN: number,
+): string {
+  const lines: string[] = [];
+  if (weightCol) lines.push(`※ウェイト列: ${weightCol}`);
+
+  for (const res of results) {
+    const gtCells = res.cells.filter((c) => c.sub === "GT");
+    if (gtCells.length === 0) continue;
+
+    const n = gtCells[0].n;
+    const qLabel = resolveQLabel(res.question, layoutMeta);
+    lines.push(`${res.question}: ${qLabel} (${res.type}, n=${n})`);
+
+    const sorted = [...gtCells].sort((a, b) => b.pct - a.pct);
+    const top = sorted.slice(0, topN);
+    const items = top.map((c) => {
+      const label = resolveVLabel(res.type, res.question, c.main, layoutMeta);
+      return `${label}: ${c.pct.toFixed(1)}%`;
+    });
+
+    const rest = sorted.length - topN;
+    if (rest > 0) items.push(`...他${rest}件`);
+    lines.push("  " + items.join(", "));
+  }
+
+  lines.push("");
+  lines.push("上記の集計結果の注目すべき傾向を2〜3文で短く述べてください。箇条書き・見出し・提案・注意点は不要です。");
+  return lines.join("\n");
+}
+
+export function buildPromptPayload(
+  results: AggResult[],
+  weightCol: string,
+  layoutMeta?: LayoutMeta,
+): string {
+  for (const topN of [5, 3, 2]) {
+    const text = summarizeResults(results, weightCol, layoutMeta, topN);
+    if (text.length <= MAX_PAYLOAD_CHARS) return text;
+  }
+  return summarizeResults(
+    results.slice(0, 20),
+    weightCol,
+    layoutMeta,
+    2,
+  );
+}
+
+// --- Comment Generation ---
+
+export async function generateComment(
+  results: AggResult[],
+  weightCol: string,
+  layoutMeta?: LayoutMeta,
+): Promise<string | null> {
+  try {
+    if (results.length === 0) return null;
+    if (!(await isAIAvailable())) return null;
+
+    const payload = buildPromptPayload(results, weightCol, layoutMeta);
+    const session = await LanguageModel!.create({
+      systemPrompt: SYSTEM_PROMPT,
+      expectedInputLanguages: ["ja"],
+      expectedOutputLanguages: ["ja"],
+    });
+
+    try {
+      return await session.prompt(payload);
+    } finally {
+      session.destroy();
+    }
+  } catch {
+    return null;
+  }
+}

--- a/src/style.css
+++ b/src/style.css
@@ -618,3 +618,79 @@ table.gt td.cross-pct {
   margin: 0 1rem;
   flex-shrink: 0;
 }
+
+/* --- AI分析コメント吹き出し --- */
+
+.ai-bubble {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  max-width: 360px;
+  min-width: 260px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem 1.2rem;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
+  z-index: 100;
+  animation: bubbleIn 0.3s ease-out;
+}
+
+.ai-bubble::after {
+  content: "";
+  position: absolute;
+  bottom: -8px;
+  right: 24px;
+  width: 0;
+  height: 0;
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+  border-top: 8px solid var(--surface);
+}
+
+.ai-bubble-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.6rem;
+  background: none;
+  border: none;
+  color: var(--muted);
+  font-size: 1rem;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0.2rem;
+}
+
+.ai-bubble-close:hover {
+  color: var(--text);
+}
+
+.ai-bubble-header {
+  font-family: 'Syne', sans-serif;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--accent2);
+  margin-bottom: 0.6rem;
+}
+
+.ai-bubble-body {
+  font-size: 0.75rem;
+  line-height: 1.7;
+  color: var(--text);
+  white-space: pre-wrap;
+}
+
+.ai-bubble-loading {
+  color: var(--muted);
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes bubbleIn {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.4; }
+}


### PR DESCRIPTION
## Summary
- 集計実行時に Chrome Prompt API (Gemini Nano) で結果の傾向を自動要約し、画面右下に吹き出しで表示
- 非対応ブラウザでは機能自体を非表示（静かなフォールバック）
- GTセルのみをコンパクトに要約してプロンプトに渡す（6kトークン制約対応）

## 変更ファイル
- `src/lib/aiComment.ts` — 新規: API検出・プロンプト構築・コメント生成
- `src/components/ResultTable.ts` — 集計描画後にAI吹き出しを自動トリガー
- `src/style.css` — 右下固定の吹き出しスタイル
- `README.md` — AI機能の有効化手順を追記

## Test plan
- [ ] Chrome 138+ でフラグ有効化後、集計実行 → 右下に吹き出し表示を確認
- [ ] × ボタンで吹き出しが閉じることを確認
- [ ] Firefox 等の非対応ブラウザで吹き出しが表示されないことを確認
- [ ] `npm run build` で型チェック通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)