### PR TITLE
feat: oxlint / oxfmt を導入

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,11 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "useTabs": false,
+  "printWidth": 100,
+  "trailingComma": "all",
+  "arrowParens": "always",
+  "bracketSpacing": true,
+  "endOfLine": "lf"
+}

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": ["typescript", "import", "unicorn"],
+  "env": {
+    "browser": true
+  },
+  "ignorePatterns": ["dist/", "node_modules/", "testdata/"],
+  "rules": {
+    "no-unused-vars": "warn",
+    "no-console": "warn",
+    "eqeqeq": "warn",
+    "no-var": "error",
+    "prefer-const": "warn",
+    "typescript/no-explicit-any": "warn",
+    "import/no-duplicates": "warn"
+  },
+  "overrides": [
+    {
+      "files": ["scripts/**/*.ts"],
+      "rules": {
+        "no-console": "off"
+      }
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1,74 +1,105 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Temotto — アンケート集計</title>
-<meta name="description" content="ブラウザ上で完結するアンケートローデータ集計ツール。CSVとレイアウトJSONを読み込み、GT集計・クロス集計をクライアントサイドで高速に実行します。">
-<link rel="stylesheet" href="/src/style.css">
-</head>
-<body>
-
-<header>
-  <h1>Temotto</h1>
-  <span>SURVEY AGGREGATOR v0.1</span>
-  <div class="header-right">
-    <div class="wasm-status" role="status" aria-live="polite">
-      <div class="status-dot loading" id="wasm-dot" aria-hidden="true"></div>
-      <span id="wasm-label">DuckDB 読み込み中...</span>
-    </div>
-    <button id="theme-toggle" class="theme-toggle" aria-label="ダークモードに切り替え">🌙</button>
-  </div>
-</header>
-
-<main>
-  <!-- LEFT: 設定パネル -->
-  <div class="panel-left" role="region" aria-label="設定">
-
-    <!-- データ読み込み -->
-    <section class="section" id="file-section">
-      <h2 class="section-label">01 / データ読み込み</h2>
-      <div class="load-tabs" role="tablist" aria-label="データ読み込み方法">
-        <button class="load-tab active" role="tab" aria-selected="true" aria-controls="tab-file" id="tab-btn-file" data-tab="file">ファイルから</button>
-        <button class="load-tab" role="tab" aria-selected="false" aria-controls="tab-saved" id="tab-btn-saved" data-tab="saved">保存データから</button>
-      </div>
-      <div class="load-tab-panel" id="tab-file" role="tabpanel" aria-labelledby="tab-btn-file">
-        <div class="file-row">
-          <label class="file-label" for="file-input">CSV</label>
-          <input type="file" id="file-input" accept=".csv" class="file-input">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Temotto — アンケート集計</title>
+    <meta
+      name="description"
+      content="ブラウザ上で完結するアンケートローデータ集計ツール。CSVとレイアウトJSONを読み込み、GT集計・クロス集計をクライアントサイドで高速に実行します。"
+    />
+    <link rel="stylesheet" href="/src/style.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Temotto</h1>
+      <span>SURVEY AGGREGATOR v0.1</span>
+      <div class="header-right">
+        <div class="wasm-status" role="status" aria-live="polite">
+          <div class="status-dot loading" id="wasm-dot" aria-hidden="true"></div>
+          <span id="wasm-label">DuckDB 読み込み中...</span>
         </div>
-        <div class="file-row">
-          <label class="file-label" for="layout-file-input">JSON</label>
-          <input type="file" id="layout-file-input" accept=".json" class="file-input">
+        <button id="theme-toggle" class="theme-toggle" aria-label="ダークモードに切り替え">
+          🌙
+        </button>
+      </div>
+    </header>
+
+    <main>
+      <!-- LEFT: 設定パネル -->
+      <div class="panel-left" role="region" aria-label="設定">
+        <!-- データ読み込み -->
+        <section class="section" id="file-section">
+          <h2 class="section-label">01 / データ読み込み</h2>
+          <div class="load-tabs" role="tablist" aria-label="データ読み込み方法">
+            <button
+              class="load-tab active"
+              role="tab"
+              aria-selected="true"
+              aria-controls="tab-file"
+              id="tab-btn-file"
+              data-tab="file"
+            >
+              ファイルから
+            </button>
+            <button
+              class="load-tab"
+              role="tab"
+              aria-selected="false"
+              aria-controls="tab-saved"
+              id="tab-btn-saved"
+              data-tab="saved"
+            >
+              保存データから
+            </button>
+          </div>
+          <div class="load-tab-panel" id="tab-file" role="tabpanel" aria-labelledby="tab-btn-file">
+            <div class="file-row">
+              <label class="file-label" for="file-input">CSV</label>
+              <input type="file" id="file-input" accept=".csv" class="file-input" />
+            </div>
+            <div class="file-row">
+              <label class="file-label" for="layout-file-input">JSON</label>
+              <input type="file" id="layout-file-input" accept=".json" class="file-input" />
+            </div>
+          </div>
+          <div
+            class="load-tab-panel hidden"
+            id="tab-saved"
+            role="tabpanel"
+            aria-labelledby="tab-btn-saved"
+          >
+            <div id="saved-files-list"></div>
+          </div>
+          <div id="loaded-data-info" class="loaded-data-info hidden" aria-live="polite"></div>
+        </section>
+
+        <!-- クロス集計軸 -->
+        <section class="section hidden" id="cross-config-section">
+          <h2 class="section-label">02 / クロス集計軸（任意）</h2>
+          <div
+            class="cross-col-list"
+            id="cross-col-list"
+            role="group"
+            aria-label="クロス集計軸の選択"
+          ></div>
+        </section>
+
+        <div id="error-msg" class="hidden" role="alert" aria-live="assertive"></div>
+
+        <button class="run-btn hidden" id="run-btn" disabled>▶ 集計を実行</button>
+      </div>
+
+      <!-- RIGHT: 結果パネル -->
+      <div class="panel-right" id="panel-right" role="region" aria-label="集計結果">
+        <div class="empty-state" id="empty-state">
+          <span class="big" aria-hidden="true">⬛</span>
+          <p>CSVを読み込んで集計を実行してください</p>
         </div>
+        <div class="hidden" id="results-area" aria-live="polite"></div>
       </div>
-      <div class="load-tab-panel hidden" id="tab-saved" role="tabpanel" aria-labelledby="tab-btn-saved">
-        <div id="saved-files-list"></div>
-      </div>
-      <div id="loaded-data-info" class="loaded-data-info hidden" aria-live="polite"></div>
-    </section>
+    </main>
 
-    <!-- クロス集計軸 -->
-    <section class="section hidden" id="cross-config-section">
-      <h2 class="section-label">02 / クロス集計軸（任意）</h2>
-      <div class="cross-col-list" id="cross-col-list" role="group" aria-label="クロス集計軸の選択"></div>
-    </section>
-
-    <div id="error-msg" class="hidden" role="alert" aria-live="assertive"></div>
-
-    <button class="run-btn hidden" id="run-btn" disabled>▶ 集計を実行</button>
-  </div>
-
-  <!-- RIGHT: 結果パネル -->
-  <div class="panel-right" id="panel-right" role="region" aria-label="集計結果">
-    <div class="empty-state" id="empty-state">
-      <span class="big" aria-hidden="true">⬛</span>
-      <p>CSVを読み込んで集計を実行してください</p>
-    </div>
-    <div class="hidden" id="results-area" aria-live="polite"></div>
-  </div>
-</main>
-
-<script type="module" src="/src/main.ts"></script>
-</body>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "vite": "^7.3.1"
       },
       "devDependencies": {
+        "oxfmt": "^0.35.0",
+        "oxlint": "^1.50.0",
         "vite-plugin-top-level-await": "^1.6.0",
         "vite-plugin-wasm": "^3.5.0"
       }
@@ -441,6 +443,652 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@oxfmt/binding-android-arm-eabi": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.35.0.tgz",
+      "integrity": "sha512-BaRKlM3DyG81y/xWTsE6gZiv89F/3pHe2BqX2H4JbiB8HNVlWWtplzgATAE5IDSdwChdeuWLDTQzJ92Lglw3ZA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-android-arm64": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.35.0.tgz",
+      "integrity": "sha512-/O+EbuAJYs6nde/anv+aID6uHsGQApyE9JtYBo/79KyU8e6RBN3DMbT0ix97y1SOnCglurmL2iZ+hlohjP2PnQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-arm64": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.35.0.tgz",
+      "integrity": "sha512-pGqRtqlNdn9d4VrmGUWVyQjkw79ryhI6je9y2jfqNUIZCfqceob+R97YYAoG7C5TFyt8ILdLVoN+L2vw/hSFyA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-x64": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.35.0.tgz",
+      "integrity": "sha512-8GmsDcSozTPjrCJeGpp+sCmS9+9V5yRrdEZ1p/sTWxPG5nYeAfSLuS0nuEYjXSO+CtdSbStIW6dxa+4NM58yRw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-freebsd-x64": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.35.0.tgz",
+      "integrity": "sha512-QyfKfTe0ytHpFKHAcHCGQEzN45QSqq1AHJOYYxQMgLM3KY4xu8OsXHpCnINjDsV4XGnQzczJDU9e04Zmd8XqIQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.35.0.tgz",
+      "integrity": "sha512-u+kv3JD6P3J38oOyUaiCqgY5TNESzBRZJ5lyZQ6c2czUW2v5SIN9E/KWWa9vxoc+P8AFXQFUVrdzGy1tK+nbPQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.35.0.tgz",
+      "integrity": "sha512-1NiZroCiV57I7Pf8kOH4XGR366kW5zir3VfSMBU2D0V14GpYjiYmPYFAoJboZvp8ACnZKUReWyMkNKSa5ad58A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-gnu": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.35.0.tgz",
+      "integrity": "sha512-7Q0Xeg7ZnW2nxnZ4R7aF6DEbCFls4skgHZg+I63XitpNvJCbVIU8MFOTZlvZGRsY9+rPgWPQGeUpLHlyx0wvMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-musl": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.35.0.tgz",
+      "integrity": "sha512-5Okqi+uhYFxwKz8hcnUftNNwdm8BCkf6GSCbcz9xJxYMm87k1E4p7PEmAAbhLTk7cjSdDre6TDL0pDzNX+Y22Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.35.0.tgz",
+      "integrity": "sha512-9k66pbZQXM/lBJWys3Xbc5yhl4JexyfqkEf/tvtq8976VIJnLAAL3M127xHA3ifYSqxdVHfVGTg84eiBHCGcNw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.35.0.tgz",
+      "integrity": "sha512-aUcY9ofKPtjO52idT6t0SAQvEF6ctjzUQa1lLp7GDsRpSBvuTrBQGeq0rYKz3gN8dMIQ7mtMdGD9tT4LhR8jAQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-musl": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.35.0.tgz",
+      "integrity": "sha512-C6yhY5Hvc2sGM+mCPek9ZLe5xRUOC/BvhAt2qIWFAeXMn4il04EYIjl3DsWiJr0xDMTJhvMOmD55xTRPlNp39w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-s390x-gnu": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.35.0.tgz",
+      "integrity": "sha512-RG2hlvOMK4OMZpO3mt8MpxLQ0AAezlFqhn5mI/g5YrVbPFyoCv9a34AAvbSJS501ocOxlFIRcKEuw5hFvddf9g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-gnu": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.35.0.tgz",
+      "integrity": "sha512-wzmh90Pwvqj9xOKHJjkQYBpydRkaXG77ZvDz+iFDRRQpnqIEqGm5gmim2s6vnZIkDGsvKCuTdtxm0GFmBjM1+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-musl": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.35.0.tgz",
+      "integrity": "sha512-+HCqYCJPCUy5I+b2cf+gUVaApfgtoQT3HdnSg/l7NIcLHOhKstlYaGyrFZLmUpQt4WkFbpGKZZayG6zjRU0KFA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-openharmony-arm64": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.35.0.tgz",
+      "integrity": "sha512-kFYmWfR9YL78XyO5ws+1dsxNvZoD973qfVMNFOS4e9bcHXGF7DvGC2tY5UDFwyMCeB33t3sDIuGONKggnVNSJA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-arm64-msvc": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.35.0.tgz",
+      "integrity": "sha512-uD/NGdM65eKNCDGyTGdO8e9n3IHX+wwuorBvEYrPJXhDXL9qz6gzddmXH8EN04ejUXUujlq4FsoSeCfbg0Y+Jg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-ia32-msvc": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.35.0.tgz",
+      "integrity": "sha512-oSRD2k8J2uxYDEKR2nAE/YTY9PobOEnhZgCmspHu0+yBQ665yH8lFErQVSTE7fcGJmJp/cC6322/gc8VFuQf7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-x64-msvc": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.35.0.tgz",
+      "integrity": "sha512-WCDJjlS95NboR0ugI2BEwzt1tYvRDorDRM9Lvctls1SLyKYuNRCyrPwp1urUPFBnwgBNn9p2/gnmo7gFMySRoQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm-eabi": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.50.0.tgz",
+      "integrity": "sha512-G7MRGk/6NCe+L8ntonRdZP7IkBfEpiZ/he3buLK6JkLgMHgJShXZ+BeOwADmspXez7U7F7L1Anf4xLSkLHiGTg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm64": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.50.0.tgz",
+      "integrity": "sha512-GeSuMoJWCVpovJi/e3xDSNgjeR8WEZ6MCXL6EtPiCIM2NTzv7LbflARINTXTJy2oFBYyvdf/l2PwHzYo6EdXvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-arm64": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.50.0.tgz",
+      "integrity": "sha512-w3SY5YtxGnxCHPJ8Twl3KmS9oja1gERYk3AMoZ7Hv8P43ZtB6HVfs02TxvarxfL214Tm3uzvc2vn+DhtUNeKnw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-x64": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.50.0.tgz",
+      "integrity": "sha512-hNfogDqy7tvmllXKBSlHo6k5x7dhTUVOHbMSE15CCAcXzmqf5883aPvBYPOq9AE7DpDUQUZ1kVE22YbiGW+tuw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-freebsd-x64": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.50.0.tgz",
+      "integrity": "sha512-ykZevOWEyu0nsxolA911ucxpEv0ahw8jfEeGWOwwb/VPoE4xoexuTOAiPNlWZNJqANlJl7yp8OyzCtXTUAxotw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.50.0.tgz",
+      "integrity": "sha512-hif3iDk7vo5GGJ4OLCCZAf2vjnU9FztGw4L0MbQL0M2iY9LKFtDMMiQAHmkF0PQGQMVbTYtPdXCLKVgdkiqWXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-musleabihf": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.50.0.tgz",
+      "integrity": "sha512-dVp9iSssiGAnTNey2Ruf6xUaQhdnvcFOJyRWd/mu5o2jVbFK15E5fbWGeFRfmuobu5QXuROtFga44+7DOS3PLg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-gnu": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.50.0.tgz",
+      "integrity": "sha512-1cT7yz2HA910CKA9NkH1ZJo50vTtmND2fkoW1oyiSb0j6WvNtJ0Wx2zoySfXWc/c+7HFoqRK5AbEoL41LOn9oA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-musl": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.50.0.tgz",
+      "integrity": "sha512-++B3k/HEPFVlj89cOz8kWfQccMZB/aWL9AhsW7jPIkG++63Mpwb2cE9XOEsd0PATbIan78k2Gky+09uWM1d/gQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-ppc64-gnu": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.50.0.tgz",
+      "integrity": "sha512-Z9b/KpFMkx66w3gVBqjIC1AJBTZAGoI9+U+K5L4QM0CB/G0JSNC1es9b3Y0Vcrlvtdn8A+IQTkYjd/Q0uCSaZw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-gnu": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.50.0.tgz",
+      "integrity": "sha512-jvmuIw8wRSohsQlFNIST5uUwkEtEJmOQYr33bf/K2FrFPXHhM4KqGekI3ShYJemFS/gARVacQFgBzzJKCAyJjg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-musl": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.50.0.tgz",
+      "integrity": "sha512-x+UrN47oYNh90nmAAyql8eQaaRpHbDPu5guasDg10+OpszUQ3/1+1J6zFMmV4xfIEgTcUXG/oI5fxJhF4eWCNA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-s390x-gnu": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.50.0.tgz",
+      "integrity": "sha512-i/JLi2ljLUIVfekMj4ISmdt+Hn11wzYUdRRrkVUYsCWw7zAy5xV7X9iA+KMyM156LTFympa7s3oKBjuCLoTAUQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-gnu": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.50.0.tgz",
+      "integrity": "sha512-/C7brhn6c6UUPccgSPCcpLQXcp+xKIW/3sji/5VZ8/OItL3tQ2U7KalHz887UxxSQeEOmd1kY6lrpuwFnmNqOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-musl": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.50.0.tgz",
+      "integrity": "sha512-oDR1f+bGOYU8LfgtEW8XtotWGB63ghtcxk5Jm6IDTCk++rTA/IRMsjOid2iMd+1bW+nP9Mdsmcdc7VbPD3+iyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-openharmony-arm64": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.50.0.tgz",
+      "integrity": "sha512-4CmRGPp5UpvXyu4jjP9Tey/SrXDQLRvZXm4pb4vdZBxAzbFZkCyh0KyRy4txld/kZKTJlW4TO8N1JKrNEk+mWw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-arm64-msvc": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.50.0.tgz",
+      "integrity": "sha512-Fq0M6vsGcFsSfeuWAACDhd5KJrO85ckbEfe1EGuBj+KPyJz7KeWte2fSFrFGmNKNXyhEMyx4tbgxiWRujBM2KQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-ia32-msvc": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.50.0.tgz",
+      "integrity": "sha512-qTdWR9KwY/vxJGhHVIZG2eBOhidOQvOwzDxnX+jhW/zIVacal1nAhR8GLkiywW8BIFDkQKXo/zOfT+/DY+ns/w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-x64-msvc": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.50.0.tgz",
+      "integrity": "sha512-682t7npLC4G2Ca+iNlI9fhAKTcFPYYXJjwoa88H4q+u5HHHlsnL/gHULapX3iqp+A8FIJbgdylL5KMYo2LaluQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rollup/plugin-virtual": {
@@ -1509,6 +2157,91 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oxfmt": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.35.0.tgz",
+      "integrity": "sha512-QYeXWkP+aLt7utt5SLivNIk09glWx9QE235ODjgcEZ3sd1VMaUBSpLymh6ZRCA76gD2rMP4bXanUz/fx+nLM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinypool": "2.1.0"
+      },
+      "bin": {
+        "oxfmt": "bin/oxfmt"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxfmt/binding-android-arm-eabi": "0.35.0",
+        "@oxfmt/binding-android-arm64": "0.35.0",
+        "@oxfmt/binding-darwin-arm64": "0.35.0",
+        "@oxfmt/binding-darwin-x64": "0.35.0",
+        "@oxfmt/binding-freebsd-x64": "0.35.0",
+        "@oxfmt/binding-linux-arm-gnueabihf": "0.35.0",
+        "@oxfmt/binding-linux-arm-musleabihf": "0.35.0",
+        "@oxfmt/binding-linux-arm64-gnu": "0.35.0",
+        "@oxfmt/binding-linux-arm64-musl": "0.35.0",
+        "@oxfmt/binding-linux-ppc64-gnu": "0.35.0",
+        "@oxfmt/binding-linux-riscv64-gnu": "0.35.0",
+        "@oxfmt/binding-linux-riscv64-musl": "0.35.0",
+        "@oxfmt/binding-linux-s390x-gnu": "0.35.0",
+        "@oxfmt/binding-linux-x64-gnu": "0.35.0",
+        "@oxfmt/binding-linux-x64-musl": "0.35.0",
+        "@oxfmt/binding-openharmony-arm64": "0.35.0",
+        "@oxfmt/binding-win32-arm64-msvc": "0.35.0",
+        "@oxfmt/binding-win32-ia32-msvc": "0.35.0",
+        "@oxfmt/binding-win32-x64-msvc": "0.35.0"
+      }
+    },
+    "node_modules/oxlint": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.50.0.tgz",
+      "integrity": "sha512-iSJ4IZEICBma8cZX7kxIIz9PzsYLF2FaLAYN6RKu7VwRVKdu7RIgpP99bTZaGl//Yao7fsaGZLSEo5xBrI5ReQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "oxlint": "bin/oxlint"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxlint/binding-android-arm-eabi": "1.50.0",
+        "@oxlint/binding-android-arm64": "1.50.0",
+        "@oxlint/binding-darwin-arm64": "1.50.0",
+        "@oxlint/binding-darwin-x64": "1.50.0",
+        "@oxlint/binding-freebsd-x64": "1.50.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.50.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.50.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.50.0",
+        "@oxlint/binding-linux-arm64-musl": "1.50.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.50.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.50.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.50.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.50.0",
+        "@oxlint/binding-linux-x64-gnu": "1.50.0",
+        "@oxlint/binding-linux-x64-musl": "1.50.0",
+        "@oxlint/binding-openharmony-arm64": "1.50.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.50.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.50.0",
+        "@oxlint/binding-win32-x64-msvc": "1.50.0"
+      },
+      "peerDependencies": {
+        "oxlint-tsgolint": ">=0.14.1"
+      },
+      "peerDependenciesMeta": {
+        "oxlint-tsgolint": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1745,6 +2478,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-2.1.0.tgz",
+      "integrity": "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,12 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint": "oxlint src/ scripts/ vite.config.ts",
+    "lint:fix": "oxlint --fix src/ scripts/ vite.config.ts",
+    "fmt": "oxfmt src/ scripts/ vite.config.ts index.html",
+    "fmt:check": "oxfmt --check src/ scripts/ vite.config.ts index.html",
+    "check": "npm run fmt:check && npm run lint && tsc --noEmit"
   },
   "dependencies": {
     "@duckdb/duckdb-wasm": "^1.33.1-dev18.0",
@@ -14,6 +19,8 @@
     "vite": "^7.3.1"
   },
   "devDependencies": {
+    "oxfmt": "^0.35.0",
+    "oxlint": "^1.50.0",
     "vite-plugin-top-level-await": "^1.6.0",
     "vite-plugin-wasm": "^3.5.0"
   }

