### PR TITLE
refactor: 不要なcsv.tsラッパーを削除

### DIFF
--- a/src/components/FileInput.ts
+++ b/src/components/FileInput.ts
@@ -1,4 +1,3 @@
-import { readFileAsText } from "../lib/csv";
 import { parseLayout, buildLayoutMeta, type Layout, type LayoutMeta } from "../lib/layout";
 
 export function initCsvInput(
@@ -14,7 +13,7 @@ export function initCsvInput(
 
   async function handleFile(file: File) {
     try {
-      const csvText = await readFileAsText(file);
+      const csvText = await file.text();
       onLoad(csvText, file.name);
     } catch (err) {
       onError((err as Error).message);

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,4 +1,0 @@
-/** CSVファイルをテキストとして読み込む */
-export function readFileAsText(file: File): Promise<string> {
-  return file.text();
-}


### PR DESCRIPTION
## Summary
- `src/lib/csv.ts` の `readFileAsText()` は `file.text()` を1行ラップしているだけで不要なため削除
- `initCsvInput` で直接 `file.text()` を使用するよう変更（`initLayoutInput` 側と統一）

## Test plan
- [ ] `tsc --noEmit` が通ること
- [ ] CSVファイルのアップロードが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)