### PR TITLE
refactor: DuckDB特性を活かした集計エンジン最適化

### DIFF
--- a/src/lib/aggregate.ts
+++ b/src/lib/aggregate.ts
@@ -1,7 +1,7 @@
 /** DuckDB SQL集計ロジック */
 
 import type * as duckdb from "@duckdb/duckdb-wasm";
-import { Aggregator } from "./aggregator";
+import { Aggregator, fetchCrossHeaders } from "./aggregator";
 
 // --- 集計結果の型定義 ---
 
@@ -44,21 +44,41 @@ export interface Query {
   cross_cols: QuestionDef[];
 }
 
-/** 集計のエントリポイント。conn上のsurveyビューに対して全設問を集計する */
+/** 集計のエントリポイント。db上のsurveyビューに対して全設問を並列集計する */
 export async function aggregate(
-  conn: duckdb.AsyncDuckDBConnection,
+  db: duckdb.AsyncDuckDB,
   payload: Query
 ): Promise<AggResult[]> {
-  const ctx = await Aggregator.create(conn, payload);
+  const weightCol = payload.weight_col;
+  const crossCols = payload.cross_cols ?? [];
 
-  const results: AggResult[] = [];
-  for (const q of payload.questions) {
-    if (q.type === "SA") {
-      results.push(await ctx.aggregateSA(q.column));
-    } else {
-      results.push(await ctx.aggregateMA(q.prefix, q.columns));
+  // クロスヘッダーキャッシュを先に構築（1コネクション）
+  let crossHeaderCache: Awaited<ReturnType<typeof fetchCrossHeaders>>;
+  if (crossCols.length > 0) {
+    const conn = await db.connect();
+    try {
+      crossHeaderCache = await fetchCrossHeaders(conn, crossCols, weightCol);
+    } finally {
+      await conn.close();
     }
+  } else {
+    crossHeaderCache = new Map();
   }
 
-  return results;
+  // 設問ごとに並列実行（各自コネクション作成・破棄）
+  return Promise.all(
+    payload.questions.map(async (q) => {
+      const conn = await db.connect();
+      try {
+        const ctx = new Aggregator(conn, weightCol, crossCols, crossHeaderCache);
+        if (q.type === "SA") {
+          return ctx.aggregateSA(q.column);
+        } else {
+          return ctx.aggregateMA(q.prefix, q.columns);
+        }
+      } finally {
+        await conn.close();
+      }
+    })
+  );
 }

--- a/src/lib/aggregator.ts
+++ b/src/lib/aggregator.ts
@@ -1,7 +1,7 @@
 /** 集計エンジン - SQL生成・実行の全責務を担う */
 
 import type * as duckdb from "@duckdb/duckdb-wasm";
-import type { Cell, AggResult, QuestionDef, Query } from "./aggregate";
+import type { Cell, AggResult, QuestionDef } from "./aggregate";
 import { questionKey } from "./aggregate";
 
 // --- SQL ヘルパー ---
@@ -18,8 +18,8 @@ function weightExpr(weightCol: string): string {
 
 function maWeightedCountExpr(maCol: string, weightCol: string): string {
   return weightCol
-    ? `SUM(CASE WHEN "${esc(maCol)}" = '1' THEN TRY_CAST("${esc(weightCol)}" AS DOUBLE) ELSE 0 END)`
-    : `COUNT(CASE WHEN "${esc(maCol)}" = '1' THEN 1 END)::DOUBLE`;
+    ? `COALESCE(SUM(TRY_CAST("${esc(weightCol)}" AS DOUBLE)) FILTER (WHERE "${esc(maCol)}" = '1'), 0)`
+    : `COUNT(*) FILTER (WHERE "${esc(maCol)}" = '1')::DOUBLE`;
 }
 
 /** MA設問の「表示された」条件: いずれかのサブカラムが空でない */
@@ -44,64 +44,84 @@ type CrossHeaderCache = Map<
 // --- 集計コンテキスト ---
 
 export class Aggregator {
-  private constructor(
+  constructor(
     private conn: duckdb.AsyncDuckDBConnection,
     private weightCol: string,
     private crossCols: QuestionDef[],
     private crossHeaderCache: CrossHeaderCache,
   ) {}
 
-  /** ファクトリ: conn と payload から前処理済みのコンテキストを生成 */
-  static async create(
-    conn: duckdb.AsyncDuckDBConnection,
-    payload: Query,
-  ): Promise<Aggregator> {
-    const weightCol = payload.weight_col;
-    const crossCols = payload.cross_cols ?? [];
-    const crossHeaderCache =
-      crossCols.length > 0
-        ? await fetchCrossHeaders(conn, crossCols, weightCol)
-        : (new Map() as CrossHeaderCache);
-
-    return new Aggregator(conn, weightCol, crossCols, crossHeaderCache);
-  }
-
   async aggregateSA(col: string): Promise<AggResult> {
-    const sql = `
-      SELECT
-        "${esc(col)}" AS label,
-        ${weightExpr(this.weightCol)} AS cnt
-      FROM survey
-      WHERE "${esc(col)}" IS NOT NULL
-        AND "${esc(col)}" != ''
-      GROUP BY "${esc(col)}"
-      ORDER BY
-        TRY_CAST("${esc(col)}" AS DOUBLE) NULLS LAST,
-        "${esc(col)}" ASC
-    `;
+    // クロス軸を SA / MA に分離（CTE統合は SA×SA のみ）
+    const saCross = this.crossCols.filter((q) => q.type === "SA") as Array<{ type: "SA"; column: string }>;
+    const maCross = this.crossCols.filter((q) => q.type === "MA") as Array<{ type: "MA"; prefix: string; columns: string[] }>;
+
+    // CTE: GT + 全SA×SAクロスを1クエリで取得
+    const GT_SENTINEL = "__GT__";
+    let sql = `WITH base AS (
+      SELECT * FROM survey
+      WHERE "${esc(col)}" IS NOT NULL AND "${esc(col)}" != ''
+    )
+    SELECT "${esc(col)}" AS mv, '${GT_SENTINEL}' AS sv, ${weightExpr(this.weightCol)} AS cnt
+    FROM base GROUP BY "${esc(col)}"`;
+
+    for (const crossQ of saCross) {
+      sql += `
+    UNION ALL
+    SELECT "${esc(col)}" AS mv, "${esc(crossQ.column)}" AS sv, ${weightExpr(this.weightCol)} AS cnt
+    FROM base
+    WHERE "${esc(crossQ.column)}" IS NOT NULL AND "${esc(crossQ.column)}" != ''
+    GROUP BY "${esc(col)}", "${esc(crossQ.column)}"`;
+    }
+
+    sql += `
+    ORDER BY sv, TRY_CAST(mv AS DOUBLE) NULLS LAST, mv ASC`;
 
     const arrowResult = await this.conn.query(sql);
-    const rowArr = arrowResult.toArray();
+    const allRows = arrowResult.toArray();
 
-    // per-question n: 集計結果のカウント合計 = 表示された人数（N/A含む）
-    const questionN = rowArr.reduce((sum, r) => sum + Number(r.cnt), 0);
+    // sv ごとに行を仕分け
+    const gtRows: Array<{ mv: string; cnt: number }> = [];
+    const crossBuckets = new Map<string, Map<string, number>>();
 
-    // GT セル（n は設問が表示された人数）
-    const cells: Cell[] = rowArr.map((r) =>
-      mkCell(String(r.label), "GT", questionN, Number(r.cnt))
+    for (const r of allRows) {
+      const sv = String(r.sv);
+      const mv = String(r.mv);
+      const cnt = Number(r.cnt);
+      if (sv === GT_SENTINEL) {
+        gtRows.push({ mv, cnt });
+      } else {
+        let bucket = crossBuckets.get(sv);
+        if (!bucket) { bucket = new Map(); crossBuckets.set(sv, bucket); }
+        bucket.set(mv, cnt);
+      }
+    }
+
+    // GT セル
+    const questionN = gtRows.reduce((sum, r) => sum + r.cnt, 0);
+    const mainValues = gtRows.map((r) => r.mv);
+    const cells: Cell[] = gtRows.map((r) =>
+      mkCell(r.mv, "GT", questionN, r.cnt)
     );
 
-    // クロスセル
-    if (this.crossCols.length > 0) {
-      const mainValues = rowArr.map((r) => String(r.label));
-      for (const crossQ of this.crossCols) {
-        const cached = this.crossHeaderCache.get(questionKey(crossQ))!;
-        if (crossQ.type === "SA") {
-          cells.push(...await this.buildCrossCellsSA(col, mainValues, crossQ.column, cached));
-        } else {
-          cells.push(...await this.buildCrossCellsMA(col, mainValues, crossQ.columns, cached));
+    // SA×SA クロスセル
+    for (const crossQ of saCross) {
+      const cached = this.crossHeaderCache.get(crossQ.column)!;
+      const { headers, crossValues } = cached;
+      const bucket = crossBuckets;
+      for (const mv of mainValues) {
+        for (let i = 0; i < crossValues.length; i++) {
+          const sv = crossValues[i];
+          const cnt = bucket.get(sv)?.get(mv) ?? 0;
+          cells.push(mkCell(mv, sv, headers[i].n, cnt));
         }
       }
+    }
+
+    // SA×MA クロスセル（構造が異なるため個別クエリ維持）
+    for (const crossQ of maCross) {
+      const cached = this.crossHeaderCache.get(crossQ.prefix)!;
+      cells.push(...await this.buildCrossCellsMA(col, mainValues, crossQ.columns, cached));
     }
 
     return { question: col, type: "SA", cells };
@@ -115,8 +135,8 @@ export class Aggregator {
     // 無回答式: 表示されたが何も選択していない
     const noneSelected = cols.map((c) => `"${esc(c)}" != '1'`).join(" AND ");
     const naExpr = this.weightCol
-      ? `SUM(CASE WHEN ${noneSelected} THEN TRY_CAST("${esc(this.weightCol)}" AS DOUBLE) ELSE 0 END)`
-      : `COUNT(CASE WHEN ${noneSelected} THEN 1 END)::DOUBLE`;
+      ? `COALESCE(SUM(TRY_CAST("${esc(this.weightCol)}" AS DOUBLE)) FILTER (WHERE ${noneSelected}), 0)`
+      : `COUNT(*) FILTER (WHERE ${noneSelected})::DOUBLE`;
 
     // questionN 式: 表示された人数
     const nExpr = this.weightCol
@@ -153,45 +173,6 @@ export class Aggregator {
     }
 
     return { question: prefix, type: "MA", cells };
-  }
-
-  /** SA主軸 × SA軸クロスセル生成 */
-  private async buildCrossCellsSA(
-    mainCol: string,
-    mainValues: string[],
-    crossCol: string,
-    cached: { headers: Array<{ label: string; n: number }>; crossValues: string[] }
-  ): Promise<Cell[]> {
-    const { headers, crossValues } = cached;
-
-    const cellSQL = `
-      SELECT
-        "${esc(mainCol)}" AS mv,
-        "${esc(crossCol)}" AS sv,
-        ${weightExpr(this.weightCol)} AS cnt
-      FROM survey
-      WHERE "${esc(mainCol)}" IS NOT NULL
-        AND "${esc(mainCol)}" != ''
-        AND "${esc(crossCol)}" IS NOT NULL
-        AND "${esc(crossCol)}" != ''
-      GROUP BY "${esc(mainCol)}", "${esc(crossCol)}"
-    `;
-
-    const cellResult = await this.conn.query(cellSQL);
-    const cellMap = new Map<string, number>();
-    for (const r of cellResult.toArray()) {
-      cellMap.set(`${r.mv}\0${r.sv}`, Number(r.cnt));
-    }
-
-    const cells: Cell[] = [];
-    for (const mv of mainValues) {
-      for (let i = 0; i < crossValues.length; i++) {
-        const sv = crossValues[i];
-        cells.push(mkCell(mv, sv, headers[i].n, cellMap.get(`${mv}\0${sv}`) ?? 0));
-      }
-    }
-
-    return cells;
   }
 
   /** SA主軸 × MA軸クロスセル生成 */
@@ -249,9 +230,10 @@ export class Aggregator {
     );
 
     // 無回答カウント: 表示されたが何も選択していない
+    const naCondition = `${maCols.map((c) => `"${esc(c)}" != '1'`).join(" AND ")} AND (${maShownCondition(maCols)})`;
     const naExpr = this.weightCol
-      ? `SUM(CASE WHEN ${maCols.map((c) => `"${esc(c)}" != '1'`).join(" AND ")} AND (${maShownCondition(maCols)}) THEN TRY_CAST("${esc(this.weightCol)}" AS DOUBLE) ELSE 0 END)`
-      : `COUNT(CASE WHEN ${maCols.map((c) => `"${esc(c)}" != '1'`).join(" AND ")} AND (${maShownCondition(maCols)}) THEN 1 END)::DOUBLE`;
+      ? `COALESCE(SUM(TRY_CAST("${esc(this.weightCol)}" AS DOUBLE)) FILTER (WHERE ${naCondition}), 0)`
+      : `COUNT(*) FILTER (WHERE ${naCondition})::DOUBLE`;
 
     const sql = `
       SELECT
@@ -300,18 +282,21 @@ export class Aggregator {
     const selectClauses: string[] = [];
     for (let r = 0; r < rowMaCols.length; r++) {
       for (let c = 0; c < crossMaCols.length; c++) {
+        const cond = `"${esc(rowMaCols[r])}" = '1' AND "${esc(crossMaCols[c])}" = '1'`;
         const expr = this.weightCol
-          ? `SUM(CASE WHEN "${esc(rowMaCols[r])}" = '1' AND "${esc(crossMaCols[c])}" = '1' THEN TRY_CAST("${esc(this.weightCol)}" AS DOUBLE) ELSE 0 END)`
-          : `COUNT(CASE WHEN "${esc(rowMaCols[r])}" = '1' AND "${esc(crossMaCols[c])}" = '1' THEN 1 END)::DOUBLE`;
+          ? `COALESCE(SUM(TRY_CAST("${esc(this.weightCol)}" AS DOUBLE)) FILTER (WHERE ${cond}), 0)`
+          : `COUNT(*) FILTER (WHERE ${cond})::DOUBLE`;
         selectClauses.push(`${expr} AS r${r}c${c}`);
       }
     }
 
     // 無回答 × 各クロスMAカラム
+    const naBase = `${rowMaCols.map((col) => `"${esc(col)}" != '1'`).join(" AND ")} AND (${maShownCondition(rowMaCols)})`;
     for (let c = 0; c < crossMaCols.length; c++) {
+      const naCondition = `${naBase} AND "${esc(crossMaCols[c])}" = '1'`;
       const expr = this.weightCol
-        ? `SUM(CASE WHEN ${rowMaCols.map((col) => `"${esc(col)}" != '1'`).join(" AND ")} AND (${maShownCondition(rowMaCols)}) AND "${esc(crossMaCols[c])}" = '1' THEN TRY_CAST("${esc(this.weightCol)}" AS DOUBLE) ELSE 0 END)`
-        : `COUNT(CASE WHEN ${rowMaCols.map((col) => `"${esc(col)}" != '1'`).join(" AND ")} AND (${maShownCondition(rowMaCols)}) AND "${esc(crossMaCols[c])}" = '1' THEN 1 END)::DOUBLE`;
+        ? `COALESCE(SUM(TRY_CAST("${esc(this.weightCol)}" AS DOUBLE)) FILTER (WHERE ${naCondition}), 0)`
+        : `COUNT(*) FILTER (WHERE ${naCondition})::DOUBLE`;
       selectClauses.push(`${expr} AS na_c${c}`);
     }
 
@@ -337,7 +322,7 @@ export class Aggregator {
 
 // --- 前処理（static create から利用） ---
 
-async function fetchCrossHeaders(
+export async function fetchCrossHeaders(
   conn: duckdb.AsyncDuckDBConnection,
   crossCols: QuestionDef[],
   weightCol: string

--- a/src/lib/duckdbBridge.ts
+++ b/src/lib/duckdbBridge.ts
@@ -80,6 +80,6 @@ export async function loadCSV(csvText: string): Promise<{ headers: string[]; row
 
 /** survey ビューに対して集計を実行する */
 export async function runDuckDBAggregation(query: Query): Promise<AggResult[]> {
-  const c = await getConnection();
-  return aggregate(c, query);
+  if (!db || status !== "ready") throw new Error("DuckDB is not ready");
+  return aggregate(db, query);
 }


### PR DESCRIPTION
## Summary
- **FILTER句**: `CASE WHEN`式をDuckDBネイティブの`FILTER (WHERE ...)`に置換し、SQLの可読性を向上
- **CTE統合**: SA集計で GT + 全SA×SAクロスを`WITH base AS (...) UNION ALL`の1クエリに統合し、重複テーブルスキャンを削減
- **並列化**: `aggregate()`が`AsyncDuckDB`を受け取り、設問ごとに個別コネクションで`Promise.all`並列実行

## Test plan
- [ ] `npm run build` でビルド成功を確認済み
- [ ] ブラウザでCSV+レイアウト読み込み → GT集計の値が変更前と一致
- [ ] SA×SA, SA×MA, MA×SA, MA×MA の全クロス組み合わせで値一致を確認
- [ ] ウェイトあり/なし両方で確認
- [ ] N/A行の値が変わっていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)