### PR TITLE
fix: クロス集計のリグレッションを修正

### DIFF
--- a/src/lib/aggregate.ts
+++ b/src/lib/aggregate.ts
@@ -44,38 +44,29 @@ export interface Query {
   cross_cols: QuestionDef[];
 }
 
-/** 集計のエントリポイント。db上のsurveyビューに対して全設問を並列集計する */
-export async function aggregate(db: duckdb.AsyncDuckDB, payload: Query): Promise<AggResult[]> {
+/** 集計のエントリポイント。conn上のsurveyビューに対して全設問を集計する */
+export async function aggregate(
+  conn: duckdb.AsyncDuckDBConnection,
+  payload: Query,
+): Promise<AggResult[]> {
   const weightCol = payload.weight_col;
   const crossCols = payload.cross_cols ?? [];
 
-  // クロスヘッダーキャッシュを先に構築（1コネクション）
-  let crossHeaderCache: Awaited<ReturnType<typeof fetchCrossHeaders>>;
-  if (crossCols.length > 0) {
-    const conn = await db.connect();
-    try {
-      crossHeaderCache = await fetchCrossHeaders(conn, crossCols, weightCol);
-    } finally {
-      await conn.close();
+  const crossHeaderCache =
+    crossCols.length > 0
+      ? await fetchCrossHeaders(conn, crossCols, weightCol)
+      : (new Map() as Awaited<ReturnType<typeof fetchCrossHeaders>>);
+
+  const ctx = new Aggregator(conn, weightCol, crossCols, crossHeaderCache);
+
+  const results: AggResult[] = [];
+  for (const q of payload.questions) {
+    if (q.type === "SA") {
+      results.push(await ctx.aggregateSA(q.column));
+    } else {
+      results.push(await ctx.aggregateMA(q.prefix, q.columns));
     }
-  } else {
-    crossHeaderCache = new Map();
   }
 
-  // 設問ごとに並列実行（各自コネクション作成・破棄）
-  return Promise.all(
-    payload.questions.map(async (q) => {
-      const conn = await db.connect();
-      try {
-        const ctx = new Aggregator(conn, weightCol, crossCols, crossHeaderCache);
-        if (q.type === "SA") {
-          return ctx.aggregateSA(q.column);
-        } else {
-          return ctx.aggregateMA(q.prefix, q.columns);
-        }
-      } finally {
-        await conn.close();
-      }
-    }),
-  );
+  return results;
 }

--- a/src/lib/aggregator.ts
+++ b/src/lib/aggregator.ts
@@ -16,8 +16,8 @@ function weightExpr(weightCol: string): string {
 
 function maWeightedCountExpr(maCol: string, weightCol: string): string {
   return weightCol
-    ? `COALESCE(SUM(TRY_CAST("${esc(weightCol)}" AS DOUBLE)) FILTER (WHERE "${esc(maCol)}" = '1'), 0)`
-    : `COUNT(*) FILTER (WHERE "${esc(maCol)}" = '1')::DOUBLE`;
+    ? `SUM(CASE WHEN "${esc(maCol)}" = '1' THEN TRY_CAST("${esc(weightCol)}" AS DOUBLE) ELSE 0 END)`
+    : `COUNT(CASE WHEN "${esc(maCol)}" = '1' THEN 1 END)::DOUBLE`;
 }
 
 /** MA設問の「表示された」条件: いずれかのサブカラムが空でない */
@@ -63,15 +63,12 @@ export class Aggregator {
 
     // CTE: GT + 全SA×SAクロスを1クエリで取得
     const GT_SENTINEL = "__GT__";
-    let sql = `WITH base AS (
-      SELECT * FROM survey
-      WHERE "${esc(col)}" IS NOT NULL AND "${esc(col)}" != ''
-    )
+    let inner = `
     SELECT "${esc(col)}" AS mv, '${GT_SENTINEL}' AS sv, ${weightExpr(this.weightCol)} AS cnt
     FROM base GROUP BY "${esc(col)}"`;
 
     for (const crossQ of saCross) {
-      sql += `
+      inner += `
     UNION ALL
     SELECT "${esc(col)}" AS mv, "${esc(crossQ.column)}" AS sv, ${weightExpr(this.weightCol)} AS cnt
     FROM base
@@ -79,7 +76,12 @@ export class Aggregator {
     GROUP BY "${esc(col)}", "${esc(crossQ.column)}"`;
     }
 
-    sql += `
+    const sql = `WITH base AS (
+      SELECT * FROM survey
+      WHERE "${esc(col)}" IS NOT NULL AND "${esc(col)}" != ''
+    )
+    SELECT * FROM (${inner}
+    ) AS combined
     ORDER BY sv, TRY_CAST(mv AS DOUBLE) NULLS LAST, mv ASC`;
 
     const arrowResult = await this.conn.query(sql);
@@ -141,8 +143,8 @@ export class Aggregator {
     // 無回答式: 表示されたが何も選択していない
     const noneSelected = cols.map((c) => `"${esc(c)}" != '1'`).join(" AND ");
     const naExpr = this.weightCol
-      ? `COALESCE(SUM(TRY_CAST("${esc(this.weightCol)}" AS DOUBLE)) FILTER (WHERE ${noneSelected}), 0)`
-      : `COUNT(*) FILTER (WHERE ${noneSelected})::DOUBLE`;
+      ? `SUM(CASE WHEN ${noneSelected} THEN TRY_CAST("${esc(this.weightCol)}" AS DOUBLE) ELSE 0 END)`
+      : `COUNT(CASE WHEN ${noneSelected} THEN 1 END)::DOUBLE`;
 
     // questionN 式: 表示された人数
     const nExpr = this.weightCol
@@ -240,8 +242,8 @@ export class Aggregator {
     // 無回答カウント: 表示されたが何も選択していない
     const naCondition = `${maCols.map((c) => `"${esc(c)}" != '1'`).join(" AND ")} AND (${maShownCondition(maCols)})`;
     const naExpr = this.weightCol
-      ? `COALESCE(SUM(TRY_CAST("${esc(this.weightCol)}" AS DOUBLE)) FILTER (WHERE ${naCondition}), 0)`
-      : `COUNT(*) FILTER (WHERE ${naCondition})::DOUBLE`;
+      ? `SUM(CASE WHEN ${naCondition} THEN TRY_CAST("${esc(this.weightCol)}" AS DOUBLE) ELSE 0 END)`
+      : `COUNT(CASE WHEN ${naCondition} THEN 1 END)::DOUBLE`;
 
     const sql = `
       SELECT
@@ -292,8 +294,8 @@ export class Aggregator {
       for (let c = 0; c < crossMaCols.length; c++) {
         const cond = `"${esc(rowMaCols[r])}" = '1' AND "${esc(crossMaCols[c])}" = '1'`;
         const expr = this.weightCol
-          ? `COALESCE(SUM(TRY_CAST("${esc(this.weightCol)}" AS DOUBLE)) FILTER (WHERE ${cond}), 0)`
-          : `COUNT(*) FILTER (WHERE ${cond})::DOUBLE`;
+          ? `SUM(CASE WHEN ${cond} THEN TRY_CAST("${esc(this.weightCol)}" AS DOUBLE) ELSE 0 END)`
+          : `COUNT(CASE WHEN ${cond} THEN 1 END)::DOUBLE`;
         selectClauses.push(`${expr} AS r${r}c${c}`);
       }
     }
@@ -303,8 +305,8 @@ export class Aggregator {
     for (let c = 0; c < crossMaCols.length; c++) {
       const naCondition = `${naBase} AND "${esc(crossMaCols[c])}" = '1'`;
       const expr = this.weightCol
-        ? `COALESCE(SUM(TRY_CAST("${esc(this.weightCol)}" AS DOUBLE)) FILTER (WHERE ${naCondition}), 0)`
-        : `COUNT(*) FILTER (WHERE ${naCondition})::DOUBLE`;
+        ? `SUM(CASE WHEN ${naCondition} THEN TRY_CAST("${esc(this.weightCol)}" AS DOUBLE) ELSE 0 END)`
+        : `COUNT(CASE WHEN ${naCondition} THEN 1 END)::DOUBLE`;
       selectClauses.push(`${expr} AS na_c${c}`);
     }
 

--- a/src/lib/duckdbBridge.ts
+++ b/src/lib/duckdbBridge.ts
@@ -80,6 +80,6 @@ export async function loadCSV(csvText: string): Promise<{ headers: string[]; row
 
 /** survey ビューに対して集計を実行する */
 export async function runDuckDBAggregation(query: Query): Promise<AggResult[]> {
-  if (!db || status !== "ready") throw new Error("DuckDB is not ready");
-  return aggregate(db, query);
+  const c = await getConnection();
+  return aggregate(c, query);
 }


### PR DESCRIPTION
## Summary
- PR #24 で `db.connect()` による新規接続作成に変更した結果、`max_expression_depth=0` となりクロス集計が全て失敗していた
- シングルトン接続での逐次実行に戻し、UNION ALL の ORDER BY をサブクエリでラップ、FILTER 構文を CASE WHEN に戻して修正

## Test plan
- [ ] SA設問をクロス集計軸に選択して集計が正常に完了すること
- [ ] MA設問をクロス集計軸に選択して集計が正常に完了すること
- [ ] GT集計が引き続き正常に動作すること
- [ ] SA×SA, SA×MA, MA×SA, MA×MA 全パターンのクロス集計を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)