### PR TITLE
refactor: Google Fontsを削除しシステムフォントに変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,6 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Noto+Sans+Mono:wght@400;700&display=swap" rel="stylesheet">
 <title>Temotto — アンケート集計</title>
 <meta name="description" content="ブラウザ上で完結するアンケートローデータ集計ツール。CSVとレイアウトJSONを読み込み、GT集計・クロス集計をクライアントサイドで高速に実行します。">
 <link rel="stylesheet" href="/src/style.css">

--- a/src/style.css
+++ b/src/style.css
@@ -5,8 +5,8 @@
 /* === Design Tokens: Light Mode === */
 :root {
   /* Typography */
-  --font-family-base: "Noto Sans JP", "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
-  --font-family-mono: "Noto Sans Mono", "SF Mono", Consolas, monospace;
+  --font-family-base: system-ui, sans-serif;
+  --font-family-mono: ui-monospace, monospace;
 
   /* Neutral Scale */
   --color-white: #ffffff;


### PR DESCRIPTION
## Summary
- Google Fonts（Noto Sans JP, Noto Sans Mono）の外部読み込みを削除
- `system-ui` / `ui-monospace` によるシステムフォントスタックに変更
- 外部リクエスト削減による初期表示の高速化

## Test plan
- [ ] 各OS（macOS / Windows）でフォント表示が崩れないこと
- [ ] 等幅フォント（集計結果テーブル等）が正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)