### PR TITLE
feat: DADS準拠のアクセシビリティ改善

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,26 +16,26 @@
   <h1>Temotto</h1>
   <span>SURVEY AGGREGATOR v0.1</span>
   <div class="header-right">
-    <div class="wasm-status">
-      <div class="status-dot loading" id="wasm-dot"></div>
+    <div class="wasm-status" role="status" aria-live="polite">
+      <div class="status-dot loading" id="wasm-dot" aria-hidden="true"></div>
       <span id="wasm-label">DuckDB 読み込み中...</span>
     </div>
-    <button id="theme-toggle" class="theme-toggle" title="テーマ切り替え">🌙</button>
+    <button id="theme-toggle" class="theme-toggle" aria-label="ダークモードに切り替え">🌙</button>
   </div>
 </header>
 
 <main>
   <!-- LEFT: 設定パネル -->
-  <div class="panel-left">
+  <div class="panel-left" role="region" aria-label="設定">
 
     <!-- データ読み込み -->
-    <div class="section" id="file-section">
-      <div class="section-label">01 / データ読み込み</div>
-      <div class="load-tabs">
-        <button class="load-tab active" data-tab="file">ファイルから</button>
-        <button class="load-tab" data-tab="saved">保存データから</button>
+    <section class="section" id="file-section">
+      <h2 class="section-label">01 / データ読み込み</h2>
+      <div class="load-tabs" role="tablist" aria-label="データ読み込み方法">
+        <button class="load-tab active" role="tab" aria-selected="true" aria-controls="tab-file" id="tab-btn-file" data-tab="file">ファイルから</button>
+        <button class="load-tab" role="tab" aria-selected="false" aria-controls="tab-saved" id="tab-btn-saved" data-tab="saved">保存データから</button>
       </div>
-      <div class="load-tab-panel" id="tab-file">
+      <div class="load-tab-panel" id="tab-file" role="tabpanel" aria-labelledby="tab-btn-file">
         <div class="file-row">
           <label class="file-label" for="file-input">CSV</label>
           <input type="file" id="file-input" accept=".csv" class="file-input">
@@ -45,30 +45,30 @@
           <input type="file" id="layout-file-input" accept=".json" class="file-input">
         </div>
       </div>
-      <div class="load-tab-panel hidden" id="tab-saved">
+      <div class="load-tab-panel hidden" id="tab-saved" role="tabpanel" aria-labelledby="tab-btn-saved">
         <div id="saved-files-list"></div>
       </div>
-      <div id="loaded-data-info" class="loaded-data-info hidden"></div>
-    </div>
+      <div id="loaded-data-info" class="loaded-data-info hidden" aria-live="polite"></div>
+    </section>
 
     <!-- クロス集計軸 -->
-    <div class="section hidden" id="cross-config-section">
-      <div class="section-label">02 / クロス集計軸（任意）</div>
-      <div class="cross-col-list" id="cross-col-list"></div>
-    </div>
+    <section class="section hidden" id="cross-config-section">
+      <h2 class="section-label">02 / クロス集計軸（任意）</h2>
+      <div class="cross-col-list" id="cross-col-list" role="group" aria-label="クロス集計軸の選択"></div>
+    </section>
 
-    <div id="error-msg" class="hidden"></div>
+    <div id="error-msg" class="hidden" role="alert" aria-live="assertive"></div>
 
     <button class="run-btn hidden" id="run-btn" disabled>▶ 集計を実行</button>
   </div>
 
   <!-- RIGHT: 結果パネル -->
-  <div class="panel-right" id="panel-right">
+  <div class="panel-right" id="panel-right" role="region" aria-label="集計結果">
     <div class="empty-state" id="empty-state">
-      <span class="big">⬛</span>
+      <span class="big" aria-hidden="true">⬛</span>
       <p>CSVを読み込んで集計を実行してください</p>
     </div>
-    <div class="hidden" id="results-area"></div>
+    <div class="hidden" id="results-area" aria-live="polite"></div>
   </div>
 </main>
 

