### PR TITLE
feat: Vitest導入とaggregate関数の統合テスト追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "oxfmt": "^0.35.0",
         "oxlint": "^1.50.0",
         "vite-plugin-top-level-await": "^1.6.0",
-        "vite-plugin-wasm": "^3.5.0"
+        "vite-plugin-wasm": "^3.5.0",
+        "vitest": "^4.0.18"
       }
     },
     "node_modules/@duckdb/duckdb-wasm": {
@@ -444,6 +445,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@oxfmt/binding-android-arm-eabi": {
       "version": "0.35.0",
@@ -1434,6 +1442,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@swc/core": {
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.11.tgz",
@@ -1676,6 +1691,17 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/command-line-args": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
@@ -1688,11 +1714,129 @@
       "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
       "license": "MIT"
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -1753,6 +1897,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -1780,6 +1934,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -1911,6 +2075,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -1962,6 +2133,26 @@
         "@esbuild/win32-arm64": "0.27.3",
         "@esbuild/win32-ia32": "0.27.3",
         "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -2118,6 +2309,16 @@
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "license": "MIT"
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -2156,6 +2357,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/oxfmt": {
       "version": "0.35.0",
@@ -2241,6 +2453,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2421,6 +2640,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2429,6 +2655,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -2464,6 +2704,23 @@
         "node": ">=12.17"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2488,6 +2745,16 @@
       "license": "MIT",
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -2631,6 +2898,101 @@
       "license": "MIT",
       "peerDependencies": {
         "vite": "^2 || ^3 || ^4 || ^5 || ^6 || ^7"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wordwrapjs": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "lint:fix": "oxlint --fix src/ scripts/ vite.config.ts",
     "fmt": "oxfmt src/ scripts/ vite.config.ts index.html",
     "fmt:check": "oxfmt --check src/ scripts/ vite.config.ts index.html",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "check": "npm run fmt:check && npm run lint && tsc --noEmit"
   },
   "dependencies": {
@@ -22,6 +24,7 @@
     "oxfmt": "^0.35.0",
     "oxlint": "^1.50.0",
     "vite-plugin-top-level-await": "^1.6.0",
-    "vite-plugin-wasm": "^3.5.0"
+    "vite-plugin-wasm": "^3.5.0",
+    "vitest": "^4.0.18"
   }
 }