--- a/src/components/CrossConfig.ts
+++ b/src/components/CrossConfig.ts
@@ -9,7 +9,7 @@ let state: CrossConfigState = { questions: [], crossSelected: {} };
 
 export function initCrossConfig(
   questions: QuestionDef[],
-  questionLabels: Record<string, string>
+  questionLabels: Record<string, string>,
 ): void {
   state = { questions, crossSelected: {} };
   questions.forEach((q) => (state.crossSelected[questionKey(q)] = false));
@@ -32,9 +32,7 @@ export function initCrossConfig(
 
     const qLabel = questionLabels[key];
     const typeTag = q.type === "MA" ? " [MA]" : "";
-    const displayText = qLabel
-      ? `${key}: ${qLabel}${typeTag}`
-      : `${key}${typeTag}`;
+    const displayText = qLabel ? `${key}: ${qLabel}${typeTag}` : `${key}${typeTag}`;
 
     label.appendChild(cb);
     label.appendChild(document.createTextNode(" " + displayText));

--- a/src/components/FileInput.ts
+++ b/src/components/FileInput.ts
@@ -2,7 +2,7 @@ import { parseLayout, buildLayoutMeta, type Layout, type LayoutMeta } from "../l
 
 export function initCsvInput(
   onLoad: (csvText: string, fileName: string) => void,
-  onError: (msg: string) => void
+  onError: (msg: string) => void,
 ): void {
   const fileInput = document.getElementById("file-input") as HTMLInputElement;
 
@@ -23,7 +23,7 @@ export function initCsvInput(
 
 export function initLayoutInput(
   onLoad: (layout: Layout, meta: LayoutMeta, fileName: string, rawText: string) => void,
-  onError: (msg: string) => void
+  onError: (msg: string) => void,
 ): void {
   const fileInput = document.getElementById("layout-file-input") as HTMLInputElement;
 

--- a/src/components/ResultTable.ts
+++ b/src/components/ResultTable.ts
@@ -6,10 +6,7 @@ import { downloadAllCSV } from "../lib/download";
 import { isAIAvailable, generateComment } from "../lib/aiComment";
 
 function escHtml(str: string): string {
-  return String(str)
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
+  return String(str).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
 /** 設問ラベルを解決する。なければ列名をそのまま返す */
@@ -25,7 +22,7 @@ function resolveValueLabel(
   type: "SA" | "MA",
   col: string,
   rowLabel: string,
-  meta?: LayoutMeta
+  meta?: LayoutMeta,
 ): string {
   // 無回答マーカー
   if (rowLabel === NA_VALUE) return "無回答";
@@ -40,11 +37,7 @@ function resolveValueLabel(
 
 /** クロス軸ヘッダーのラベルを解決する。
  *  crossCols があれば SA クロス軸の値ラベルも解決する */
-function resolveSubLabel(
-  subLabel: string,
-  meta?: LayoutMeta,
-  crossCols?: QuestionDef[]
-): string {
+function resolveSubLabel(subLabel: string, meta?: LayoutMeta, crossCols?: QuestionDef[]): string {
   if (subLabel === NA_VALUE) return "無回答";
   if (!meta) return subLabel;
   // MAカラム名の場合: valueLabels[colName]["1"] にラベルがある
@@ -67,7 +60,7 @@ export function renderResults(
   weightCol: string,
   _rawN: number,
   layoutMeta?: LayoutMeta,
-  crossCols?: QuestionDef[]
+  crossCols?: QuestionDef[],
 ): void {
   document.getElementById("empty-state")!.classList.add("hidden");
   const area = document.getElementById("results-area")!;
@@ -101,9 +94,7 @@ export function renderResults(
   grid.className = hasCross ? "tables-grid cross-mode" : "tables-grid";
   area.appendChild(grid);
 
-  const allGtCells = results.flatMap((r) =>
-    r.cells.filter((c) => c.sub === "GT")
-  );
+  const allGtCells = results.flatMap((r) => r.cells.filter((c) => c.sub === "GT"));
   const maxPct = Math.max(...allGtCells.map((c) => c.pct), 0);
 
   results.forEach((res) => {
@@ -164,9 +155,7 @@ async function showAIBubble(
   `;
   document.body.appendChild(bubble);
 
-  bubble
-    .querySelector(".ai-bubble-close")!
-    .addEventListener("click", () => bubble.remove());
+  bubble.querySelector(".ai-bubble-close")!.addEventListener("click", () => bubble.remove());
 
   const comment = await generateComment(results, weightCol, layoutMeta);
   if (comment) {
@@ -183,7 +172,7 @@ function buildGtTable(
   pv: ReturnType<typeof pivot>,
   weightCol: string,
   maxPct: number,
-  layoutMeta?: LayoutMeta
+  layoutMeta?: LayoutMeta,
 ): HTMLTableElement {
   const { mains, lookup } = pv;
 
@@ -208,9 +197,7 @@ function buildGtTable(
         <tr>
           <td>${escHtml(resolveValueLabel(res.type, res.question, main, layoutMeta))}</td>
           <td class="num">${
-            res.type === "SA" && !weightCol
-              ? cell.count.toLocaleString()
-              : cell.count.toFixed(1)
+            res.type === "SA" && !weightCol ? cell.count.toLocaleString() : cell.count.toFixed(1)
           }</td>
           <td class="pct">${cell.pct.toFixed(1)}%</td>
           <td class="bar-cell" aria-hidden="true">
@@ -230,7 +217,7 @@ function buildCrossTable(
   pv: ReturnType<typeof pivot>,
   weightCol: string,
   layoutMeta?: LayoutMeta,
-  crossCols?: QuestionDef[]
+  crossCols?: QuestionDef[],
 ): HTMLTableElement {
   const { mains, subs, lookup } = pv;
   const gtSub = subs.find((s) => s.label === "GT")!;
@@ -308,9 +295,7 @@ function buildCrossTable(
     const tdCount = document.createElement("td");
     tdCount.className = "num";
     tdCount.textContent =
-      res.type === "SA" && !weightCol
-        ? gtCell.count.toLocaleString()
-        : gtCell.count.toFixed(1);
+      res.type === "SA" && !weightCol ? gtCell.count.toLocaleString() : gtCell.count.toFixed(1);
     tr.appendChild(tdCount);
 
     const tdPct = document.createElement("td");

--- a/src/lib/aggregate.ts
+++ b/src/lib/aggregate.ts
@@ -6,9 +6,9 @@ import { Aggregator, fetchCrossHeaders } from "./aggregator";
 // --- 集計結果の型定義 ---
 
 export interface Cell {
-  main: string;   // 選択肢ラベル（集計対象の設問値）
-  sub: string;    // "GT" or クロス集計軸の値 ("男", "女", ...) or MAカラム名
-  n: number;      // その sub の母数
+  main: string; // 選択肢ラベル（集計対象の設問値）
+  sub: string; // "GT" or クロス集計軸の値 ("男", "女", ...) or MAカラム名
+  n: number; // その sub の母数
   count: number;
   pct: number;
 }
@@ -25,13 +25,13 @@ export type QuestionDef = SAQuestion | MAQuestion;
 
 interface SAQuestion {
   type: "SA";
-  column: string;       // カラム名 "q1"
+  column: string; // カラム名 "q1"
 }
 
 interface MAQuestion {
   type: "MA";
-  prefix: string;       // グループプレフィックス "Q3"
-  columns: string[];    // ["Q3_1","Q3_2","Q3_3"]
+  prefix: string; // グループプレフィックス "Q3"
+  columns: string[]; // ["Q3_1","Q3_2","Q3_3"]
 }
 
 export function questionKey(q: QuestionDef): string {
@@ -45,10 +45,7 @@ export interface Query {
 }
 
 /** 集計のエントリポイント。db上のsurveyビューに対して全設問を並列集計する */
-export async function aggregate(
-  db: duckdb.AsyncDuckDB,
-  payload: Query
-): Promise<AggResult[]> {
+export async function aggregate(db: duckdb.AsyncDuckDB, payload: Query): Promise<AggResult[]> {
   const weightCol = payload.weight_col;
   const crossCols = payload.cross_cols ?? [];
 
@@ -79,6 +76,6 @@ export async function aggregate(
       } finally {
         await conn.close();
       }
-    })
+    }),
   );
 }

--- a/src/lib/aggregator.ts
+++ b/src/lib/aggregator.ts
@@ -11,9 +11,7 @@ function esc(name: string): string {
 }
 
 function weightExpr(weightCol: string): string {
-  return weightCol
-    ? `SUM(TRY_CAST("${esc(weightCol)}" AS DOUBLE))`
-    : `COUNT(*)::DOUBLE`;
+  return weightCol ? `SUM(TRY_CAST("${esc(weightCol)}" AS DOUBLE))` : `COUNT(*)::DOUBLE`;
 }
 
 function maWeightedCountExpr(maCol: string, weightCol: string): string {
@@ -53,8 +51,15 @@ export class Aggregator {
 
   async aggregateSA(col: string): Promise<AggResult> {
     // クロス軸を SA / MA に分離（CTE統合は SA×SA のみ）
-    const saCross = this.crossCols.filter((q) => q.type === "SA") as Array<{ type: "SA"; column: string }>;
-    const maCross = this.crossCols.filter((q) => q.type === "MA") as Array<{ type: "MA"; prefix: string; columns: string[] }>;
+    const saCross = this.crossCols.filter((q) => q.type === "SA") as Array<{
+      type: "SA";
+      column: string;
+    }>;
+    const maCross = this.crossCols.filter((q) => q.type === "MA") as Array<{
+      type: "MA";
+      prefix: string;
+      columns: string[];
+    }>;
 
     // CTE: GT + 全SA×SAクロスを1クエリで取得
     const GT_SENTINEL = "__GT__";
@@ -92,7 +97,10 @@ export class Aggregator {
         gtRows.push({ mv, cnt });
       } else {
         let bucket = crossBuckets.get(sv);
-        if (!bucket) { bucket = new Map(); crossBuckets.set(sv, bucket); }
+        if (!bucket) {
+          bucket = new Map();
+          crossBuckets.set(sv, bucket);
+        }
         bucket.set(mv, cnt);
       }
     }
@@ -100,9 +108,7 @@ export class Aggregator {
     // GT セル
     const questionN = gtRows.reduce((sum, r) => sum + r.cnt, 0);
     const mainValues = gtRows.map((r) => r.mv);
-    const cells: Cell[] = gtRows.map((r) =>
-      mkCell(r.mv, "GT", questionN, r.cnt)
-    );
+    const cells: Cell[] = gtRows.map((r) => mkCell(r.mv, "GT", questionN, r.cnt));
 
     // SA×SA クロスセル
     for (const crossQ of saCross) {
@@ -121,7 +127,7 @@ export class Aggregator {
     // SA×MA クロスセル（構造が異なるため個別クエリ維持）
     for (const crossQ of maCross) {
       const cached = this.crossHeaderCache.get(crossQ.prefix)!;
-      cells.push(...await this.buildCrossCellsMA(col, mainValues, crossQ.columns, cached));
+      cells.push(...(await this.buildCrossCellsMA(col, mainValues, crossQ.columns, cached)));
     }
 
     return { question: col, type: "SA", cells };
@@ -154,7 +160,7 @@ export class Aggregator {
 
     const questionN = Number(row.question_n ?? 0);
     const cells: Cell[] = cols.map((col, i) =>
-      mkCell(col, "GT", questionN, Number(row[`c${i}`] ?? 0))
+      mkCell(col, "GT", questionN, Number(row[`c${i}`] ?? 0)),
     );
 
     // 無回答行
@@ -165,9 +171,9 @@ export class Aggregator {
       for (const crossQ of this.crossCols) {
         const cached = this.crossHeaderCache.get(questionKey(crossQ))!;
         if (crossQ.type === "SA") {
-          cells.push(...await this.buildMACrossCellsSA(cols, crossQ.column, cached));
+          cells.push(...(await this.buildMACrossCellsSA(cols, crossQ.column, cached)));
         } else {
-          cells.push(...await this.buildMACrossCellsMA(cols, crossQ.columns, cached));
+          cells.push(...(await this.buildMACrossCellsMA(cols, crossQ.columns, cached)));
         }
       }
     }
@@ -180,12 +186,12 @@ export class Aggregator {
     mainCol: string,
     mainValues: string[],
     maCols: string[],
-    cached: { headers: Array<{ label: string; n: number }>; crossValues: string[] }
+    cached: { headers: Array<{ label: string; n: number }>; crossValues: string[] },
   ): Promise<Cell[]> {
     const { headers } = cached;
 
-    const selectClauses = maCols.map((maCol, i) =>
-      `${maWeightedCountExpr(maCol, this.weightCol)} AS c${i}`
+    const selectClauses = maCols.map(
+      (maCol, i) => `${maWeightedCountExpr(maCol, this.weightCol)} AS c${i}`,
     );
 
     const sql = `
@@ -202,7 +208,9 @@ export class Aggregator {
     const rowMap = new Map<string, Record<string, number>>();
     for (const r of result.toArray()) {
       const counts: Record<string, number> = {};
-      maCols.forEach((_, i) => { counts[`c${i}`] = Number(r[`c${i}`] ?? 0); });
+      maCols.forEach((_, i) => {
+        counts[`c${i}`] = Number(r[`c${i}`] ?? 0);
+      });
       rowMap.set(String(r.mv), counts);
     }
 
@@ -221,12 +229,12 @@ export class Aggregator {
   private async buildMACrossCellsSA(
     maCols: string[],
     crossCol: string,
-    cached: { headers: Array<{ label: string; n: number }>; crossValues: string[] }
+    cached: { headers: Array<{ label: string; n: number }>; crossValues: string[] },
   ): Promise<Cell[]> {
     const { headers, crossValues } = cached;
 
-    const selectClauses = maCols.map((col, i) =>
-      `${maWeightedCountExpr(col, this.weightCol)} AS c${i}`
+    const selectClauses = maCols.map(
+      (col, i) => `${maWeightedCountExpr(col, this.weightCol)} AS c${i}`,
     );
 
     // 無回答カウント: 表示されたが何も選択していない
@@ -275,7 +283,7 @@ export class Aggregator {
   private async buildMACrossCellsMA(
     rowMaCols: string[],
     crossMaCols: string[],
-    cached: { headers: Array<{ label: string; n: number }>; crossValues: string[] }
+    cached: { headers: Array<{ label: string; n: number }>; crossValues: string[] },
   ): Promise<Cell[]> {
     const { headers } = cached;
 
@@ -307,7 +315,9 @@ export class Aggregator {
     const cells: Cell[] = [];
     for (let r = 0; r < rowMaCols.length; r++) {
       for (let c = 0; c < crossMaCols.length; c++) {
-        cells.push(mkCell(rowMaCols[r], crossMaCols[c], headers[c].n, Number(row[`r${r}c${c}`] ?? 0)));
+        cells.push(
+          mkCell(rowMaCols[r], crossMaCols[c], headers[c].n, Number(row[`r${r}c${c}`] ?? 0)),
+        );
       }
     }
 
@@ -325,7 +335,7 @@ export class Aggregator {
 export async function fetchCrossHeaders(
   conn: duckdb.AsyncDuckDBConnection,
   crossCols: QuestionDef[],
-  weightCol: string
+  weightCol: string,
 ): Promise<CrossHeaderCache> {
   const cache: CrossHeaderCache = new Map();
 
@@ -345,13 +355,11 @@ export async function fetchCrossHeaders(
           "${esc(col)}" ASC
       `;
       const result = await conn.query(sql);
-      const headers = result
-        .toArray()
-        .map((r) => ({ label: String(r.cv), n: Number(r.n) }));
+      const headers = result.toArray().map((r) => ({ label: String(r.cv), n: Number(r.n) }));
       cache.set(crossQ.column, { headers, crossValues: headers.map((h) => h.label) });
     } else {
-      const selectClauses = crossQ.columns.map((col, i) =>
-        `${maWeightedCountExpr(col, weightCol)} AS c${i}`
+      const selectClauses = crossQ.columns.map(
+        (col, i) => `${maWeightedCountExpr(col, weightCol)} AS c${i}`,
       );
       const sql = `SELECT ${selectClauses.join(", ")} FROM survey`;
       const result = await conn.query(sql);

--- a/src/lib/aiComment.ts
+++ b/src/lib/aiComment.ts
@@ -51,12 +51,7 @@ function resolveQLabel(col: string, meta?: LayoutMeta): string {
   return meta?.questionLabels[col] ?? col;
 }
 
-function resolveVLabel(
-  type: "SA" | "MA",
-  col: string,
-  code: string,
-  meta?: LayoutMeta,
-): string {
+function resolveVLabel(type: "SA" | "MA", col: string, code: string, meta?: LayoutMeta): string {
   if (!meta) return code;
   if (type === "SA") return meta.valueLabels[col]?.[code] ?? code;
   return meta.valueLabels[code]?.["1"] ?? code;
@@ -92,7 +87,9 @@ function summarizeResults(
   }
 
   lines.push("");
-  lines.push("上記の集計結果の注目すべき傾向を2〜3文で短く述べてください。箇条書き・見出し・提案・注意点は不要です。");
+  lines.push(
+    "上記の集計結果の注目すべき傾向を2〜3文で短く述べてください。箇条書き・見出し・提案・注意点は不要です。",
+  );
   return lines.join("\n");
 }
 
@@ -105,12 +102,7 @@ export function buildPromptPayload(
     const text = summarizeResults(results, weightCol, layoutMeta, topN);
     if (text.length <= MAX_PAYLOAD_CHARS) return text;
   }
-  return summarizeResults(
-    results.slice(0, 20),
-    weightCol,
-    layoutMeta,
-    2,
-  );
+  return summarizeResults(results.slice(0, 20), weightCol, layoutMeta, 2);
 }
 
 // --- Comment Generation ---

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -18,7 +18,7 @@ function resolveMainLabel(main: string): string {
 export function downloadAllCSV(
   results: AggResult[],
   _weightCol: string,
-  layoutMeta?: LayoutMeta
+  layoutMeta?: LayoutMeta,
 ): void {
   const hasCross = results.some((r) => {
     const { subs } = pivot(r.cells);
@@ -117,11 +117,7 @@ function exportCSV(rows: string[][], filename: string): void {
   const bom = "\uFEFF";
   const csv =
     bom +
-    rows
-      .map((r) =>
-        r.map((v) => `"${String(v).replace(/"/g, '""')}"`).join(",")
-      )
-      .join("\r\n");
+    rows.map((r) => r.map((v) => `"${String(v).replace(/"/g, '""')}"`).join(",")).join("\r\n");
   const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");

--- a/src/lib/duckdbBridge.ts
+++ b/src/lib/duckdbBridge.ts
@@ -66,7 +66,7 @@ export async function loadCSV(csvText: string): Promise<{ headers: string[]; row
   const c = await getConnection();
   await c.query(
     `CREATE OR REPLACE VIEW survey AS
-     SELECT * FROM read_csv('survey.csv', all_varchar=true)`
+     SELECT * FROM read_csv('survey.csv', all_varchar=true)`,
   );
 
   const descResult = await c.query(`DESCRIBE survey`);

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -56,7 +56,10 @@ export function parseLayout(jsonText: string): Layout {
 }
 
 /** headers + colTypes から QuestionDef[] を組み立てる */
-export function buildQuestionDefs(headers: string[], colTypes: Record<string, string>): QuestionDef[] {
+export function buildQuestionDefs(
+  headers: string[],
+  colTypes: Record<string, string>,
+): QuestionDef[] {
   const questions: QuestionDef[] = [];
   const maAccum: Record<string, string[]> = {};
   for (const col of headers) {

--- a/src/lib/opfs.ts
+++ b/src/lib/opfs.ts
@@ -14,7 +14,7 @@ export async function saveData(
   csvName: string,
   csvText: string,
   layoutName: string,
-  layoutJson: string
+  layoutJson: string,
 ): Promise<SavedEntry> {
   const ts = Date.now();
   const folderId = String(ts);
@@ -59,7 +59,7 @@ export async function listSaved(): Promise<SavedEntry[]> {
 }
 
 export async function loadSaved(
-  folderId: string
+  folderId: string,
 ): Promise<{ csvText: string; csvName: string; layoutJson: string; layoutName: string }> {
   const dir = await getTemottoDir();
   const folder = await dir.getDirectoryHandle(folderId);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,17 +1,20 @@
 import { initCsvInput, initLayoutInput } from "./components/FileInput";
 import { initCrossConfig, getCrossColsSelected } from "./components/CrossConfig";
 import { renderResults } from "./components/ResultTable";
+import { initDuckDB, loadCSV, runDuckDBAggregation } from "./lib/duckdbBridge";
 import {
-  initDuckDB,
-  loadCSV,
-  runDuckDBAggregation,
-} from "./lib/duckdbBridge";
-import { parseLayout, buildLayoutMeta, buildQuestionDefs, type Layout, type LayoutMeta } from "./lib/layout";
+  parseLayout,
+  buildLayoutMeta,
+  buildQuestionDefs,
+  type Layout,
+  type LayoutMeta,
+} from "./lib/layout";
 import { saveData, loadSaved } from "./lib/opfs";
 import { initSavedFiles, refreshList } from "./components/SavedFiles";
 
 // 現在読み込み済みの CSV / Layout データ
-let currentCsv: { text: string; fileName: string; headers: string[]; rowCount: number } | null = null;
+let currentCsv: { text: string; fileName: string; headers: string[]; rowCount: number } | null =
+  null;
 let currentLayout: { json: string; fileName: string; meta: LayoutMeta } | null = null;
 
 // テーマ切り替え
@@ -67,10 +70,14 @@ function updateLoadedInfo(): void {
   }
   const lines: string[] = [];
   if (currentCsv) {
-    lines.push(`CSV: ${currentCsv.fileName}  —  ${currentCsv.rowCount.toLocaleString()} 行 / ${currentCsv.headers.length} 列`);
+    lines.push(
+      `CSV: ${currentCsv.fileName}  —  ${currentCsv.rowCount.toLocaleString()} 行 / ${currentCsv.headers.length} 列`,
+    );
   }
   if (currentLayout) {
-    lines.push(`JSON: ${currentLayout.fileName}  —  ${Object.keys(currentLayout.meta.colTypes).length} 列定義`);
+    lines.push(
+      `JSON: ${currentLayout.fileName}  —  ${Object.keys(currentLayout.meta.colTypes).length} 列定義`,
+    );
   }
   el.textContent = lines.join("\n");
   el.classList.remove("hidden");
@@ -80,7 +87,12 @@ function updateLoadedInfo(): void {
 async function trySaveToOPFS(): Promise<void> {
   if (!currentCsv || !currentLayout) return;
   try {
-    await saveData(currentCsv.fileName, currentCsv.text, currentLayout.fileName, currentLayout.json);
+    await saveData(
+      currentCsv.fileName,
+      currentCsv.text,
+      currentLayout.fileName,
+      currentLayout.json,
+    );
     refreshList();
   } catch (e) {
     console.warn("OPFS save failed:", e);
@@ -106,7 +118,7 @@ function onLayoutLoaded(
   _layout: Layout,
   meta: LayoutMeta,
   fileName: string,
-  rawText: string
+  rawText: string,
 ): void {
   currentLayout = { json: rawText, fileName, meta };
 
@@ -123,7 +135,12 @@ async function loadFromSaved(folderId: string): Promise<void> {
     const meta = buildLayoutMeta(layout);
     const result = await loadCSV(csvText);
 
-    currentCsv = { text: csvText, fileName: csvName, headers: result.headers, rowCount: result.rowCount };
+    currentCsv = {
+      text: csvText,
+      fileName: csvName,
+      headers: result.headers,
+      rowCount: result.rowCount,
+    };
     currentLayout = { json: layoutJson, fileName: layoutName, meta };
 
     updateLoadedInfo();

--- a/src/style.css
+++ b/src/style.css
@@ -61,7 +61,7 @@
   /* Shadows */
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
   --shadow-md: 0 2px 8px rgba(0, 0, 0, 0.08);
-  --shadow-lg: 0 4px 24px rgba(0, 0, 0, 0.10);
+  --shadow-lg: 0 4px 24px rgba(0, 0, 0, 0.1);
 
   /* Table */
   --row-border: var(--color-gray-200);
@@ -142,7 +142,11 @@
 }
 
 /* === Reset === */
-* { box-sizing: border-box; margin: 0; padding: 0; }
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
 
 body {
   background: var(--bg);
@@ -170,7 +174,9 @@ body {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  *, *::before, *::after {
+  *,
+  *::before,
+  *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
@@ -225,7 +231,9 @@ header span {
   cursor: pointer;
   font-size: var(--text-md);
   line-height: 1;
-  transition: background 0.15s, border-color 0.15s;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
   color: var(--text);
 }
 
@@ -241,13 +249,25 @@ header span {
   background: var(--muted);
   transition: background 0.3s;
 }
-.status-dot.loading { background: var(--color-warning-700); animation: pulse 1s infinite; }
-.status-dot.ready { background: var(--color-success-700); }
-.status-dot.error { background: var(--danger); }
+.status-dot.loading {
+  background: var(--color-warning-700);
+  animation: pulse 1s infinite;
+}
+.status-dot.ready {
+  background: var(--color-success-700);
+}
+.status-dot.error {
+  background: var(--danger);
+}
 
 @keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.3; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
 }
 
 /* === Layout === */
@@ -311,11 +331,19 @@ main {
   font-weight: 500;
   padding: var(--space-2) 0;
   cursor: pointer;
-  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  transition:
+    background 0.15s,
+    color 0.15s,
+    border-color 0.15s;
 }
 
-.load-tab:first-child { border-radius: var(--radius-sm) 0 0 var(--radius-sm); }
-.load-tab:last-child { border-radius: 0 var(--radius-sm) var(--radius-sm) 0; border-left: none; }
+.load-tab:first-child {
+  border-radius: var(--radius-sm) 0 0 var(--radius-sm);
+}
+.load-tab:last-child {
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  border-left: none;
+}
 
 .load-tab.active {
   background: var(--accent);
@@ -378,7 +406,9 @@ main {
   transition: border-color 0.15s;
 }
 
-.col-item:hover { border-color: var(--border-strong); }
+.col-item:hover {
+  border-color: var(--border-strong);
+}
 
 .col-pick {
   width: 18px;
@@ -416,7 +446,9 @@ select.col-type {
   outline: none;
 }
 
-select.col-type:focus { border-color: var(--accent); }
+select.col-type:focus {
+  border-color: var(--accent);
+}
 
 /* Weight Column Select */
 .weight-select-wrap {
@@ -443,7 +475,9 @@ select.weight-col-select {
   outline: none;
 }
 
-select.weight-col-select:focus { border-color: var(--accent); }
+select.weight-col-select:focus {
+  border-color: var(--accent);
+}
 
 /* Run Button (DADS Primary, Medium) */
 .run-btn {
@@ -464,9 +498,17 @@ select.weight-col-select:focus { border-color: var(--accent); }
   flex-shrink: 0;
 }
 
-.run-btn:hover { background: var(--accent-hover); }
-.run-btn:active { background: var(--color-primary-900); }
-.run-btn:disabled { background: var(--color-gray-300); color: var(--color-gray-600); cursor: not-allowed; }
+.run-btn:hover {
+  background: var(--accent-hover);
+}
+.run-btn:active {
+  background: var(--color-primary-900);
+}
+.run-btn:disabled {
+  background: var(--color-gray-300);
+  color: var(--color-gray-600);
+  cursor: not-allowed;
+}
 
 /* === Right Panel === */
 .panel-right {
@@ -485,8 +527,12 @@ select.weight-col-select:focus { border-color: var(--accent); }
   gap: var(--space-3);
 }
 
-.empty-state .big { font-size: 2.5rem; }
-.empty-state p { font-size: var(--text-md); }
+.empty-state .big {
+  font-size: 2.5rem;
+}
+.empty-state p {
+  font-size: var(--text-md);
+}
 
 /* Results Header */
 .results-header {
@@ -521,13 +567,25 @@ select.weight-col-select:focus { border-color: var(--accent); }
   font-weight: 500;
   padding: var(--space-2) var(--space-4);
   cursor: pointer;
-  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  transition:
+    background 0.15s,
+    color 0.15s,
+    border-color 0.15s;
   min-height: 36px;
 }
 
-.weight-toggle button:first-child { border-radius: var(--radius-sm) 0 0 var(--radius-sm); }
-.weight-toggle button:last-child { border-radius: 0 var(--radius-sm) var(--radius-sm) 0; border-left: none; }
-.weight-toggle button.active { background: var(--accent); color: var(--accent-contrast); border-color: var(--accent); }
+.weight-toggle button:first-child {
+  border-radius: var(--radius-sm) 0 0 var(--radius-sm);
+}
+.weight-toggle button:last-child {
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  border-left: none;
+}
+.weight-toggle button.active {
+  background: var(--accent);
+  color: var(--accent-contrast);
+  border-color: var(--accent);
+}
 
 /* Tables Grid */
 .tables-grid {
@@ -602,7 +660,9 @@ table.gt th {
   background: var(--surface2);
 }
 
-table.gt th.right { text-align: right; }
+table.gt th.right {
+  text-align: right;
+}
 
 table.gt td {
   padding: var(--space-3) var(--space-4);
@@ -610,7 +670,9 @@ table.gt td {
   line-height: var(--leading-tight);
 }
 
-table.gt tr:last-child td { border-bottom: none; }
+table.gt tr:last-child td {
+  border-bottom: none;
+}
 
 table.gt td.num {
   text-align: right;
@@ -638,7 +700,9 @@ table.gt td.pct {
   opacity: 0.8;
 }
 
-table.gt tr:hover td { background: var(--row-hover); }
+table.gt tr:hover td {
+  background: var(--row-hover);
+}
 
 /* CSV Export Button (DADS Secondary) */
 .csv-export-btn {
@@ -680,7 +744,9 @@ table.gt tr:hover td { background: var(--row-hover); }
   text-align: center;
 }
 
-.download-btn:hover { background: var(--accent-bg); }
+.download-btn:hover {
+  background: var(--accent-bg);
+}
 
 /* === Cross Config Section === */
 #cross-config-section {
@@ -712,7 +778,9 @@ table.gt tr:hover td { background: var(--row-hover); }
   min-height: 36px;
 }
 
-.cross-col-item:hover { background: var(--surface2); }
+.cross-col-item:hover {
+  background: var(--surface2);
+}
 
 /* Cross Table */
 .tables-grid.cross-mode {
@@ -800,7 +868,9 @@ table.gt td.cross-pct {
   transition: border-color 0.15s;
 }
 
-.saved-item:hover { border-color: var(--border-strong); }
+.saved-item:hover {
+  border-color: var(--border-strong);
+}
 
 .saved-item-load {
   flex: 1;
@@ -818,7 +888,9 @@ table.gt td.cross-pct {
   min-height: 44px;
 }
 
-.saved-item-load:hover { color: var(--accent); }
+.saved-item-load:hover {
+  color: var(--accent);
+}
 
 .saved-item-del {
   background: none;
@@ -837,10 +909,14 @@ table.gt td.cross-pct {
   justify-content: center;
 }
 
-.saved-item-del:hover { color: var(--danger); }
+.saved-item-del:hover {
+  color: var(--danger);
+}
 
 /* === Utilities === */
-.hidden { display: none !important; }
+.hidden {
+  display: none !important;
+}
 
 .visually-hidden {
   position: absolute;
@@ -912,7 +988,9 @@ table.gt td.cross-pct {
   justify-content: center;
 }
 
-.ai-bubble-close:hover { color: var(--text); }
+.ai-bubble-close:hover {
+  color: var(--text);
+}
 
 .ai-bubble-header {
   font-size: var(--text-base);
@@ -934,12 +1012,27 @@ table.gt td.cross-pct {
 }
 
 @keyframes bubbleIn {
-  from { opacity: 0; transform: translateY(12px); }
-  to   { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 /* === Scrollbar (Webkit) === */
-.panel-left ::-webkit-scrollbar { width: 6px; }
-.panel-left ::-webkit-scrollbar-track { background: transparent; }
-.panel-left ::-webkit-scrollbar-thumb { background: var(--border); border-radius: var(--radius-sm); }
-.panel-left ::-webkit-scrollbar-thumb:hover { background: var(--border-strong); }
+.panel-left ::-webkit-scrollbar {
+  width: 6px;
+}
+.panel-left ::-webkit-scrollbar-track {
+  background: transparent;
+}
+.panel-left ::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: var(--radius-sm);
+}
+.panel-left ::-webkit-scrollbar-thumb:hover {
+  background: var(--border-strong);
+}


### PR DESCRIPTION
## Summary
- Rustベースの高速リンター `oxlint` とフォーマッター `oxfmt` を導入
- typescript / import / unicorn プラグインを有効化し、既存コードスタイルに合わせた設定を適用
- `npm run lint`, `npm run fmt`, `npm run check` 等のスクリプトを追加

## 追加されたスクリプト
| コマンド | 用途 |
|---------|------|
| `npm run lint` | リントチェック |
| `npm run lint:fix` | リント自動修正 |
| `npm run fmt` | フォーマット適用 |
| `npm run fmt:check` | フォーマットチェック（CI向け） |
| `npm run check` | fmt:check + lint + tsc --noEmit |

## Test plan
- [x] `npm run fmt:check` — フォーマットチェック通過
- [x] `npm run lint` — 警告6件（意図的なconsole/any使用）、エラー0件
- [x] `npm run check` — 全チェック通過
- [x] `npm run build` — ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)