### PR TITLE
fix: Chrome Prompt API の言語指定を最新仕様に更新

### DIFF
--- a/src/lib/aiComment.ts
+++ b/src/lib/aiComment.ts
@@ -6,10 +6,14 @@ import type { LayoutMeta } from "./layout";
 // --- Chrome Prompt API 型宣言 ---
 
 declare global {
+  interface LanguageModelExpectedIO {
+    type: string;
+    languages?: string[];
+  }
   interface LanguageModelCreateOptions {
     systemPrompt?: string;
-    expectedInputLanguages?: string[];
-    expectedOutputLanguages?: string[];
+    expectedInputs?: LanguageModelExpectedIO[];
+    expectedOutputs?: LanguageModelExpectedIO[];
     monitor?: (monitor: EventTarget) => void;
   }
   interface LanguageModelStatic {
@@ -123,8 +127,8 @@ export async function generateComment(
     const payload = buildPromptPayload(results, weightCol, layoutMeta);
     const session = await LanguageModel!.create({
       systemPrompt: SYSTEM_PROMPT,
-      expectedInputLanguages: ["ja"],
-      expectedOutputLanguages: ["ja"],
+      expectedInputs: [{ type: "text", languages: ["ja"] }],
+      expectedOutputs: [{ type: "text", languages: ["ja"] }],
     });
 
     try {


### PR DESCRIPTION
## Summary
- Chrome Prompt API の `expectedInputLanguages` / `expectedOutputLanguages` を最新仕様の `expectedInputs` / `expectedOutputs` に移行
- コンソール警告 "No output language was specified in a LanguageModel API request" を解消

## Test plan
- [ ] `npm run build` で型エラーがないことを確認
- [ ] AI分析コメント生成時にコンソール警告が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)