### PR TITLE
feat: ライト/ダークモード切り替え & クロス集計軸ラベル解決

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,9 +12,12 @@
 <header>
   <h1>Temotto</h1>
   <span>SURVEY AGGREGATOR v0.1</span>
-  <div class="wasm-status">
-    <div class="status-dot loading" id="wasm-dot"></div>
-    <span id="wasm-label">DuckDB 読み込み中...</span>
+  <div class="header-right">
+    <div class="wasm-status">
+      <div class="status-dot loading" id="wasm-dot"></div>
+      <span id="wasm-label">DuckDB 読み込み中...</span>
+    </div>
+    <button id="theme-toggle" class="theme-toggle" title="テーマ切り替え">🌙</button>
   </div>
 </header>
 

--- a/src/components/ResultTable.ts
+++ b/src/components/ResultTable.ts
@@ -1,4 +1,4 @@
-import type { AggResult } from "../lib/aggregate";
+import type { AggResult, QuestionDef } from "../lib/aggregate";
 import type { LayoutMeta } from "../lib/layout";
 import { pivot } from "../lib/pivot";
 import { downloadAllCSV } from "../lib/download";
@@ -35,13 +35,26 @@ function resolveValueLabel(
   }
 }
 
-/** クロス軸ヘッダーのラベルを解決する。MAカラム名の場合valueLabelsで解決 */
-function resolveSubLabel(subLabel: string, meta?: LayoutMeta): string {
+/** クロス軸ヘッダーのラベルを解決する。
+ *  crossCols があれば SA クロス軸の値ラベルも解決する */
+function resolveSubLabel(
+  subLabel: string,
+  meta?: LayoutMeta,
+  crossCols?: QuestionDef[]
+): string {
   if (!meta) return subLabel;
   // MAカラム名の場合: valueLabels[colName]["1"] にラベルがある
   const maLabel = meta.valueLabels[subLabel]?.["1"];
   if (maLabel) return maLabel;
-  // SA値の場合はそのまま返す
+  // SA クロス軸の値ラベルを解決
+  if (crossCols) {
+    for (const q of crossCols) {
+      if (q.type === "SA") {
+        const label = meta.valueLabels[q.column]?.[subLabel];
+        if (label) return label;
+      }
+    }
+  }
   return subLabel;
 }
 
@@ -49,7 +62,8 @@ export function renderResults(
   results: AggResult[],
   weightCol: string,
   _rawN: number,
-  layoutMeta?: LayoutMeta
+  layoutMeta?: LayoutMeta,
+  crossCols?: QuestionDef[]
 ): void {
   document.getElementById("empty-state")!.classList.add("hidden");
   const area = document.getElementById("results-area")!;
@@ -117,7 +131,7 @@ export function renderResults(
     `;
 
     if (isCross) {
-      card.appendChild(buildCrossTable(res, pv, weightCol, layoutMeta));
+      card.appendChild(buildCrossTable(res, pv, weightCol, layoutMeta, crossCols));
     } else {
       card.appendChild(buildGtTable(res, pv, weightCol, maxPct, layoutMeta));
     }
@@ -177,7 +191,7 @@ function buildGtTable(
     <thead>
       <tr>
         <th>選択肢</th>
-        <th class="right">件数</th>
+        <th class="right">n</th>
         <th class="right">%</th>
         <th></th>
       </tr>
@@ -211,7 +225,8 @@ function buildCrossTable(
   res: AggResult,
   pv: ReturnType<typeof pivot>,
   weightCol: string,
-  layoutMeta?: LayoutMeta
+  layoutMeta?: LayoutMeta,
+  crossCols?: QuestionDef[]
 ): HTMLTableElement {
   const { mains, subs, lookup } = pv;
   const gtSub = subs.find((s) => s.label === "GT")!;
@@ -248,7 +263,7 @@ function buildCrossTable(
 
   const thCount = document.createElement("th");
   thCount.className = "right";
-  thCount.textContent = "件数";
+  thCount.textContent = "n";
   tr2.appendChild(thCount);
 
   const thPct = document.createElement("th");
@@ -260,7 +275,7 @@ function buildCrossTable(
     const th = document.createElement("th");
     th.className = "right cross-val-header";
     const nStr = weightCol ? sub.n.toFixed(1) : sub.n.toLocaleString();
-    th.innerHTML = `${escHtml(resolveSubLabel(sub.label, layoutMeta))}<br><span class="cross-n">n=${nStr}</span>`;
+    th.innerHTML = `${escHtml(resolveSubLabel(sub.label, layoutMeta, crossCols))}<br><span class="cross-n">n=${nStr}</span>`;
     tr2.appendChild(th);
   });
 

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -26,7 +26,7 @@ export function downloadAllCSV(
 }
 
 function downloadGtCSV(results: AggResult[]): void {
-  const rows: string[][] = [["変数名", "種別", "選択肢", "件数", "%"]];
+  const rows: string[][] = [["変数名", "種別", "選択肢", "n", "%"]];
 
   results.forEach((res) => {
     const { mains, lookup } = pivot(res.cells);
@@ -64,7 +64,7 @@ function downloadCrossCSV(results: AggResult[], layoutMeta?: LayoutMeta): void {
   const crossSubs = firstPivot.subs.filter((s) => s.label !== "GT");
 
   // ヘッダー行
-  const headerRow1 = ["変数名", "種別", "選択肢", "全体_件数", "全体_%"];
+  const headerRow1 = ["変数名", "種別", "選択肢", "全体_n", "全体_%"];
   const headerRow2 = ["", "", "", "", ""];
   crossSubs.forEach((sub) => {
     headerRow1.push("");

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,30 @@ import { initSavedFiles, refreshList } from "./components/SavedFiles";
 let currentCsv: { text: string; fileName: string; headers: string[]; rowCount: number } | null = null;
 let currentLayout: { json: string; fileName: string; meta: LayoutMeta } | null = null;
 
+// テーマ切り替え
+function initThemeToggle(): void {
+  const toggle = document.getElementById("theme-toggle")!;
+  const saved = localStorage.getItem("temotto-theme");
+  if (saved === "dark") {
+    document.documentElement.dataset.theme = "dark";
+    toggle.textContent = "☀️";
+  }
+  toggle.addEventListener("click", () => {
+    const isDark = document.documentElement.dataset.theme === "dark";
+    if (isDark) {
+      delete document.documentElement.dataset.theme;
+      toggle.textContent = "🌙";
+      localStorage.setItem("temotto-theme", "light");
+    } else {
+      document.documentElement.dataset.theme = "dark";
+      toggle.textContent = "☀️";
+      localStorage.setItem("temotto-theme", "dark");
+    }
+  });
+}
+
+initThemeToggle();
+
 // DuckDB Wasm をバックグラウンドで初期化開始
 initDuckDB().catch(() => {
   // エラーはduckdbBridge内でUI表示済み
@@ -133,7 +157,7 @@ async function runAggregation(): Promise<void> {
       weight_col: weightCol,
       cross_cols: crossCols,
     });
-    renderResults(results, weightCol, currentCsv.rowCount, currentLayout.meta);
+    renderResults(results, weightCol, currentCsv.rowCount, currentLayout.meta, crossCols);
   } catch (e) {
     showError("集計エラー: " + (e as Error).message);
     console.error(e);

--- a/src/style.css
+++ b/src/style.css
@@ -1,4 +1,25 @@
 :root {
+  --bg: #f5f5f7;
+  --surface: #ffffff;
+  --surface2: #eeeef0;
+  --border: #d0d0d8;
+  --accent: #6b5ce7;
+  --accent2: #0ea5e9;
+  --text: #1a1a2e;
+  --muted: #6b6b80;
+  --danger: #dc2626;
+  --accent-contrast: #ffffff;
+  --shadow: rgba(0, 0, 0, 0.08);
+  --row-border: rgba(0, 0, 0, 0.06);
+  --row-hover: rgba(107, 92, 231, 0.04);
+  --cross-bg: rgba(14, 165, 233, 0.06);
+  --gt-bg: rgba(107, 92, 231, 0.06);
+  --ma-badge-bg: rgba(14, 165, 233, 0.12);
+  --error-bg: rgba(220, 38, 38, 0.06);
+  --error-border: rgba(220, 38, 38, 0.2);
+}
+
+[data-theme="dark"] {
   --bg: #0d0d0f;
   --surface: #16161a;
   --surface2: #1e1e24;
@@ -8,6 +29,15 @@
   --text: #e8e8f0;
   --muted: #6b6b80;
   --danger: #ff6b6b;
+  --accent-contrast: #0d0d0f;
+  --shadow: rgba(0, 0, 0, 0.4);
+  --row-border: rgba(42, 42, 53, 0.6);
+  --row-hover: rgba(232, 255, 71, 0.03);
+  --cross-bg: rgba(71, 200, 255, 0.06);
+  --gt-bg: rgba(232, 255, 71, 0.06);
+  --ma-badge-bg: rgba(71, 200, 255, 0.15);
+  --error-bg: rgba(255, 107, 107, 0.08);
+  --error-border: rgba(255, 107, 107, 0.2);
 }
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -44,8 +74,14 @@ header span {
   letter-spacing: 0.1em;
 }
 
-.wasm-status {
+.header-right {
   margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.wasm-status {
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -53,6 +89,22 @@ header span {
   color: var(--muted);
   min-width: 10rem;
   justify-content: flex-end;
+}
+
+.theme-toggle {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.35rem 0.55rem;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  transition: background 0.2s;
+  color: var(--text);
+}
+
+.theme-toggle:hover {
+  background: var(--border);
 }
 
 .status-dot {
@@ -125,7 +177,7 @@ main {
 
 .load-tab.active {
   background: var(--accent);
-  color: #0d0d0f;
+  color: var(--accent-contrast);
   border-color: var(--accent);
 }
 
@@ -202,7 +254,7 @@ main {
 
 .col-name .ma-badge {
   font-size: 0.65rem;
-  background: rgba(71,200,255,0.15);
+  background: var(--ma-badge-bg);
   color: var(--accent2);
   padding: 0 0.3em;
   border-radius: 2px;
@@ -255,7 +307,7 @@ select.weight-col-select:focus { border-color: var(--accent); }
   margin: 0.75rem 1rem;
   padding: 0.85rem;
   background: var(--accent);
-  color: #0d0d0f;
+  color: var(--accent-contrast);
   border: none;
 
   font-weight: 700;
@@ -268,7 +320,7 @@ select.weight-col-select:focus { border-color: var(--accent); }
   flex-shrink: 0;
 }
 
-.run-btn:hover { background: #f5ff80; transform: translateY(-1px); }
+.run-btn:hover { background: var(--accent); opacity: 0.85; transform: translateY(-1px); }
 .run-btn:active { transform: translateY(0); }
 .run-btn:disabled { background: var(--border); color: var(--muted); cursor: not-allowed; transform: none; }
 
@@ -329,7 +381,7 @@ select.weight-col-select:focus { border-color: var(--accent); }
 
 .weight-toggle button:first-child { border-radius: 3px 0 0 3px; }
 .weight-toggle button:last-child { border-radius: 0 3px 3px 0; border-left: none; }
-.weight-toggle button.active { background: var(--accent); color: #0d0d0f; border-color: var(--accent); }
+.weight-toggle button.active { background: var(--accent); color: var(--accent-contrast); border-color: var(--accent); }
 
 .tables-grid {
   display: grid;
@@ -390,7 +442,7 @@ table.gt th.right { text-align: right; }
 
 table.gt td {
   padding: 0.45rem 1rem;
-  border-bottom: 1px solid rgba(42,42,53,0.6);
+  border-bottom: 1px solid var(--row-border);
 }
 
 table.gt tr:last-child td { border-bottom: none; }
@@ -416,7 +468,7 @@ table.gt td.pct {
   opacity: 0.7;
 }
 
-table.gt tr:hover td { background: rgba(232,255,71,0.03); }
+table.gt tr:hover td { background: var(--row-hover); }
 
 .download-btn {
   margin: 1rem 1rem 0.5rem;
@@ -482,20 +534,20 @@ table.gt.cross-table {
 
 table.gt th.cross-group-header {
   text-align: center;
-  background: rgba(71,200,255,0.06);
+  background: var(--cross-bg);
   border-left: 1px solid var(--border);
   border-bottom: 1px solid var(--border);
   color: var(--accent2);
 }
 
 table.gt th.gt-group {
-  background: rgba(232,255,71,0.06);
+  background: var(--gt-bg);
   color: var(--accent);
 }
 
 table.gt th.cross-val-header {
   text-align: right;
-  border-left: 1px solid rgba(42,42,53,0.6);
+  border-left: 1px solid var(--row-border);
   font-size: 0.62rem;
   white-space: nowrap;
 }
@@ -510,7 +562,7 @@ table.gt td.cross-pct {
   text-align: right;
   font-variant-numeric: tabular-nums;
   color: var(--accent2);
-  border-left: 1px solid rgba(42,42,53,0.6);
+  border-left: 1px solid var(--row-border);
   opacity: 0.85;
 }
 
@@ -612,8 +664,8 @@ table.gt td.cross-pct {
   color: var(--danger);
   font-size: 0.78rem;
   padding: 0.5rem 1rem;
-  background: rgba(255,107,107,0.08);
-  border: 1px solid rgba(255,107,107,0.2);
+  background: var(--error-bg);
+  border: 1px solid var(--error-border);
   border-radius: 3px;
   margin: 0 1rem;
   flex-shrink: 0;
@@ -631,7 +683,7 @@ table.gt td.cross-pct {
   border: 1px solid var(--border);
   border-radius: 12px;
   padding: 1rem 1.2rem;
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 4px 24px var(--shadow);
   z-index: 100;
   animation: bubbleIn 0.3s ease-out;
 }


### PR DESCRIPTION
## Summary
- デフォルトテーマをダークモードからライトモードに変更し、ヘッダー右端のトグルボタン（🌙/☀️）でダーク↔ライトを切り替え可能に（`localStorage`で永続化）
- ハードコードされた色値をCSS custom propertiesに統一し、`[data-theme="dark"]`セレクタでダークテーマを定義
- クロス集計ヘッダーでSAクロス軸の選択肢ラベル（valueLabels）を解決するよう`resolveSubLabel`を拡張
- CSVダウンロードのヘッダー文言を「件数」→「n」に統一

## Test plan
- [ ] 初回アクセス時にライトモードで表示されること
- [ ] トグルボタンでダーク↔ライトの切り替えが動作すること
- [ ] ページリロード後もテーマが保持されること
- [ ] クロス集計テーブルのヘッダーにSA軸の値ラベルが表示されること
- [ ] CSVダウンロードのヘッダーが「n」になっていること
- [ ] `npm run build` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)