--- a/tests/aggregate.test.ts
+++ b/tests/aggregate.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { aggregate, type Query, type Cell } from "../src/lib/aggregate";
+import { setupDuckDB, teardownDuckDB } from "./helpers/duckdb";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let conn: any;
+
+beforeAll(async () => {
+  conn = await setupDuckDB();
+}, 30_000);
+
+afterAll(async () => {
+  await teardownDuckDB();
+});
+
+/** セルを (main, sub) で検索するヘルパー */
+function findCell(cells: Cell[], main: string, sub: string): Cell | undefined {
+  return cells.find((c) => c.main === main && c.sub === sub);
+}
+
+// ============================================================
+// テストデータ (testdata/test_data.csv) 14行
+// SA の WHERE: IS NOT NULL AND != '' → "N/A"は有効な文字列として残る
+//
+// CSV行(1-indexed, ヘッダー除く):
+//  1: id=1,  w=1.2, q1=1,   q2=3,   q3_1=1, q3_2=0, q3_3=1
+//  2: id=2,  w=0.9, q1=2,   q2=1,   q3_1=0, q3_2=1, q3_3=1
+//  3: id=3,  w=1.5, q1=1,   q2=2,   q3_1=1, q3_2=1, q3_3=0
+//  4: id=4,  w=0.8, q1=3,   q2=1,   q3_1=1, q3_2=0, q3_3=0
+//  5: id=5,  w=1.1, q1=1,   q2=3,   q3_1=0, q3_2=1, q3_3=1
+//  6: id=6,  w=1.0, q1=2,   q2=2,   q3_1=1, q3_2=0, q3_3=1
+//  7: id=7,  w=1.3, q1=1,   q2=1,   q3_1=0, q3_2=1, q3_3=0
+//  8: id=8,  w=0.7, q1=3,   q2=3,   q3_1=1, q3_2=0, q3_3=1
+//  9: id=9,  w=1.4, q1=2,   q2=2,   q3_1=1, q3_2=1, q3_3=0
+// 10: id=10, w=1.0, q1=1,   q2=1,   q3_1=0, q3_2=0, q3_3=1
+// 11: id=11, w=1.0, q1=N/A, q2=N/A, q3_1=0, q3_2=0, q3_3=0
+// 12: id=12, w=0.8, q1=1,   q2='',  q3_1=0, q3_2=0, q3_3=0
+// 13: id=13, w=1.1, q1=N/A, q2=2,   q3_1='',q3_2='',q3_3=''
+// 14: id=14, w=1.0, q1='',  q2=1,   q3_1=1, q3_2=0, q3_3=1
+// ============================================================
+
+describe("aggregate - 重みなし", () => {
+  describe("SA GT集計（クロスなし）", () => {
+    it("q1 の GT 集計で各値の count/n/pct が正しい", async () => {
+      const query: Query = {
+        questions: [{ type: "SA", column: "q1" }],
+        weight_col: "",
+        cross_cols: [],
+      };
+
+      const results = await aggregate(conn, query);
+      expect(results).toHaveLength(1);
+
+      const r = results[0];
+      expect(r.question).toBe("q1");
+      expect(r.type).toBe("SA");
+
+      // q1 有効行: 行1-13 (行14=空のみ除外, N/Aは文字列として有効) = 13行
+      // q1=1: 行1,3,5,7,10,12 = 6件
+      // q1=2: 行2,6,9 = 3件
+      // q1=3: 行4,8 = 2件
+      // q1=N/A: 行11,13 = 2件
+      const n = 13;
+      const cell1 = findCell(r.cells, "1", "GT")!;
+      expect(cell1).toBeDefined();
+      expect(cell1.n).toBe(n);
+      expect(cell1.count).toBe(6);
+      expect(cell1.pct).toBeCloseTo((6 / n) * 100, 5);
+
+      const cell2 = findCell(r.cells, "2", "GT")!;
+      expect(cell2.count).toBe(3);
+
+      const cell3 = findCell(r.cells, "3", "GT")!;
+      expect(cell3.count).toBe(2);
+
+      const cellNA = findCell(r.cells, "N/A", "GT")!;
+      expect(cellNA.count).toBe(2);
+    });
+  });
+
+  describe("MA GT集計（クロスなし）", () => {
+    it("q3 の GT 集計で各サブカラムの count と無回答が正しい", async () => {
+      const query: Query = {
+        questions: [{ type: "MA", prefix: "q3", columns: ["q3_1", "q3_2", "q3_3"] }],
+        weight_col: "",
+        cross_cols: [],
+      };
+
+      const results = await aggregate(conn, query);
+      expect(results).toHaveLength(1);
+
+      const r = results[0];
+      expect(r.question).toBe("q3");
+      expect(r.type).toBe("MA");
+
+      // MA shown条件: q3_1~q3_3 のいずれかが非空かつ非NULL
+      // 行13: q3_1='',q3_2='',q3_3='' → 全部空なので除外
+      // 行1-12,14 = 13行が shown
+      // q3_1='1': 行1,3,4,6,8,9,14 = 7件
+      // q3_2='1': 行2,3,5,7,9 = 5件
+      // q3_3='1': 行1,2,5,6,8,10,14 = 7件
+      // 無回答(shown but none='1'): 行11(0,0,0),12(0,0,0) = 2件
+      const n = 13;
+
+      const cellQ3_1 = findCell(r.cells, "q3_1", "GT")!;
+      expect(cellQ3_1).toBeDefined();
+      expect(cellQ3_1.n).toBe(n);
+      expect(cellQ3_1.count).toBe(7);
+
+      const cellQ3_2 = findCell(r.cells, "q3_2", "GT")!;
+      expect(cellQ3_2.count).toBe(5);
+
+      const cellQ3_3 = findCell(r.cells, "q3_3", "GT")!;
+      expect(cellQ3_3.count).toBe(7);
+
+      const cellNA = findCell(r.cells, "N/A", "GT")!;
+      expect(cellNA).toBeDefined();
+      expect(cellNA.count).toBe(2);
+    });
+  });
+
+  describe("SA × SA クロス集計", () => {
+    it("q2 を q1 でクロスした結果が正しい", async () => {
+      const query: Query = {
+        questions: [{ type: "SA", column: "q2" }],
+        weight_col: "",
+        cross_cols: [{ type: "SA", column: "q1" }],
+      };
+
+      const results = await aggregate(conn, query);
+      expect(results).toHaveLength(1);
+
+      const r = results[0];
+      // q2有効行(非空・非NULL): 行1-10,13,14 + 行11(N/A) = 13行 (行12=空のみ除外)
+      // q2=1: 行2,4,7,10,14 = 5件
+      // q2=2: 行3,6,9,13 = 4件
+      // q2=3: 行1,5,8 = 3件
+      // q2=N/A: 行11 = 1件
+      const gtN = 13;
+      expect(findCell(r.cells, "1", "GT")!.n).toBe(gtN);
+      expect(findCell(r.cells, "1", "GT")!.count).toBe(5);
+      expect(findCell(r.cells, "2", "GT")!.count).toBe(4);
+      expect(findCell(r.cells, "3", "GT")!.count).toBe(3);
+      expect(findCell(r.cells, "N/A", "GT")!.count).toBe(1);
+
+      // クロス: q2有効行の中で q1 の値ごとに分岐
+      // クロスヘッダーのn: q1=1かつq2有効 の行数
+      // q1=1 かつ q2有効: 行1,3,5,7,10 (行12はq2空で除外) = 5行
+      // q1=1 でq2=1: 行7,10 = 2件
+      const crossCell = findCell(r.cells, "1", "1"); // q2=1, q1=1
+      expect(crossCell).toBeDefined();
+      expect(crossCell!.count).toBe(2);
+    });
+  });
+
+  describe("SA × MA クロス集計", () => {
+    it("q1 を q3 でクロスした結果が正しい", async () => {
+      const query: Query = {
+        questions: [{ type: "SA", column: "q1" }],
+        weight_col: "",
+        cross_cols: [{ type: "MA", prefix: "q3", columns: ["q3_1", "q3_2", "q3_3"] }],
+      };
+
+      const results = await aggregate(conn, query);
+      expect(results).toHaveLength(1);
+
+      const r = results[0];
+      expect(findCell(r.cells, "1", "GT")).toBeDefined();
+
+      // SA×MA: q1有効行の中でq3_1='1'のカウント
+      // q1有効: 行1-13 (行14=空除外) = 13行
+      // q1=1 の行: 行1,3,5,7,10,12
+      // q1=1 かつ q3_1='1': 行1,3 = 2件
+      const cell = findCell(r.cells, "1", "q3_1");
+      expect(cell).toBeDefined();
+      expect(cell!.count).toBe(2);
+    });
+  });
+
+  describe("MA × SA クロス集計", () => {
+    it("q3 を q1 でクロスした結果が正しい", async () => {
+      const query: Query = {
+        questions: [{ type: "MA", prefix: "q3", columns: ["q3_1", "q3_2", "q3_3"] }],
+        weight_col: "",
+        cross_cols: [{ type: "SA", column: "q1" }],
+      };
+
+      const results = await aggregate(conn, query);
+      expect(results).toHaveLength(1);
+
+      const r = results[0];
+      // クロスヘッダー: q1の各値ごとのn（全survey行でq1有効な行のweight集計）
+      // q1=1の行: 行1,3,5,7,10,12
+      // q3_1='1' かつ q1=1: 行1,3 = 2件
+      const cell = findCell(r.cells, "q3_1", "1");
+      expect(cell).toBeDefined();
+      expect(cell!.count).toBe(2);
+
+      // q3_2='1' かつ q1=1: 行3(q3_2=1,q1=1), 行5(q3_2=1,q1=1), 行7(q3_2=1,q1=1) = 3件
+      const cell2 = findCell(r.cells, "q3_2", "1");
+      expect(cell2).toBeDefined();
+      expect(cell2!.count).toBe(3);
+    });
+  });
+
+  describe("MA × MA クロス集計", () => {
+    it("q3 を自身でクロスした結果にセルが存在する", async () => {
+      const query: Query = {
+        questions: [{ type: "MA", prefix: "q3", columns: ["q3_1", "q3_2", "q3_3"] }],
+        weight_col: "",
+        cross_cols: [{ type: "MA", prefix: "q3", columns: ["q3_1", "q3_2", "q3_3"] }],
+      };
+
+      const results = await aggregate(conn, query);
+      expect(results).toHaveLength(1);
+
+      const r = results[0];
+      // q3_1='1' かつ q3_1='1': 行1,3,4,6,8,9,14 = 7件
+      const cell = findCell(r.cells, "q3_1", "q3_1");
+      expect(cell).toBeDefined();
+      expect(cell!.count).toBe(7);
+
+      // q3_1='1' かつ q3_2='1': 行3,9 = 2件
+      const cell12 = findCell(r.cells, "q3_1", "q3_2");
+      expect(cell12).toBeDefined();
+      expect(cell12!.count).toBe(2);
+    });
+  });
+});
+
+describe("aggregate - 重み付き", () => {
+  describe("SA GT集計（重み付き）", () => {
+    it("q1 の重み付き GT 集計で weighted count が正しい", async () => {
+      const query: Query = {
+        questions: [{ type: "SA", column: "q1" }],
+        weight_col: "weight",
+        cross_cols: [],
+      };
+
+      const results = await aggregate(conn, query);
+      const r = results[0];
+
+      // q1有効行: 行1-13 (行14=空のみ除外, N/Aは文字列として有効)
+      // q1=1: 行1(1.2)+3(1.5)+5(1.1)+7(1.3)+10(1.0)+12(0.8) = 6.9
+      // q1=2: 行2(0.9)+6(1.0)+9(1.4) = 3.3
+      // q1=3: 行4(0.8)+8(0.7) = 1.5
+      // q1=N/A: 行11(1.0)+13(1.1) = 2.1
+      // n = 6.9+3.3+1.5+2.1 = 13.8
+      const cell1 = findCell(r.cells, "1", "GT")!;
+      expect(cell1).toBeDefined();
+      expect(cell1.count).toBeCloseTo(6.9, 1);
+      expect(cell1.n).toBeCloseTo(13.8, 1);
+      expect(cell1.pct).toBeCloseTo((6.9 / 13.8) * 100, 1);
+
+      const cell2 = findCell(r.cells, "2", "GT")!;
+      expect(cell2.count).toBeCloseTo(3.3, 1);
+
+      const cell3 = findCell(r.cells, "3", "GT")!;
+      expect(cell3.count).toBeCloseTo(1.5, 1);
+    });
+  });
+
+  describe("MA GT集計（重み付き）", () => {
+    it("q3 の重み付き GT 集計で weighted count が正しい", async () => {
+      const query: Query = {
+        questions: [{ type: "MA", prefix: "q3", columns: ["q3_1", "q3_2", "q3_3"] }],
+        weight_col: "weight",
+        cross_cols: [],
+      };
+
+      const results = await aggregate(conn, query);
+      const r = results[0];
+
+      // shown行: 行1-12,14 = 13行 (行13は全空で除外)
+      // q3_1='1': 行1(1.2)+3(1.5)+4(0.8)+6(1.0)+8(0.7)+9(1.4)+14(1.0) = 7.6
+      const cellQ3_1 = findCell(r.cells, "q3_1", "GT")!;
+      expect(cellQ3_1).toBeDefined();
+      expect(cellQ3_1.count).toBeCloseTo(7.6, 1);
+    });
+  });
+});

