### PR TITLE
fix: DuckDB WASMをCDNから読み込みCloudflare Pages対応

### DIFF
--- a/src/lib/duckdbBridge.ts
+++ b/src/lib/duckdbBridge.ts
@@ -1,9 +1,7 @@
 import * as duckdb from "@duckdb/duckdb-wasm";
-import duckdb_wasm from "@duckdb/duckdb-wasm/dist/duckdb-mvp.wasm?url";
-import mvp_worker from "@duckdb/duckdb-wasm/dist/duckdb-browser-mvp.worker.js?url";
-import duckdb_wasm_eh from "@duckdb/duckdb-wasm/dist/duckdb-eh.wasm?url";
-import eh_worker from "@duckdb/duckdb-wasm/dist/duckdb-browser-eh.worker.js?url";
 import { aggregate, type Query, type AggResult } from "./aggregate";
+
+const DUCKDB_CDN = "https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.33.1-dev18.0/dist";
 
 type DuckStatus = "loading" | "ready" | "error";
 
@@ -27,8 +25,14 @@ export async function initDuckDB(): Promise<void> {
       updateStatusUI("loading", "DuckDB 読み込み中...");
 
       const BUNDLES: duckdb.DuckDBBundles = {
-        mvp: { mainModule: duckdb_wasm, mainWorker: mvp_worker },
-        eh: { mainModule: duckdb_wasm_eh, mainWorker: eh_worker },
+        mvp: {
+          mainModule: `${DUCKDB_CDN}/duckdb-mvp.wasm`,
+          mainWorker: `${DUCKDB_CDN}/duckdb-browser-mvp.worker.js`,
+        },
+        eh: {
+          mainModule: `${DUCKDB_CDN}/duckdb-eh.wasm`,
+          mainWorker: `${DUCKDB_CDN}/duckdb-browser-eh.worker.js`,
+        },
       };
 
       const bundle = await duckdb.selectBundle(BUNDLES);

--- a/src/lib/duckdbBridge.ts
+++ b/src/lib/duckdbBridge.ts
@@ -36,7 +36,10 @@ export async function initDuckDB(): Promise<void> {
       };
 
       const bundle = await duckdb.selectBundle(BUNDLES);
-      const worker = new Worker(bundle.mainWorker!);
+      const workerBlob = new Blob([`importScripts("${bundle.mainWorker!}");`], {
+        type: "application/javascript",
+      });
+      const worker = new Worker(URL.createObjectURL(workerBlob));
       const logger = new duckdb.ConsoleLogger();
       db = new duckdb.AsyncDuckDB(logger, worker);
       await db.instantiate(bundle.mainModule, bundle.pthreadWorker);


### PR DESCRIPTION
## Summary
- DuckDB WASMバイナリ(33MB+38MB)をバンドルから除外し、jsDelivr CDNから実行時に読み込む方式に変更
- Cloudflare Pagesの25MBファイルサイズ制限を回避
- ビルド成果物が約75MB → 約400KBに縮小

## Test plan
- [ ] `npm run build` が成功すること
- [ ] ローカルで `npm run preview` してDuckDBが正常に初期化されること
- [ ] Cloudflare Pagesでデプロイが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)