--- a/src/components/ResultTable.ts
+++ b/src/components/ResultTable.ts
@@ -187,15 +187,17 @@ function buildGtTable(
 ): HTMLTableElement {
   const { mains, lookup } = pv;
 
+  const questionLabel = resolveQuestionLabel(res.question, layoutMeta);
   const table = document.createElement("table");
   table.className = "gt";
   table.innerHTML = `
+    <caption class="visually-hidden">${escHtml(questionLabel)} の集計結果</caption>
     <thead>
       <tr>
         <th>選択肢</th>
         <th class="right">n</th>
         <th class="right">%</th>
-        <th></th>
+        <th aria-hidden="true"><span class="visually-hidden">グラフ</span></th>
       </tr>
     </thead>
     <tbody>
@@ -211,7 +213,7 @@ function buildGtTable(
               : cell.count.toFixed(1)
           }</td>
           <td class="pct">${cell.pct.toFixed(1)}%</td>
-          <td class="bar-cell">
+          <td class="bar-cell" aria-hidden="true">
             <div class="bar" style="width:${((cell.pct / Math.max(maxPct, 1)) * 72).toFixed(1)}px"></div>
           </td>
         </tr>
@@ -234,8 +236,14 @@ function buildCrossTable(
   const gtSub = subs.find((s) => s.label === "GT")!;
   const crossSubs = subs.filter((s) => s.label !== "GT");
 
+  const questionLabel = resolveQuestionLabel(res.question, layoutMeta);
   const table = document.createElement("table");
   table.className = "gt cross-table";
+
+  const caption = document.createElement("caption");
+  caption.className = "visually-hidden";
+  caption.textContent = `${questionLabel} のクロス集計結果`;
+  table.appendChild(caption);
 
   // ヘッダー行1: 選択肢 | 全体 | クロス値...
   const tr1 = document.createElement("tr");

--- a/src/components/SavedFiles.ts
+++ b/src/components/SavedFiles.ts
@@ -43,7 +43,7 @@ export async function refreshList(): Promise<void> {
     delBtn.className = "saved-item-del";
     delBtn.type = "button";
     delBtn.textContent = "×";
-    delBtn.title = "削除";
+    delBtn.setAttribute("aria-label", `${entry.csvName} を削除`);
     delBtn.addEventListener("click", async (e) => {
       e.stopPropagation();
       await deleteSaved(entry.folderId);

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,16 +21,19 @@ function initThemeToggle(): void {
   if (saved === "dark") {
     document.documentElement.dataset.theme = "dark";
     toggle.textContent = "☀️";
+    toggle.setAttribute("aria-label", "ライトモードに切り替え");
   }
   toggle.addEventListener("click", () => {
     const isDark = document.documentElement.dataset.theme === "dark";
     if (isDark) {
       delete document.documentElement.dataset.theme;
       toggle.textContent = "🌙";
+      toggle.setAttribute("aria-label", "ダークモードに切り替え");
       localStorage.setItem("temotto-theme", "light");
     } else {
       document.documentElement.dataset.theme = "dark";
       toggle.textContent = "☀️";
+      toggle.setAttribute("aria-label", "ライトモードに切り替え");
       localStorage.setItem("temotto-theme", "dark");
     }
   });
@@ -165,14 +168,43 @@ async function runAggregation(): Promise<void> {
 }
 
 // タブ切り替え
-for (const tab of document.querySelectorAll<HTMLButtonElement>(".load-tab")) {
-  tab.addEventListener("click", () => {
-    for (const t of document.querySelectorAll<HTMLButtonElement>(".load-tab")) {
-      t.classList.toggle("active", t === tab);
+const tabs = Array.from(document.querySelectorAll<HTMLButtonElement>(".load-tab"));
+
+function activateTab(tab: HTMLButtonElement): void {
+  for (const t of tabs) {
+    const isActive = t === tab;
+    t.classList.toggle("active", isActive);
+    t.setAttribute("aria-selected", String(isActive));
+    t.tabIndex = isActive ? 0 : -1;
+  }
+  const target = tab.dataset.tab!;
+  document.getElementById("tab-file")!.classList.toggle("hidden", target !== "file");
+  document.getElementById("tab-saved")!.classList.toggle("hidden", target !== "saved");
+  tab.focus();
+}
+
+// 初期状態: 非アクティブタブを tabIndex=-1 に設定
+for (const t of tabs) {
+  if (!t.classList.contains("active")) t.tabIndex = -1;
+}
+
+for (const tab of tabs) {
+  tab.addEventListener("click", () => activateTab(tab));
+  tab.addEventListener("keydown", (e: KeyboardEvent) => {
+    const idx = tabs.indexOf(tab);
+    if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+      e.preventDefault();
+      activateTab(tabs[(idx + 1) % tabs.length]);
+    } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+      e.preventDefault();
+      activateTab(tabs[(idx - 1 + tabs.length) % tabs.length]);
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      activateTab(tabs[0]);
+    } else if (e.key === "End") {
+      e.preventDefault();
+      activateTab(tabs[tabs.length - 1]);
     }
-    const target = tab.dataset.tab!;
-    document.getElementById("tab-file")!.classList.toggle("hidden", target !== "file");
-    document.getElementById("tab-saved")!.classList.toggle("hidden", target !== "saved");
   });
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -842,6 +842,18 @@ table.gt td.cross-pct {
 /* === Utilities === */
 .hidden { display: none !important; }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 #error-msg {
   color: var(--danger);
   font-size: var(--text-base);


### PR DESCRIPTION
## Summary
- WAI-ARIAタブパターン（`role="tablist/tab/tabpanel"`, `aria-selected`, 矢印キー操作）を実装
- 動的コンテンツ（DuckDBステータス・エラー・集計結果・読み込み情報）に `aria-live` リージョンを追加
- テーブルに `<caption>`、棒グラフ列に `aria-hidden`、空 `<th>` に visually-hidden テキストを追加
- セクションを `<section>` + `<h2>` にセマンティック化、パネルに `role="region"` ランドマークを追加
- テーマ切り替えボタンの `aria-label` を状態に応じて動的更新
- 削除ボタンにファイル名付き `aria-label` を追加
- `.visually-hidden` ユーティリティクラスを追加

## Test plan
- [ ] スクリーンリーダー（VoiceOver）でタブ切り替え・矢印キー操作を確認
- [ ] エラー発生時にスクリーンリーダーが即時読み上げることを確認
- [ ] 集計結果表示後、テーブルのcaptionがスクリーンリーダーで読まれることを確認
- [ ] テーマ切り替え後、ボタンのaria-labelが正しく更新されることを確認
- [ ] `tsc --noEmit` でビルドが通ることを確認（確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)