--- a/tests/helpers/duckdb.ts
+++ b/tests/helpers/duckdb.ts
@@ -1,0 +1,48 @@
+import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const require = createRequire(import.meta.url);
+const DUCKDB_DIST = resolve(require.resolve("@duckdb/duckdb-wasm"), "..");
+
+// Node.js ブロッキングモードを使用（Worker不要）
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const {
+  createDuckDB,
+  NODE_RUNTIME,
+  ConsoleLogger,
+} = require(resolve(DUCKDB_DIST, "duckdb-node-blocking.cjs"));
+
+let db: ReturnType<typeof createDuckDB> extends Promise<infer T> ? T : never;
+let conn: Awaited<ReturnType<typeof db.connect>> | null = null;
+
+export async function setupDuckDB() {
+  if (conn) return conn;
+
+  const logger = new ConsoleLogger();
+  const bundles = {
+    mvp: { mainModule: resolve(DUCKDB_DIST, "duckdb-mvp.wasm") },
+    eh: { mainModule: resolve(DUCKDB_DIST, "duckdb-eh.wasm") },
+  };
+  db = await createDuckDB(bundles, logger, NODE_RUNTIME);
+  await db.instantiate();
+
+  conn = await db.connect();
+
+  // testdata/test_data.csv を survey ビューとして登録
+  const csvPath = resolve(import.meta.dirname!, "../../testdata/test_data.csv");
+  const csvText = readFileSync(csvPath, "utf-8");
+  await db.registerFileText("survey.csv", csvText);
+  await conn.query(
+    `CREATE OR REPLACE VIEW survey AS SELECT * FROM read_csv('survey.csv', all_varchar=true)`,
+  );
+
+  return conn;
+}
+
+export async function teardownDuckDB(): Promise<void> {
+  if (conn) {
+    await conn.close();
+    conn = null;
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,13 @@
+/// <reference types="vitest/config" />
 import { defineConfig } from "vite";
 import wasm from "vite-plugin-wasm";
 import topLevelAwait from "vite-plugin-top-level-await";
 
 export default defineConfig({
   plugins: [wasm(), topLevelAwait()],
+  test: {
+    pool: "forks",
+  },
   server: {
     headers: {
       "Cross-Origin-Opener-Policy": "same-origin",


### PR DESCRIPTION
## Summary
- Vitestをテストフレームワークとして導入（`npm test` / `npm run test:watch`）
- DuckDB Wasmのブロッキングモード（`duckdb-node-blocking.cjs`）を使ったNode.js環境でのテストヘルパーを作成
- `aggregate()` 関数の統合テスト8ケースを追加（SA/MA GT集計、全クロス集計パターン、重み付き集計）

## Test plan
- [x] `npm test` で全8テストがパスすることを確認
- [x] `npm run check` (fmt/lint/tsc) が既存のチェックに影響しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)