### PR TITLE
refactor: OPFS の as any を .entries() に置換

### DIFF
--- a/src/lib/opfs.ts
+++ b/src/lib/opfs.ts
@@ -38,14 +38,14 @@ export async function listSaved(): Promise<SavedEntry[]> {
   const dir = await getTemottoDir();
   const entries: SavedEntry[] = [];
 
-  for await (const [name, handle] of dir as any) {
+  for await (const [name, handle] of dir.entries()) {
     if (handle.kind !== "directory") continue;
     const ts = Number(name);
     if (!Number.isFinite(ts)) continue;
 
     let csvName = "";
     let layoutName = "";
-    for await (const [fileName] of handle as any) {
+    for await (const [fileName] of (handle as FileSystemDirectoryHandle).entries()) {
       if (fileName.endsWith(".csv")) csvName = fileName;
       else if (fileName.endsWith(".json")) layoutName = fileName;
     }
@@ -66,7 +66,7 @@ export async function loadSaved(
 
   let csvName = "";
   let layoutName = "";
-  for await (const [fileName] of folder as any) {
+  for await (const [fileName] of folder.entries()) {
     if (fileName.endsWith(".csv")) csvName = fileName;
     else if (fileName.endsWith(".json")) layoutName = fileName;
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
+    "lib": ["ESNext", "DOM", "DOM.Iterable", "DOM.AsyncIterable"],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,


### PR DESCRIPTION
## Summary
- `opfs.ts` の `FileSystemDirectoryHandle` イテレーションで使われていた `as any` を `.entries()` に置換し型安全に
- `tsconfig.json` に `DOM.AsyncIterable` を追加して async iteration の型定義を有効化

## Test plan
- [ ] `tsc --noEmit` が通ること（確認済み）
- [ ] データ保存・一覧・読み込み・削除が動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)