### PR TITLE
refactor: main.tsの可変状態を整理しbuildQuestionDefsを共通化

### DIFF
--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -1,3 +1,5 @@
+import type { QuestionDef } from "./aggregate";
+
 export interface LayoutItem {
   code: string;
   label: string;
@@ -51,6 +53,25 @@ export function parseLayout(jsonText: string): Layout {
     }
   }
   return parsed as Layout;
+}
+
+/** headers + colTypes から QuestionDef[] を組み立てる */
+export function buildQuestionDefs(headers: string[], colTypes: Record<string, string>): QuestionDef[] {
+  const questions: QuestionDef[] = [];
+  const maAccum: Record<string, string[]> = {};
+  for (const col of headers) {
+    const t = colTypes[col];
+    if (!t) continue;
+    if (t === "sa") {
+      questions.push({ type: "SA", column: col });
+    } else if (t.startsWith("ma:")) {
+      (maAccum[t.slice(3)] ??= []).push(col);
+    }
+  }
+  for (const [prefix, cols] of Object.entries(maAccum)) {
+    questions.push({ type: "MA", prefix, columns: cols });
+  }
+  return questions;
 }
 
 export function buildLayoutMeta(layout: Layout): LayoutMeta {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,12 @@
 import { initCsvInput, initLayoutInput } from "./components/FileInput";
 import { initCrossConfig, getCrossColsSelected } from "./components/CrossConfig";
 import { renderResults } from "./components/ResultTable";
-import type { QuestionDef } from "./lib/aggregate";
 import {
   initDuckDB,
   loadCSV,
   runDuckDBAggregation,
 } from "./lib/duckdbBridge";
-import { parseLayout, buildLayoutMeta, type Layout, type LayoutMeta } from "./lib/layout";
+import { parseLayout, buildLayoutMeta, buildQuestionDefs, type Layout, type LayoutMeta } from "./lib/layout";
 import { saveData, loadSaved } from "./lib/opfs";
 import { initSavedFiles, refreshList } from "./components/SavedFiles";
 
@@ -27,25 +26,6 @@ let skipNextSave = false;
 initDuckDB().catch(() => {
   // エラーはduckdbBridge内でUI表示済み
 });
-
-// headers + colTypes から QuestionDef[] を組み立てる
-function buildQuestionDefs(hdrs: string[], colTypes: Record<string, string>): QuestionDef[] {
-  const questions: QuestionDef[] = [];
-  const maAccum: Record<string, string[]> = {};
-  for (const col of hdrs) {
-    const t = colTypes[col];
-    if (!t) continue;
-    if (t === "sa") {
-      questions.push({ type: "SA", column: col });
-    } else if (t.startsWith("ma:")) {
-      (maAccum[t.slice(3)] ??= []).push(col);
-    }
-  }
-  for (const [prefix, cols] of Object.entries(maAccum)) {
-    questions.push({ type: "MA", prefix, columns: cols });
-  }
-  return questions;
-}
 
 // CSV + レイアウト両方揃ったらUI初期化
 function initAfterBothLoaded(): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,9 +10,9 @@ import { parseLayout, buildLayoutMeta, buildQuestionDefs, type Layout, type Layo
 import { saveData, loadSaved } from "./lib/opfs";
 import { initSavedFiles, refreshList } from "./components/SavedFiles";
 
-// 中間状態: CSV / Layout それぞれ到着時にオブジェクトごと差し替え
-let pendingCsv: { text: string; fileName: string; headers: string[]; rowCount: number } | null = null;
-let pendingLayout: { json: string; fileName: string; meta: LayoutMeta } | null = null;
+// 現在読み込み済みの CSV / Layout データ
+let currentCsv: { text: string; fileName: string; headers: string[]; rowCount: number } | null = null;
+let currentLayout: { json: string; fileName: string; meta: LayoutMeta } | null = null;
 
 // DuckDB Wasm をバックグラウンドで初期化開始
 initDuckDB().catch(() => {
@@ -21,10 +21,10 @@ initDuckDB().catch(() => {
 
 // CSV + レイアウト両方揃ったらUI初期化
 function initAfterBothLoaded(): void {
-  if (!pendingCsv || !pendingLayout) return;
+  if (!currentCsv || !currentLayout) return;
 
-  const crossCandidates = buildQuestionDefs(pendingCsv.headers, pendingLayout.meta.colTypes);
-  initCrossConfig(crossCandidates, pendingLayout.meta.questionLabels);
+  const crossCandidates = buildQuestionDefs(currentCsv.headers, currentLayout.meta.colTypes);
+  initCrossConfig(crossCandidates, currentLayout.meta.questionLabels);
 
   document.getElementById("cross-config-section")!.classList.remove("hidden");
   document.getElementById("run-btn")!.classList.remove("hidden");
@@ -34,16 +34,16 @@ function initAfterBothLoaded(): void {
 // 読み込み済みデータ情報を表示
 function updateLoadedInfo(): void {
   const el = document.getElementById("loaded-data-info")!;
-  if (!pendingCsv && !pendingLayout) {
+  if (!currentCsv && !currentLayout) {
     el.classList.add("hidden");
     return;
   }
   const lines: string[] = [];
-  if (pendingCsv) {
-    lines.push(`CSV: ${pendingCsv.fileName}  —  ${pendingCsv.rowCount.toLocaleString()} 行 / ${pendingCsv.headers.length} 列`);
+  if (currentCsv) {
+    lines.push(`CSV: ${currentCsv.fileName}  —  ${currentCsv.rowCount.toLocaleString()} 行 / ${currentCsv.headers.length} 列`);
   }
-  if (pendingLayout) {
-    lines.push(`JSON: ${pendingLayout.fileName}  —  ${Object.keys(pendingLayout.meta.colTypes).length} 列定義`);
+  if (currentLayout) {
+    lines.push(`JSON: ${currentLayout.fileName}  —  ${Object.keys(currentLayout.meta.colTypes).length} 列定義`);
   }
   el.textContent = lines.join("\n");
   el.classList.remove("hidden");
@@ -51,9 +51,9 @@ function updateLoadedInfo(): void {
 
 // OPFS自動保存（CSV+レイアウト両方揃ったとき）
 async function trySaveToOPFS(): Promise<void> {
-  if (!pendingCsv || !pendingLayout) return;
+  if (!currentCsv || !currentLayout) return;
   try {
-    await saveData(pendingCsv.fileName, pendingCsv.text, pendingLayout.fileName, pendingLayout.json);
+    await saveData(currentCsv.fileName, currentCsv.text, currentLayout.fileName, currentLayout.json);
     refreshList();
   } catch (e) {
     console.warn("OPFS save failed:", e);
@@ -64,7 +64,7 @@ async function trySaveToOPFS(): Promise<void> {
 async function onCSVLoaded(csvText: string, fileName: string): Promise<void> {
   try {
     const result = await loadCSV(csvText);
-    pendingCsv = { text: csvText, fileName, headers: result.headers, rowCount: result.rowCount };
+    currentCsv = { text: csvText, fileName, headers: result.headers, rowCount: result.rowCount };
 
     updateLoadedInfo();
     initAfterBothLoaded();
@@ -81,7 +81,7 @@ function onLayoutLoaded(
   fileName: string,
   rawText: string
 ): void {
-  pendingLayout = { json: rawText, fileName, meta };
+  currentLayout = { json: rawText, fileName, meta };
 
   updateLoadedInfo();
   initAfterBothLoaded();
@@ -96,8 +96,8 @@ async function loadFromSaved(folderId: string): Promise<void> {
     const meta = buildLayoutMeta(layout);
     const result = await loadCSV(csvText);
 
-    pendingCsv = { text: csvText, fileName: csvName, headers: result.headers, rowCount: result.rowCount };
-    pendingLayout = { json: layoutJson, fileName: layoutName, meta };
+    currentCsv = { text: csvText, fileName: csvName, headers: result.headers, rowCount: result.rowCount };
+    currentLayout = { json: layoutJson, fileName: layoutName, meta };
 
     updateLoadedInfo();
     initAfterBothLoaded();
@@ -118,22 +118,22 @@ function showError(msg: string): void {
 
 // 集計実行
 async function runAggregation(): Promise<void> {
-  if (!pendingCsv || !pendingLayout) return;
+  if (!currentCsv || !currentLayout) return;
   showError("");
 
   // ウェイト列はレイアウトから自動決定
   const weightCol =
-    Object.entries(pendingLayout.meta.colTypes).find(([, t]) => t === "weight")?.[0] ?? "";
+    Object.entries(currentLayout.meta.colTypes).find(([, t]) => t === "weight")?.[0] ?? "";
   const crossCols = getCrossColsSelected();
 
   try {
-    const questions = buildQuestionDefs(pendingCsv.headers, pendingLayout.meta.colTypes);
+    const questions = buildQuestionDefs(currentCsv.headers, currentLayout.meta.colTypes);
     const results = await runDuckDBAggregation({
       questions,
       weight_col: weightCol,
       cross_cols: crossCols,
     });
-    renderResults(results, weightCol, pendingCsv.rowCount, pendingLayout.meta);
+    renderResults(results, weightCol, currentCsv.rowCount, currentLayout.meta);
   } catch (e) {
     showError("集計エラー: " + (e as Error).message);
     console.error(e);

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,17 +10,9 @@ import { parseLayout, buildLayoutMeta, buildQuestionDefs, type Layout, type Layo
 import { saveData, loadSaved } from "./lib/opfs";
 import { initSavedFiles, refreshList } from "./components/SavedFiles";
 
-// データストア
-let headers: string[] = [];
-let dataRowCount = 0;
-let layoutMeta: LayoutMeta | null = null;
-
-// OPFS保存用
-let lastCsvText = "";
-let lastCsvFileName = "";
-let lastLayoutJson = "";
-let lastLayoutFileName = "";
-let skipNextSave = false;
+// 中間状態: CSV / Layout それぞれ到着時にオブジェクトごと差し替え
+let pendingCsv: { text: string; fileName: string; headers: string[]; rowCount: number } | null = null;
+let pendingLayout: { json: string; fileName: string; meta: LayoutMeta } | null = null;
 
 // DuckDB Wasm をバックグラウンドで初期化開始
 initDuckDB().catch(() => {
@@ -29,10 +21,10 @@ initDuckDB().catch(() => {
 
 // CSV + レイアウト両方揃ったらUI初期化
 function initAfterBothLoaded(): void {
-  if (headers.length === 0 || !layoutMeta) return;
+  if (!pendingCsv || !pendingLayout) return;
 
-  const crossCandidates = buildQuestionDefs(headers, layoutMeta.colTypes);
-  initCrossConfig(crossCandidates, layoutMeta.questionLabels);
+  const crossCandidates = buildQuestionDefs(pendingCsv.headers, pendingLayout.meta.colTypes);
+  initCrossConfig(crossCandidates, pendingLayout.meta.questionLabels);
 
   document.getElementById("cross-config-section")!.classList.remove("hidden");
   document.getElementById("run-btn")!.classList.remove("hidden");
@@ -42,29 +34,37 @@ function initAfterBothLoaded(): void {
 // 読み込み済みデータ情報を表示
 function updateLoadedInfo(): void {
   const el = document.getElementById("loaded-data-info")!;
-  if (!lastCsvFileName && !lastLayoutFileName) {
+  if (!pendingCsv && !pendingLayout) {
     el.classList.add("hidden");
     return;
   }
   const lines: string[] = [];
-  if (lastCsvFileName) {
-    lines.push(`CSV: ${lastCsvFileName}  —  ${dataRowCount.toLocaleString()} 行 / ${headers.length} 列`);
+  if (pendingCsv) {
+    lines.push(`CSV: ${pendingCsv.fileName}  —  ${pendingCsv.rowCount.toLocaleString()} 行 / ${pendingCsv.headers.length} 列`);
   }
-  if (lastLayoutFileName && layoutMeta) {
-    lines.push(`JSON: ${lastLayoutFileName}  —  ${Object.keys(layoutMeta.colTypes).length} 列定義`);
+  if (pendingLayout) {
+    lines.push(`JSON: ${pendingLayout.fileName}  —  ${Object.keys(pendingLayout.meta.colTypes).length} 列定義`);
   }
   el.textContent = lines.join("\n");
   el.classList.remove("hidden");
+}
+
+// OPFS自動保存（CSV+レイアウト両方揃ったとき）
+async function trySaveToOPFS(): Promise<void> {
+  if (!pendingCsv || !pendingLayout) return;
+  try {
+    await saveData(pendingCsv.fileName, pendingCsv.text, pendingLayout.fileName, pendingLayout.json);
+    refreshList();
+  } catch (e) {
+    console.warn("OPFS save failed:", e);
+  }
 }
 
 // CSV読み込みハンドラ: DuckDBにロードしてheaders/rowCountを取得
 async function onCSVLoaded(csvText: string, fileName: string): Promise<void> {
   try {
     const result = await loadCSV(csvText);
-    headers = result.headers;
-    dataRowCount = result.rowCount;
-    lastCsvText = csvText;
-    lastCsvFileName = fileName;
+    pendingCsv = { text: csvText, fileName, headers: result.headers, rowCount: result.rowCount };
 
     updateLoadedInfo();
     initAfterBothLoaded();
@@ -81,40 +81,28 @@ function onLayoutLoaded(
   fileName: string,
   rawText: string
 ): void {
-  layoutMeta = meta;
-  lastLayoutJson = rawText;
-  lastLayoutFileName = fileName;
+  pendingLayout = { json: rawText, fileName, meta };
 
   updateLoadedInfo();
   initAfterBothLoaded();
   trySaveToOPFS();
 }
 
-// OPFS自動保存（CSV+レイアウト両方揃ったとき）
-async function trySaveToOPFS(): Promise<void> {
-  if (skipNextSave) return;
-  if (!lastCsvText || !lastLayoutJson) return;
-  try {
-    await saveData(lastCsvFileName, lastCsvText, lastLayoutFileName, lastLayoutJson);
-    refreshList();
-  } catch (e) {
-    console.warn("OPFS save failed:", e);
-  }
-}
-
-// 保存データから読み込み
+// 保存データから読み込み（OPFS再保存は不要なのでtrySaveToOPFSを呼ばない）
 async function loadFromSaved(folderId: string): Promise<void> {
   try {
-    skipNextSave = true;
     const { csvText, csvName, layoutJson, layoutName } = await loadSaved(folderId);
     const layout = parseLayout(layoutJson);
     const meta = buildLayoutMeta(layout);
-    await onCSVLoaded(csvText, csvName);
-    onLayoutLoaded(layout, meta, layoutName, layoutJson);
+    const result = await loadCSV(csvText);
+
+    pendingCsv = { text: csvText, fileName: csvName, headers: result.headers, rowCount: result.rowCount };
+    pendingLayout = { json: layoutJson, fileName: layoutName, meta };
+
+    updateLoadedInfo();
+    initAfterBothLoaded();
   } catch (e) {
     showError("保存データの読み込みエラー: " + (e as Error).message);
-  } finally {
-    skipNextSave = false;
   }
 }
 
@@ -130,22 +118,22 @@ function showError(msg: string): void {
 
 // 集計実行
 async function runAggregation(): Promise<void> {
-  if (!layoutMeta) return;
+  if (!pendingCsv || !pendingLayout) return;
   showError("");
 
   // ウェイト列はレイアウトから自動決定
   const weightCol =
-    Object.entries(layoutMeta.colTypes).find(([, t]) => t === "weight")?.[0] ?? "";
+    Object.entries(pendingLayout.meta.colTypes).find(([, t]) => t === "weight")?.[0] ?? "";
   const crossCols = getCrossColsSelected();
 
   try {
-    const questions = buildQuestionDefs(headers, layoutMeta.colTypes);
+    const questions = buildQuestionDefs(pendingCsv.headers, pendingLayout.meta.colTypes);
     const results = await runDuckDBAggregation({
       questions,
       weight_col: weightCol,
       cross_cols: crossCols,
     });
-    renderResults(results, weightCol, dataRowCount, layoutMeta);
+    renderResults(results, weightCol, pendingCsv.rowCount, pendingLayout.meta);
   } catch (e) {
     showError("集計エラー: " + (e as Error).message);
     console.error(e);

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,27 +28,31 @@ initDuckDB().catch(() => {
   // エラーはduckdbBridge内でUI表示済み
 });
 
+// headers + colTypes から QuestionDef[] を組み立てる
+function buildQuestionDefs(hdrs: string[], colTypes: Record<string, string>): QuestionDef[] {
+  const questions: QuestionDef[] = [];
+  const maAccum: Record<string, string[]> = {};
+  for (const col of hdrs) {
+    const t = colTypes[col];
+    if (!t) continue;
+    if (t === "sa") {
+      questions.push({ type: "SA", column: col });
+    } else if (t.startsWith("ma:")) {
+      (maAccum[t.slice(3)] ??= []).push(col);
+    }
+  }
+  for (const [prefix, cols] of Object.entries(maAccum)) {
+    questions.push({ type: "MA", prefix, columns: cols });
+  }
+  return questions;
+}
+
 // CSV + レイアウト両方揃ったらUI初期化
 function initAfterBothLoaded(): void {
   if (headers.length === 0 || !layoutMeta) return;
 
-  // クロス集計軸候補: SA列 + MAグループ
-  const crossCandidates: QuestionDef[] = [];
-  const maAccumForCross: Record<string, string[]> = {};
-  for (const col of headers) {
-    const t = layoutMeta!.colTypes[col];
-    if (!t) continue;
-    if (t === "sa") {
-      crossCandidates.push({ type: "SA", column: col });
-    } else if (t.startsWith("ma:")) {
-      const prefix = t.slice(3);
-      (maAccumForCross[prefix] ??= []).push(col);
-    }
-  }
-  for (const [prefix, cols] of Object.entries(maAccumForCross)) {
-    crossCandidates.push({ type: "MA", prefix, columns: cols });
-  }
-  initCrossConfig(crossCandidates, layoutMeta!.questionLabels);
+  const crossCandidates = buildQuestionDefs(headers, layoutMeta.colTypes);
+  initCrossConfig(crossCandidates, layoutMeta.questionLabels);
 
   document.getElementById("cross-config-section")!.classList.remove("hidden");
   document.getElementById("run-btn")!.classList.remove("hidden");
@@ -155,23 +159,7 @@ async function runAggregation(): Promise<void> {
   const crossCols = getCrossColsSelected();
 
   try {
-    // layoutMeta.colTypes から全SA/MA列を questions に変換
-    const questions: QuestionDef[] = [];
-    const maAccum: Record<string, string[]> = {};
-    for (const col of headers) {
-      const t = layoutMeta.colTypes[col];
-      if (!t) continue;
-      if (t === "sa") {
-        questions.push({ type: "SA", column: col });
-      } else if (t.startsWith("ma:")) {
-        const prefix = t.slice(3);
-        (maAccum[prefix] ??= []).push(col);
-      }
-    }
-    for (const [prefix, cols] of Object.entries(maAccum)) {
-      questions.push({ type: "MA", prefix, columns: cols });
-    }
-
+    const questions = buildQuestionDefs(headers, layoutMeta.colTypes);
     const results = await runDuckDBAggregation({
       questions,
       weight_col: weightCol,


### PR DESCRIPTION
## Summary

- `buildQuestionDefs` を `layout.ts` に抽出し、`initAfterBothLoaded` と `runAggregation` で重複していたQuestionDef組み立てロジックを共通化
- `main.ts` のモジュールレベル `let` 変数を8個から2個（`pendingCsv` / `pendingLayout`）に集約し、可変状態の表面積を削減
- `skipNextSave` フラグを廃止し、`loadFromSaved` の構造を簡素化

## Test plan

- [ ] `npm run build` で型チェック通過を確認
- [ ] CSV → Layout の順でアップロード → 集計実行できる
- [ ] Layout → CSV の順でも同様に動作する
- [ ] 保存データからの読み込み → 集計実行できる
- [ ] CSV/Layoutの片方だけ再アップロード → 正しく更新される

🤖 Generated with [Claude Code](https://claude.com/claude-code)