### PR TITLE
feat: Cloudflare Pages用COOP/COEPヘッダー追加

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,3 @@
+/*
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Embedder-Policy: require-corp


### PR DESCRIPTION
## Summary
- Cloudflare Pagesデプロイ用に `public/_headers` を追加
- DuckDB Wasmが必要とする `SharedArrayBuffer` のために COOP/COEP ヘッダーを全パスに設定

## Test plan
- [ ] `npm run build` でビルド成功を確認
- [ ] `dist/_headers` にファイルがコピーされていることを確認
- [ ] Cloudflare Pagesにデプロイ後、レスポンスヘッダーに `Cross-Origin-Opener-Policy` と `Cross-Origin-Embedder-Policy` が含まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)