### PR TITLE
refactor: translate all code comments to English

### DIFF
--- a/src/components/GettingStarted.ts
+++ b/src/components/GettingStarted.ts
@@ -67,7 +67,6 @@ function show(): void {
   const modal = document.getElementById("getting-started-modal")!;
   modal.classList.remove("hidden");
   document.body.style.overflow = "hidden";
-  // フォーカスをモーダル内に移動
   (document.getElementById("gs-ok") as HTMLButtonElement).focus();
 }
 
@@ -86,26 +85,22 @@ export function initGettingStarted(): void {
   const modal = document.getElementById("getting-started-modal")!;
   modal.innerHTML = buildModalHTML();
 
-  // 閉じるボタン
   document.getElementById("gs-close")!.addEventListener("click", hide);
   document.getElementById("gs-ok")!.addEventListener("click", hide);
 
-  // 背景クリックで閉じる
   modal.addEventListener("click", (e) => {
     if (e.target === modal) hide();
   });
 
-  // ESCキーで閉じる
   document.addEventListener("keydown", (e) => {
     if (e.key === "Escape" && !modal.classList.contains("hidden")) {
       hide();
     }
   });
 
-  // ヘッダーの「?」ボタン
   document.getElementById("help-btn")!.addEventListener("click", show);
 
-  // 初回訪問時に自動表示
+  // Auto-show on first visit
   if (!localStorage.getItem(STORAGE_KEY)) {
     show();
   }

--- a/src/components/rightPane/AIBubble.ts
+++ b/src/components/rightPane/AIBubble.ts
@@ -9,7 +9,7 @@ export async function showAIBubble(
 ): Promise<void> {
   if (!(await isAIAvailable())) return;
 
-  // 既存の吹き出しがあれば除去
+  // Remove existing bubble if any
   document.querySelector(".ai-bubble")?.remove();
 
   const bubble = document.createElement("div");

--- a/src/components/rightPane/ChartRenderer.ts
+++ b/src/components/rightPane/ChartRenderer.ts
@@ -1,4 +1,4 @@
-/** チャート描画コンポーネント */
+/** Chart rendering component */
 
 import type { AggResult, QuestionDef } from "../../lib/aggregate";
 import type { LayoutMeta } from "../../lib/layout";
@@ -9,7 +9,7 @@ import { escHtml } from "../shared/escHtml";
 
 import type { ChartConfiguration } from "chart.js";
 
-/** アクティブなChart.jsインスタンスを追跡（メモリリーク防止） */
+/** Track active Chart.js instances to prevent memory leaks */
 const activeCharts: Chart[] = [];
 
 export function destroyAllCharts(): void {
@@ -31,7 +31,6 @@ export function renderChartCard(
   const wrapper = document.createElement("div");
   wrapper.className = "chart-card";
 
-  // ヘッダー
   const head = document.createElement("div");
   head.className = "gt-table-head";
   const questionLabel = resolveQuestionLabel(res.question, layoutMeta);
@@ -79,7 +78,7 @@ function buildGtChart(
   const data = mains.map((m) => lookup.get(`${m}\0GT`)?.pct ?? 0);
   const colors = mains.map((_, i) => getSeriesColor(i));
 
-  // 帯グラフ: 1本の横棒に各選択肢をセグメントとして表示
+  // Stacked bar: each option as a segment in one horizontal bar
   if (chartType === "obi") {
     const datasets = mains.map((m, i) => ({
       label: resolveValueLabel(res.type, res.question, m, layoutMeta),
@@ -170,7 +169,7 @@ function buildCrossChart(
   const { mains, subs, lookup } = pv;
   const crossSubs = subs.filter((s) => s.label !== "GT");
 
-  // 帯グラフ: クロス値ごとに1本ずつ帯を表示
+  // Stacked bar: one bar per cross value
   if (gtChartType === "obi") {
     const subLabels = crossSubs.map((s) => resolveSubLabel(s.label, layoutMeta, crossCols));
     const datasets = mains.map((m, i) => ({
@@ -211,7 +210,7 @@ function buildCrossChart(
     } as ChartConfiguration);
   }
 
-  // 横棒 / 縦棒 → 集合棒グラフ（方向はGT選択に合わせる）
+  // Clustered bar chart (direction matches GT selection)
   const isHorizontal = gtChartType === "bar-h";
   const labels = mains.map((m) => resolveValueLabel(res.type, res.question, m, layoutMeta));
 

--- a/src/components/rightPane/CrossTable.ts
+++ b/src/components/rightPane/CrossTable.ts
@@ -5,19 +5,19 @@ import type { pivot } from "../../lib/pivot";
 import { resolveQuestionLabel, resolveValueLabel, resolveSubLabel } from "../../lib/labelResolver";
 import { escHtml } from "../shared/escHtml";
 
-/** クロス軸ごとにsubsをグループ化する（プレフィックス付きsub値を利用） */
+/** Group subs by cross axis using prefixed sub values */
 function groupSubsByCrossAxis(
   crossSubs: { label: string; n: number }[],
   crossCols: QuestionDef[],
   resType: "SA" | "MA",
 ): { crossCol: QuestionDef; subs: { label: string; n: number }[] }[] {
-  // SA主軸: SA軸が先、MA軸が後。MA主軸: crossCols順
+  // SA main: SA axes first, then MA. MA main: crossCols order
   const orderedCols =
     resType === "SA"
       ? [...crossCols.filter((q) => q.type === "SA"), ...crossCols.filter((q) => q.type === "MA")]
       : crossCols;
 
-  // 軸キーごとにsubsを分類
+  // Classify subs by axis key
   const axisMap = new Map<string, { label: string; n: number }[]>();
   for (const sub of crossSubs) {
     const parsed = parseCrossSub(sub.label);
@@ -56,12 +56,12 @@ export function buildCrossTable(
   caption.textContent = `${questionLabel} のクロス集計結果`;
   table.appendChild(caption);
 
-  // クロス軸グループを構築
+  // Build cross-axis groups
   const crossGroups =
     crossCols && crossCols.length > 0 ? groupSubsByCrossAxis(crossSubs, crossCols, res.type) : [];
   const hasMultipleAxes = crossGroups.length > 1;
 
-  // ヘッダー行1: 選択肢 | 全体 | クロス軸グループ...
+  // Header row 1: Option | Total | Cross axis groups...
   const tr1 = document.createElement("tr");
 
   const thLabel = document.createElement("th");
@@ -69,7 +69,7 @@ export function buildCrossTable(
   thLabel.textContent = "選択肢";
   tr1.appendChild(thLabel);
 
-  // 全体列グループ
+  // Total column group
   const thTotal = document.createElement("th");
   thTotal.colSpan = 2;
   thTotal.className = "cross-group-header gt-group";
@@ -93,7 +93,7 @@ export function buildCrossTable(
     tr1.appendChild(thCross);
   }
 
-  // ヘッダー行2: 件数 | % | 各クロス値(n=X)...
+  // Header row 2: count | % | cross values (n=X)...
   const tr2 = document.createElement("tr");
 
   const thCount = document.createElement("th");
@@ -134,10 +134,10 @@ export function buildCrossTable(
   thead.appendChild(tr2);
   table.appendChild(thead);
 
-  // ボディ
+  // Body
   const tbody = document.createElement("tbody");
 
-  // 軸グループ境界のインデックスを事前計算
+  // Precompute axis group boundary indices
   const axisBorderIndices = new Set<number>();
   if (hasMultipleAxes) {
     let offset = 0;
@@ -167,7 +167,7 @@ export function buildCrossTable(
     tdPct.textContent = gtCell.pct.toFixed(1) + "%";
     tr.appendChild(tdPct);
 
-    // クロスセル
+    // Cross cells
     crossSubs.forEach((sub, i) => {
       const cell = lookup.get(`${main}\0${sub.label}`);
       const td = document.createElement("td");

--- a/src/components/rightPane/ResultView.ts
+++ b/src/components/rightPane/ResultView.ts
@@ -9,13 +9,13 @@ import { buildCrossTable } from "./CrossTable";
 import { showAIBubble } from "./AIBubble";
 import { destroyAllCharts, renderChartCard, type GtChartType } from "./ChartRenderer";
 
-// --- 表示モード状態 ---
+// View mode state
 type ViewMode = "table" | "chart";
 let currentViewMode: ViewMode = "table";
 let saChartType: GtChartType = "bar-h";
 let maChartType: GtChartType = "bar-h";
 
-// --- 再描画用にデータをキャッシュ ---
+// Cached data for re-rendering
 let lastResults: AggResult[] | null = null;
 let lastWeightCol = "";
 let lastRawN = 0;
@@ -29,7 +29,6 @@ export function renderResults(
   layoutMeta?: LayoutMeta,
   crossCols?: QuestionDef[],
 ): void {
-  // キャッシュ
   lastResults = results;
   lastWeightCol = weightCol;
   lastRawN = rawN;
@@ -46,7 +45,6 @@ export function renderResults(
     return subs.length > 1;
   });
 
-  // ヘッダー
   const hdr = buildToolbar(hasCross, results, weightCol, currentViewMode, layoutMeta, {
     onViewModeChange: (mode) => {
       currentViewMode = mode;
@@ -63,7 +61,7 @@ export function renderResults(
   });
   area.appendChild(hdr);
 
-  // チャート種類セレクト（2行目）
+  // Chart type selector (2nd row)
   if (currentViewMode === "chart") {
     const chartOpts = buildChartOpts(saChartType, maChartType, {
       onSaChartTypeChange: (type) => {
@@ -78,7 +76,7 @@ export function renderResults(
     area.appendChild(chartOpts);
   }
 
-  // コンテンツ描画
+  // Render content
   const grid = document.createElement("div");
   area.appendChild(grid);
 
@@ -88,7 +86,7 @@ export function renderResults(
     renderTableContent(grid, results, weightCol, hasCross, layoutMeta, crossCols);
   }
 
-  // AI分析コメントを自動生成（非同期、テーブル描画をブロックしない）
+  // Generate AI analysis comment asynchronously (non-blocking)
   showAIBubble(results, weightCol, layoutMeta);
 }
 
@@ -97,7 +95,7 @@ function reRender(): void {
   renderResults(lastResults, lastWeightCol, lastRawN, lastLayoutMeta, lastCrossCols);
 }
 
-// テーマ変更時にチャート再描画
+// Re-render charts on theme change
 const observer = new MutationObserver(() => {
   if (currentViewMode === "chart" && lastResults) {
     reRender();

--- a/src/components/rightPane/Toolbar.ts
+++ b/src/components/rightPane/Toolbar.ts
@@ -29,7 +29,7 @@ export function buildToolbar(
     </span>
   `;
 
-  // トグル: テーブル / チャート
+  // Toggle: table / chart
   const toggle = document.createElement("div");
   toggle.className = "view-toggle";
   const btnTable = document.createElement("button");
@@ -50,7 +50,7 @@ export function buildToolbar(
   });
   hdr.appendChild(toggle);
 
-  // CSV出力ボタン
+  // CSV export button
   const csvBtn = document.createElement("button");
   csvBtn.className = "csv-export-btn";
   csvBtn.textContent = "全件CSV出力";
@@ -68,7 +68,7 @@ export function buildChartOpts(
   const chartOpts = document.createElement("div");
   chartOpts.className = "chart-opts";
 
-  // SA用
+  // SA chart type
   const saLabel = document.createElement("label");
   saLabel.textContent = "SA: ";
   const saSelect = document.createElement("select");
@@ -84,7 +84,7 @@ export function buildChartOpts(
   saLabel.appendChild(saSelect);
   chartOpts.appendChild(saLabel);
 
-  // MA用
+  // MA chart type
   const maLabel = document.createElement("label");
   maLabel.textContent = "MA: ";
   const maSelect = document.createElement("select");

--- a/src/lib/aggregate.ts
+++ b/src/lib/aggregate.ts
@@ -1,14 +1,12 @@
-/** DuckDB SQL集計ロジック */
+/** DuckDB SQL aggregation logic */
 
 import type * as duckdb from "@duckdb/duckdb-wasm";
 import { Aggregator, fetchCrossHeaders } from "./aggregator";
 
-// --- 集計結果の型定義 ---
-
 export interface Cell {
-  main: string; // 選択肢ラベル（集計対象の設問値）
-  sub: string; // "GT" or クロス集計軸の値 ("男", "女", ...) or MAカラム名
-  n: number; // その sub の母数
+  main: string; // Option label (aggregation target value)
+  sub: string; // "GT" or cross-tab axis value or MA column name
+  n: number; // Denominator for this sub
   count: number;
   pct: number;
 }
@@ -19,34 +17,32 @@ export interface AggResult {
   cells: Cell[];
 }
 
-// --- 集計 payload ---
-
 export type QuestionDef = SAQuestion | MAQuestion;
 
 interface SAQuestion {
   type: "SA";
-  column: string; // カラム名 "q1"
+  column: string;
 }
 
 interface MAQuestion {
   type: "MA";
-  prefix: string; // グループプレフィックス "Q3"
-  columns: string[]; // ["Q3_1","Q3_2","Q3_3"]
+  prefix: string;
+  columns: string[];
 }
 
 export function questionKey(q: QuestionDef): string {
   return q.type === "SA" ? q.column : q.prefix;
 }
 
-/** クロスsub値のセパレータ（軸キーと生値を分離） */
+/** Cross sub value separator (separates axis key from raw value) */
 export const CROSS_SEP = "\x01";
 
-/** 軸キー付きクロスsub値を生成する (例: "q1\x011") */
+/** Build prefixed cross sub value (e.g. "q1\x011") */
 export function crossSub(axisKey: string, rawValue: string): string {
   return `${axisKey}${CROSS_SEP}${rawValue}`;
 }
 
-/** クロスsub値を { axisKey, rawValue } にパースする。GT等プレフィックスなしはそのまま返す */
+/** Parse cross sub value into { axisKey, rawValue }. Returns null for unprefixed values like GT. */
 export function parseCrossSub(sub: string): { axisKey: string; rawValue: string } | null {
   const idx = sub.indexOf(CROSS_SEP);
   if (idx < 0) return null;
@@ -59,7 +55,7 @@ export interface Query {
   cross_cols: QuestionDef[];
 }
 
-/** 集計のエントリポイント。conn上のsurveyビューに対して全設問を集計する */
+/** Aggregation entry point. Aggregates all questions against the survey view. */
 export async function aggregate(
   conn: duckdb.AsyncDuckDBConnection,
   payload: Query,

--- a/src/lib/aggregator.ts
+++ b/src/lib/aggregator.ts
@@ -1,10 +1,10 @@
-/** 集計エンジン - SQL生成・実行の全責務を担う */
+/** Aggregation engine — handles all SQL generation and execution */
 
 import type * as duckdb from "@duckdb/duckdb-wasm";
 import type { Cell, AggResult, QuestionDef } from "./aggregate";
 import { questionKey, crossSub } from "./aggregate";
 
-// --- SQL ヘルパー ---
+// SQL helpers
 
 function esc(name: string): string {
   return name.replace(/"/g, '""');
@@ -20,26 +20,26 @@ function maWeightedCountExpr(maCol: string, weightCol: string): string {
     : `COUNT(CASE WHEN "${esc(maCol)}" = '1' THEN 1 END)::DOUBLE`;
 }
 
-/** MA設問の「表示された」条件: いずれかのサブカラムが空でない */
+/** MA "shown" condition: at least one sub-column is non-empty */
 function maShownCondition(cols: string[]): string {
   return cols.map((c) => `("${esc(c)}" IS NOT NULL AND "${esc(c)}" != '')`).join(" OR ");
 }
 
-/** 無回答マーカー */
+/** No-answer marker */
 export const NA_VALUE = "N/A";
 
 function mkCell(main: string, sub: string, n: number, count: number): Cell {
   return { main, sub, n, count, pct: n > 0 ? (count / n) * 100 : 0 };
 }
 
-// --- クロスヘッダーキャッシュ ---
+// Cross-header cache
 
 type CrossHeaderCache = Map<
   string,
   { headers: Array<{ label: string; n: number }>; crossValues: string[] }
 >;
 
-// --- 集計コンテキスト ---
+// Aggregation context
 
 export class Aggregator {
   constructor(
@@ -50,7 +50,7 @@ export class Aggregator {
   ) {}
 
   async aggregateSA(col: string): Promise<AggResult> {
-    // クロス軸を SA / MA に分離（CTE統合は SA×SA のみ）
+    // Separate cross axes into SA/MA (CTE consolidation for SA×SA only)
     const saCross = this.crossCols.filter((q) => q.type === "SA") as Array<{
       type: "SA";
       column: string;
@@ -61,7 +61,7 @@ export class Aggregator {
       columns: string[];
     }>;
 
-    // CTE: GT + 全SA×SAクロスを1クエリで取得
+    // CTE: fetch GT + all SA×SA cross in one query
     const GT_SENTINEL = "__GT__";
     let inner = `
     SELECT "${esc(col)}" AS mv, '${GT_SENTINEL}' AS sv, ${weightExpr(this.weightCol)} AS cnt
@@ -87,7 +87,7 @@ export class Aggregator {
     const arrowResult = await this.conn.query(sql);
     const allRows = arrowResult.toArray();
 
-    // sv ごとに行を仕分け
+    // Partition rows by sv
     const gtRows: Array<{ mv: string; cnt: number }> = [];
     const crossBuckets = new Map<string, Map<string, number>>();
 
@@ -107,12 +107,12 @@ export class Aggregator {
       }
     }
 
-    // GT セル
+    // GT cells
     const questionN = gtRows.reduce((sum, r) => sum + r.cnt, 0);
     const mainValues = gtRows.map((r) => r.mv);
     const cells: Cell[] = gtRows.map((r) => mkCell(r.mv, "GT", questionN, r.cnt));
 
-    // SA×SA クロスセル
+    // SA×SA cross cells
     for (const crossQ of saCross) {
       const cached = this.crossHeaderCache.get(crossQ.column)!;
       const { headers, crossValues } = cached;
@@ -126,7 +126,7 @@ export class Aggregator {
       }
     }
 
-    // SA×MA クロスセル（構造が異なるため個別クエリ維持）
+    // SA×MA cross cells (separate query due to different structure)
     for (const crossQ of maCross) {
       const cached = this.crossHeaderCache.get(crossQ.prefix)!;
       cells.push(
@@ -142,18 +142,18 @@ export class Aggregator {
       return `${maWeightedCountExpr(col, this.weightCol)} AS c${i}`;
     });
 
-    // 無回答式: 表示されたが何も選択していない
+    // No-answer: shown but nothing selected
     const noneSelected = cols.map((c) => `"${esc(c)}" != '1'`).join(" AND ");
     const naExpr = this.weightCol
       ? `SUM(CASE WHEN ${noneSelected} THEN TRY_CAST("${esc(this.weightCol)}" AS DOUBLE) ELSE 0 END)`
       : `COUNT(CASE WHEN ${noneSelected} THEN 1 END)::DOUBLE`;
 
-    // questionN 式: 表示された人数
+    // questionN: number of respondents shown
     const nExpr = this.weightCol
       ? `COALESCE(SUM(TRY_CAST("${esc(this.weightCol)}" AS DOUBLE)), 0)`
       : `COUNT(*)::DOUBLE`;
 
-    // 回答対象外を除外し、naCount・questionN もまとめて取得
+    // Exclude non-respondents; fetch naCount and questionN together
     const sql = `
       SELECT ${selectClauses.join(", ")}, ${naExpr} AS na_cnt, ${nExpr} AS question_n
       FROM survey
@@ -167,10 +167,10 @@ export class Aggregator {
       mkCell(col, "GT", questionN, Number(row[`c${i}`] ?? 0)),
     );
 
-    // 無回答行
+    // No-answer row
     cells.push(mkCell(NA_VALUE, "GT", questionN, Number(row.na_cnt ?? 0)));
 
-    // クロスセル
+    // Cross cells
     if (this.crossCols.length > 0) {
       for (const crossQ of this.crossCols) {
         const cached = this.crossHeaderCache.get(questionKey(crossQ))!;
@@ -187,7 +187,7 @@ export class Aggregator {
     return { question: prefix, type: "MA", cells };
   }
 
-  /** SA主軸 × MA軸クロスセル生成 */
+  /** SA main × MA cross cell generation */
   private async buildCrossCellsMA(
     mainCol: string,
     mainValues: string[],
@@ -232,7 +232,7 @@ export class Aggregator {
     return cells;
   }
 
-  /** MA主軸 × SA軸クロスセル生成 */
+  /** MA main × SA cross cell generation */
   private async buildMACrossCellsSA(
     maCols: string[],
     crossCol: string,
@@ -244,7 +244,7 @@ export class Aggregator {
       (col, i) => `${maWeightedCountExpr(col, this.weightCol)} AS c${i}`,
     );
 
-    // 無回答カウント: 表示されたが何も選択していない
+    // No-answer count: shown but nothing selected
     const naCondition = `${maCols.map((c) => `"${esc(c)}" != '1'`).join(" AND ")} AND (${maShownCondition(maCols)})`;
     const naExpr = this.weightCol
       ? `SUM(CASE WHEN ${naCondition} THEN TRY_CAST("${esc(this.weightCol)}" AS DOUBLE) ELSE 0 END)`
@@ -285,7 +285,7 @@ export class Aggregator {
       }
     }
 
-    // 無回答クロスセル
+    // No-answer cross cells
     for (let i = 0; i < crossValues.length; i++) {
       cells.push(
         mkCell(
@@ -300,7 +300,7 @@ export class Aggregator {
     return cells;
   }
 
-  /** MA主軸 × MA軸クロスセル生成 */
+  /** MA main × MA cross cell generation */
   private async buildMACrossCellsMA(
     rowMaCols: string[],
     crossMaPrefix: string,
@@ -320,7 +320,7 @@ export class Aggregator {
       }
     }
 
-    // 無回答 × 各クロスMAカラム
+    // No-answer × each cross MA column
     const naBase = `${rowMaCols.map((col) => `"${esc(col)}" != '1'`).join(" AND ")} AND (${maShownCondition(rowMaCols)})`;
     for (let c = 0; c < crossMaCols.length; c++) {
       const naCondition = `${naBase} AND "${esc(crossMaCols[c])}" = '1'`;
@@ -348,7 +348,7 @@ export class Aggregator {
       }
     }
 
-    // 無回答クロスセル
+    // No-answer cross cells
     for (let c = 0; c < crossMaCols.length; c++) {
       cells.push(
         mkCell(
@@ -364,7 +364,7 @@ export class Aggregator {
   }
 }
 
-// --- 前処理（static create から利用） ---
+// Cross-header prefetching
 
 export async function fetchCrossHeaders(
   conn: duckdb.AsyncDuckDBConnection,

--- a/src/lib/aiComment.ts
+++ b/src/lib/aiComment.ts
@@ -1,9 +1,9 @@
-/** Chrome Built-in AI (Prompt API) によるAI分析コメント生成 */
+/** AI analysis comment generation via Chrome Built-in AI (Prompt API) */
 
 import type { AggResult } from "./aggregate";
 import type { LayoutMeta } from "./layout";
 
-// --- Chrome Prompt API 型宣言 ---
+// Chrome Prompt API type declarations
 
 declare global {
   interface LanguageModelExpectedIO {

--- a/src/lib/chartConfig.ts
+++ b/src/lib/chartConfig.ts
@@ -1,4 +1,4 @@
-/** Chart.js 設定・登録（tree-shaken） */
+/** Chart.js setup and registration (tree-shaken) */
 
 import {
   Chart,
@@ -14,7 +14,7 @@ Chart.register(BarController, CategoryScale, LinearScale, BarElement, Tooltip, L
 
 export { Chart };
 
-/** アンケート集計用カラーパレット（ライト/ダーク両対応） */
+/** Color palette for survey aggregation (light/dark compatible) */
 const PALETTE = [
   "#0064d4",
   "#0097a7",
@@ -32,7 +32,7 @@ export function getSeriesColor(index: number): string {
   return PALETTE[index % PALETTE.length];
 }
 
-/** CSS変数から現テーマの色を取得 */
+/** Get current theme colors from CSS variables */
 export function getThemeColors(): {
   text: string;
   muted: string;

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -4,7 +4,7 @@ import type { LayoutMeta } from "./layout";
 import { NA_VALUE } from "./aggregator";
 import { pivot } from "./pivot";
 
-/** クロスsub値をラベルに解決する */
+/** Resolve cross sub value to label */
 function resolveSubLabel(subLabel: string, meta?: LayoutMeta): string {
   if (subLabel === NA_VALUE) return "無回答";
 
@@ -22,7 +22,7 @@ function resolveSubLabel(subLabel: string, meta?: LayoutMeta): string {
   return meta.valueLabels[subLabel]?.["1"] ?? subLabel;
 }
 
-/** 選択肢ラベルを解決する（CSV出力用） */
+/** Resolve option label for CSV export */
 function resolveMainLabel(main: string): string {
   return main === NA_VALUE ? "無回答" : main;
 }
@@ -69,7 +69,7 @@ function downloadGtCSV(results: AggResult[]): void {
 }
 
 function downloadCrossCSV(results: AggResult[], layoutMeta?: LayoutMeta): void {
-  // 最初の結果からクロス軸構造を取得
+  // Get cross-axis structure from first result
   const firstResult = results.find((r) => {
     const { subs } = pivot(r.cells);
     return subs.length > 1;
@@ -82,7 +82,7 @@ function downloadCrossCSV(results: AggResult[], layoutMeta?: LayoutMeta): void {
   const firstPivot = pivot(firstResult.cells);
   const crossSubs = firstPivot.subs.filter((s) => s.label !== "GT");
 
-  // ヘッダー行
+  // Header rows
   const headerRow1 = ["変数名", "種別", "選択肢", "全体_n", "全体_%"];
   const headerRow2 = ["", "", "", "", ""];
   crossSubs.forEach((sub) => {
@@ -113,7 +113,7 @@ function downloadCrossCSV(results: AggResult[], layoutMeta?: LayoutMeta): void {
       rows.push(dataRow);
     });
 
-    // n行
+    // n row
     const nRow = [res.question, res.type, "n", gtSub.n.toFixed(1), ""];
     resCrossSubs.forEach((sub) => {
       nRow.push(sub.n.toFixed(1));

--- a/src/lib/duckdbBridge.ts
+++ b/src/lib/duckdbBridge.ts
@@ -63,7 +63,7 @@ async function getConnection(): Promise<duckdb.AsyncDuckDBConnection> {
   return conn;
 }
 
-/** CSVテキストをDuckDBに登録し、ヘッダーと行数を返す */
+/** Register CSV text in DuckDB and return headers and row count */
 export async function loadCSV(csvText: string): Promise<{ headers: string[]; rowCount: number }> {
   await initDuckDB();
   if (!db) throw new Error("DuckDB is not ready");
@@ -85,7 +85,7 @@ export async function loadCSV(csvText: string): Promise<{ headers: string[]; row
   return { headers, rowCount };
 }
 
-/** survey ビューに対して集計を実行する */
+/** Execute aggregation against the survey view */
 export async function runDuckDBAggregation(query: Query): Promise<AggResult[]> {
   const c = await getConnection();
   return aggregate(c, query);

--- a/src/lib/labelResolver.ts
+++ b/src/lib/labelResolver.ts
@@ -1,19 +1,16 @@
-/** ラベル解決ユーティリティ（ResultTable / ChartRenderer 共有） */
+/** Label resolution utility (shared by ResultTable / ChartRenderer) */
 
 import type { QuestionDef } from "./aggregate";
 import { parseCrossSub } from "./aggregate";
 import type { LayoutMeta } from "./layout";
 import { NA_VALUE } from "./aggregator";
 
-/** 設問ラベルを解決する。なければ列名をそのまま返す */
+/** Resolve question label; falls back to column name */
 export function resolveQuestionLabel(col: string, meta?: LayoutMeta): string {
   return meta?.questionLabels[col] ?? col;
 }
 
-/** 選択肢ラベルを解決する
- *  SA: valueLabels[col][code]
- *  MA: valueLabels[colName]["1"]（colName = row.label）
- */
+/** Resolve option label (SA: valueLabels[col][code], MA: valueLabels[colName]["1"]) */
 export function resolveValueLabel(
   type: "SA" | "MA",
   col: string,
@@ -29,9 +26,7 @@ export function resolveValueLabel(
   }
 }
 
-/** クロス軸ヘッダーのラベルを解決する
- *  sub値は "axisKey\x01rawValue" 形式でプレフィックス付き
- */
+/** Resolve cross-axis header label (sub values are prefixed as "axisKey\x01rawValue") */
 export function resolveSubLabel(
   subLabel: string,
   meta?: LayoutMeta,
@@ -44,14 +39,14 @@ export function resolveSubLabel(
     const { axisKey, rawValue } = parsed;
     if (rawValue === NA_VALUE) return "無回答";
     if (!meta) return rawValue;
-    // MA軸: rawValue はカラム名 → valueLabels[rawValue]["1"]
+    // MA axis: rawValue is column name → valueLabels[rawValue]["1"]
     const maLabel = meta.valueLabels[rawValue]?.["1"];
     if (maLabel) return maLabel;
-    // SA軸: rawValue は値コード → valueLabels[axisKey][rawValue]
+    // SA axis: rawValue is value code → valueLabels[axisKey][rawValue]
     return meta.valueLabels[axisKey]?.[rawValue] ?? rawValue;
   }
 
-  // プレフィックスなし（後方互換）
+  // No prefix (backwards compatibility)
   if (!meta) return subLabel;
   const maLabel = meta.valueLabels[subLabel]?.["1"];
   if (maLabel) return maLabel;

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -3,7 +3,7 @@ import type { QuestionDef } from "./aggregate";
 export interface LayoutItem {
   code: string;
   label: string;
-  column?: string; // 列名の明示指定（省略時は `{key}_{code}` で導出）
+  column?: string; // Explicit column name (defaults to `{key}_{code}`)
 }
 
 export type LayoutColType = "SA" | "MA" | "ID" | "WEIGHT" | "EXCLUDE";
@@ -18,15 +18,11 @@ export interface LayoutEntry {
 export type Layout = LayoutEntry[];
 
 export interface LayoutMeta {
-  /** 設問ラベル: CSVの列名（またはMAグループ名） → 表示名 */
+  /** Question labels: CSV column name (or MA group name) → display name */
   questionLabels: Record<string, string>;
-  /**
-   * 選択肢ラベル:
-   *   SA → { colName: { code: label } }
-   *   MA → { colName: { "1": itemLabel } }
-   */
+  /** Value labels: SA → { colName: { code: label } }, MA → { colName: { "1": itemLabel } } */
   valueLabels: Record<string, Record<string, string>>;
-  /** 列種別: { colName → ColConfig互換の種別文字列 } */
+  /** Column types: { colName → type string } */
   colTypes: Record<string, string>;
 }
 
@@ -55,7 +51,7 @@ export function parseLayout(jsonText: string): Layout {
   return parsed as Layout;
 }
 
-/** headers + colTypes から QuestionDef[] を組み立てる */
+/** Build QuestionDef[] from headers and colTypes */
 export function buildQuestionDefs(
   headers: string[],
   colTypes: Record<string, string>,
@@ -114,7 +110,7 @@ export function buildLayoutMeta(layout: Layout): LayoutMeta {
           for (const item of items) {
             const colName = item.column ?? `${key}_${item.code}`;
             colTypes[colName] = `ma:${key}`;
-            // MA列は 1/0 フラグ。"1" の表示ラベルとしてitem.labelを保持
+            // MA columns are 1/0 flags; store item.label as display label for "1"
             valueLabels[colName] = { "1": item.label };
           }
         }

--- a/src/lib/pivot.ts
+++ b/src/lib/pivot.ts
@@ -1,6 +1,6 @@
 import type { Cell } from "./aggregate";
 
-/** cells をグリッド構造に変換する */
+/** Convert flat cells array into a grid structure */
 export function pivot(cells: Cell[]): {
   mains: string[];
   subs: { label: string; n: number }[];

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,12 +13,12 @@ import { saveData, loadSaved } from "./lib/opfs";
 import { initSavedFiles, refreshList } from "./components/leftPane/SavedFiles";
 import { initGettingStarted } from "./components/GettingStarted";
 
-// 現在読み込み済みの CSV / Layout データ
+// Currently loaded CSV / Layout data
 let currentCsv: { text: string; fileName: string; headers: string[]; rowCount: number } | null =
   null;
 let currentLayout: { json: string; fileName: string; meta: LayoutMeta } | null = null;
 
-// テーマ切り替え
+// Theme toggle
 function initThemeToggle(): void {
   const toggle = document.getElementById("theme-toggle")!;
   const saved = localStorage.getItem("temotto-theme");
@@ -46,12 +46,12 @@ function initThemeToggle(): void {
 initThemeToggle();
 initGettingStarted();
 
-// DuckDB Wasm をバックグラウンドで初期化開始
+// Start DuckDB Wasm initialization in the background
 initDuckDB().catch(() => {
-  // エラーはduckdbBridge内でUI表示済み
+  // Error already displayed in UI by duckdbBridge
 });
 
-// CSV + レイアウト両方揃ったらUI初期化
+// Initialize UI when both CSV and layout are loaded
 function initAfterBothLoaded(): void {
   if (!currentCsv || !currentLayout) return;
 
@@ -63,7 +63,7 @@ function initAfterBothLoaded(): void {
   (document.getElementById("run-btn") as HTMLButtonElement).disabled = false;
 }
 
-// 読み込み済みデータ情報を表示
+// Display loaded data info
 function updateLoadedInfo(): void {
   const el = document.getElementById("loaded-data-info")!;
   if (!currentCsv && !currentLayout) {
@@ -85,7 +85,7 @@ function updateLoadedInfo(): void {
   el.classList.remove("hidden");
 }
 
-// OPFS自動保存（CSV+レイアウト両方揃ったとき）
+// Auto-save to OPFS when both CSV and layout are loaded
 async function trySaveToOPFS(): Promise<void> {
   if (!currentCsv || !currentLayout) return;
   try {
@@ -101,7 +101,7 @@ async function trySaveToOPFS(): Promise<void> {
   }
 }
 
-// CSV読み込みハンドラ: DuckDBにロードしてheaders/rowCountを取得
+// CSV load handler: load into DuckDB and get headers/rowCount
 async function onCSVLoaded(csvText: string, fileName: string): Promise<void> {
   try {
     const result = await loadCSV(csvText);
@@ -115,7 +115,7 @@ async function onCSVLoaded(csvText: string, fileName: string): Promise<void> {
   }
 }
 
-// レイアウト読み込みハンドラ
+// Layout load handler
 function onLayoutLoaded(
   _layout: Layout,
   meta: LayoutMeta,
@@ -129,7 +129,7 @@ function onLayoutLoaded(
   trySaveToOPFS();
 }
 
-// 保存データから読み込み（OPFS再保存は不要なのでtrySaveToOPFSを呼ばない）
+// Load from saved data (skip OPFS re-save)
 async function loadFromSaved(folderId: string): Promise<void> {
   try {
     const { csvText, csvName, layoutJson, layoutName } = await loadSaved(folderId);
@@ -162,12 +162,12 @@ function showError(msg: string): void {
   }
 }
 
-// 集計実行
+// Run aggregation
 async function runAggregation(): Promise<void> {
   if (!currentCsv || !currentLayout) return;
   showError("");
 
-  // ウェイト列はレイアウトから自動決定
+  // Weight column auto-determined from layout
   const weightCol =
     Object.entries(currentLayout.meta.colTypes).find(([, t]) => t === "weight")?.[0] ?? "";
   const crossCols = getCrossColsSelected();
@@ -186,7 +186,7 @@ async function runAggregation(): Promise<void> {
   }
 }
 
-// タブ切り替え
+// Tab switching
 const tabs = Array.from(document.querySelectorAll<HTMLButtonElement>(".load-tab"));
 
 function activateTab(tab: HTMLButtonElement): void {
@@ -202,7 +202,7 @@ function activateTab(tab: HTMLButtonElement): void {
   tab.focus();
 }
 
-// 初期状態: 非アクティブタブを tabIndex=-1 に設定
+// Set inactive tabs to tabIndex=-1
 for (const t of tabs) {
   if (!t.classList.contains("active")) t.tabIndex = -1;
 }
@@ -227,7 +227,7 @@ for (const tab of tabs) {
   });
 }
 
-// イベントバインド
+// Event binding
 initCsvInput(onCSVLoaded, (msg) => showError(msg));
 initLayoutInput(onLayoutLoaded, (msg) => showError(msg));
 initSavedFiles(loadFromSaved);


### PR DESCRIPTION
## Summary
- Translated all Japanese comments across 16 TypeScript source files to concise English
- Removed redundant/obvious comments that didn't add value
- No functional changes — code logic is untouched

## Test plan
- [x] `tsc --noEmit` passes with no errors
- [ ] Verify app runs correctly in dev mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)