### PR TITLE
feat: i18n対応と設定パネルの追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,26 +12,26 @@
   </head>
   <body>
     <header>
-      <button id="back-btn" class="back-btn hidden" aria-label="データ読み込みに戻る">←</button>
+      <button id="back-btn" class="back-btn hidden" data-i18n="header.back" data-i18n-attr="aria-label" aria-label="データ読み込みに戻る">←</button>
       <h1>Temotto</h1>
-      <span>SURVEY AGGREGATOR v0.1</span>
+      <span data-i18n="header.subtitle">SURVEY AGGREGATOR v0.1</span>
       <div class="header-right">
         <div class="wasm-status" role="status" aria-live="polite">
           <div class="status-dot loading" id="wasm-dot" aria-hidden="true"></div>
-          <span id="wasm-label">DuckDB 読み込み中...</span>
+          <span id="wasm-label" data-i18n="wasm.loading">DuckDB 読み込み中...</span>
         </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="ダークモードに切り替え">
-          🌙
+        <button id="settings-btn" class="settings-btn" data-i18n="header.settings" data-i18n-attr="aria-label" aria-label="設定を開く">
+          ⚙
         </button>
       </div>
     </header>
 
     <main data-screen="import">
-      <!-- IMPORT SCREEN: 中央カード型 -->
+      <!-- IMPORT SCREEN -->
       <div id="import-screen" class="import-screen">
         <div class="import-card">
-          <h2 class="import-card-title">データ読み込み</h2>
-          <div class="load-tabs" role="tablist" aria-label="データ読み込み方法">
+          <h2 class="import-card-title" data-i18n="import.title">データ読み込み</h2>
+          <div class="load-tabs" role="tablist" data-i18n="import.tab.label" data-i18n-attr="aria-label" aria-label="データ読み込み方法">
             <button
               class="load-tab active"
               role="tab"
@@ -39,6 +39,7 @@
               aria-controls="tab-file"
               id="tab-btn-file"
               data-tab="file"
+              data-i18n="import.tab.file"
             >
               ファイルから
             </button>
@@ -49,6 +50,7 @@
               aria-controls="tab-saved"
               id="tab-btn-saved"
               data-tab="saved"
+              data-i18n="import.tab.saved"
             >
               履歴から
             </button>
@@ -57,18 +59,18 @@
             <div class="dropzone" id="csv-dropzone" data-accept=".csv">
               <input type="file" id="file-input" accept=".csv" class="dropzone-input" />
               <div class="dropzone-content">
-                <span class="dropzone-icon">ローデータ</span>
-                <span class="dropzone-text">ここにローデータファイル(csv)をドロップ</span>
-                <span class="dropzone-hint">またはクリックして選択</span>
+                <span class="dropzone-icon" data-i18n="dropzone.csv.icon">ローデータ</span>
+                <span class="dropzone-text" data-i18n="dropzone.csv.text">ここにローデータファイル(csv)をドロップ</span>
+                <span class="dropzone-hint" data-i18n="dropzone.csv.hint">またはクリックして選択</span>
               </div>
               <div class="dropzone-loaded hidden" id="csv-dropzone-loaded"></div>
             </div>
             <div class="dropzone" id="layout-dropzone" data-accept=".json">
               <input type="file" id="layout-file-input" accept=".json" class="dropzone-input" />
               <div class="dropzone-content">
-                <span class="dropzone-icon">レイアウト</span>
-                <span class="dropzone-text">ここにレイアウトファイル(json)をドロップ</span>
-                <span class="dropzone-hint">またはクリックして選択</span>
+                <span class="dropzone-icon" data-i18n="dropzone.layout.icon">レイアウト</span>
+                <span class="dropzone-text" data-i18n="dropzone.layout.text">ここにレイアウトファイル(json)をドロップ</span>
+                <span class="dropzone-hint" data-i18n="dropzone.layout.hint">またはクリックして選択</span>
               </div>
               <div class="dropzone-loaded hidden" id="layout-dropzone-loaded"></div>
             </div>
@@ -82,48 +84,55 @@
             <div id="saved-files-list"></div>
           </div>
           <div id="loaded-data-info" class="loaded-data-info hidden" aria-live="polite"></div>
-          <button class="proceed-btn hidden" id="proceed-btn">集計画面へ進む →</button>
+          <button class="proceed-btn hidden" id="proceed-btn" data-i18n="import.proceed">集計画面へ進む →</button>
         </div>
       </div>
 
       <!-- AGGREGATION SCREEN: LEFT panel -->
       <div class="panel-left" role="region" aria-label="設定">
-        <!-- データ概要 -->
         <section class="section" id="data-summary-section">
-          <h2 class="section-label">データ概要</h2>
+          <h2 class="section-label" data-i18n="section.summary">データ概要</h2>
           <div id="data-summary" class="data-summary"></div>
         </section>
 
-        <!-- クロス集計軸 -->
         <section class="section hidden" id="cross-config-section">
-          <h2 class="section-label">クロス集計軸（任意）</h2>
+          <h2 class="section-label" data-i18n="section.cross">クロス集計軸（任意）</h2>
           <div
             class="cross-col-list"
             id="cross-col-list"
             role="group"
+            data-i18n="section.cross.label"
+            data-i18n-attr="aria-label"
             aria-label="クロス集計軸の選択"
           ></div>
         </section>
 
-        <!-- ウェイト情報 -->
         <div id="weight-info" class="weight-info hidden"></div>
 
         <div id="error-msg" class="hidden" role="alert" aria-live="assertive"></div>
 
-        <button class="run-btn hidden" id="run-btn" disabled>▶ 集計を実行</button>
+        <button class="run-btn hidden" id="run-btn" disabled data-i18n="run.button">▶ 集計を実行</button>
       </div>
 
       <!-- AGGREGATION SCREEN: RIGHT panel -->
       <div class="panel-right" id="panel-right" role="region" aria-label="集計結果">
         <div class="empty-state" id="empty-state">
           <span class="big" aria-hidden="true">⬛</span>
-          <p>クロス集計軸を選んで集計を実行してください</p>
+          <p data-i18n="empty.text">クロス集計軸を選んで集計を実行してください</p>
         </div>
         <div class="hidden" id="results-area" aria-live="polite"></div>
       </div>
     </main>
 
-    <button id="help-btn" class="help-btn" aria-label="使い方ガイド">?</button>
+    <button id="help-btn" class="help-btn" data-i18n="help.label" data-i18n-attr="aria-label" aria-label="使い方ガイド">?</button>
+
+    <div
+      id="settings-modal"
+      class="modal-overlay hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="settings-title"
+    ></div>
 
     <div
       id="getting-started-modal"

--- a/index.html
+++ b/index.html
@@ -12,7 +12,15 @@
   </head>
   <body>
     <header>
-      <button id="back-btn" class="back-btn hidden" data-i18n="header.back" data-i18n-attr="aria-label" aria-label="データ読み込みに戻る">←</button>
+      <button
+        id="back-btn"
+        class="back-btn hidden"
+        data-i18n="header.back"
+        data-i18n-attr="aria-label"
+        aria-label="データ読み込みに戻る"
+      >
+        ←
+      </button>
       <h1>Temotto</h1>
       <span data-i18n="header.subtitle">SURVEY AGGREGATOR v0.1</span>
       <div class="header-right">
@@ -20,9 +28,18 @@
           <div class="status-dot loading" id="wasm-dot" aria-hidden="true"></div>
           <span id="wasm-label" data-i18n="wasm.loading">DuckDB 読み込み中...</span>
         </div>
-        <button id="settings-btn" class="settings-btn" data-i18n="header.settings" data-i18n-attr="aria-label" aria-label="設定を開く">
-          ⚙
-        </button>
+        <div class="settings-wrap">
+          <button
+            id="settings-btn"
+            class="settings-btn"
+            data-i18n="header.settings"
+            data-i18n-attr="aria-label"
+            aria-label="設定を開く"
+          >
+            ⚙
+          </button>
+          <div id="settings-panel" class="settings-panel hidden"></div>
+        </div>
       </div>
     </header>
 
@@ -31,7 +48,13 @@
       <div id="import-screen" class="import-screen">
         <div class="import-card">
           <h2 class="import-card-title" data-i18n="import.title">データ読み込み</h2>
-          <div class="load-tabs" role="tablist" data-i18n="import.tab.label" data-i18n-attr="aria-label" aria-label="データ読み込み方法">
+          <div
+            class="load-tabs"
+            role="tablist"
+            data-i18n="import.tab.label"
+            data-i18n-attr="aria-label"
+            aria-label="データ読み込み方法"
+          >
             <button
               class="load-tab active"
               role="tab"
@@ -60,8 +83,12 @@
               <input type="file" id="file-input" accept=".csv" class="dropzone-input" />
               <div class="dropzone-content">
                 <span class="dropzone-icon" data-i18n="dropzone.csv.icon">ローデータ</span>
-                <span class="dropzone-text" data-i18n="dropzone.csv.text">ここにローデータファイル(csv)をドロップ</span>
-                <span class="dropzone-hint" data-i18n="dropzone.csv.hint">またはクリックして選択</span>
+                <span class="dropzone-text" data-i18n="dropzone.csv.text"
+                  >ここにローデータファイル(csv)をドロップ</span
+                >
+                <span class="dropzone-hint" data-i18n="dropzone.csv.hint"
+                  >またはクリックして選択</span
+                >
               </div>
               <div class="dropzone-loaded hidden" id="csv-dropzone-loaded"></div>
             </div>
@@ -69,8 +96,12 @@
               <input type="file" id="layout-file-input" accept=".json" class="dropzone-input" />
               <div class="dropzone-content">
                 <span class="dropzone-icon" data-i18n="dropzone.layout.icon">レイアウト</span>
-                <span class="dropzone-text" data-i18n="dropzone.layout.text">ここにレイアウトファイル(json)をドロップ</span>
-                <span class="dropzone-hint" data-i18n="dropzone.layout.hint">またはクリックして選択</span>
+                <span class="dropzone-text" data-i18n="dropzone.layout.text"
+                  >ここにレイアウトファイル(json)をドロップ</span
+                >
+                <span class="dropzone-hint" data-i18n="dropzone.layout.hint"
+                  >またはクリックして選択</span
+                >
               </div>
               <div class="dropzone-loaded hidden" id="layout-dropzone-loaded"></div>
             </div>
@@ -84,7 +115,9 @@
             <div id="saved-files-list"></div>
           </div>
           <div id="loaded-data-info" class="loaded-data-info hidden" aria-live="polite"></div>
-          <button class="proceed-btn hidden" id="proceed-btn" data-i18n="import.proceed">集計画面へ進む →</button>
+          <button class="proceed-btn hidden" id="proceed-btn" data-i18n="import.proceed">
+            集計画面へ進む →
+          </button>
         </div>
       </div>
 
@@ -111,7 +144,9 @@
 
         <div id="error-msg" class="hidden" role="alert" aria-live="assertive"></div>
 
-        <button class="run-btn hidden" id="run-btn" disabled data-i18n="run.button">▶ 集計を実行</button>
+        <button class="run-btn hidden" id="run-btn" disabled data-i18n="run.button">
+          ▶ 集計を実行
+        </button>
       </div>
 
       <!-- AGGREGATION SCREEN: RIGHT panel -->
@@ -124,15 +159,15 @@
       </div>
     </main>
 
-    <button id="help-btn" class="help-btn" data-i18n="help.label" data-i18n-attr="aria-label" aria-label="使い方ガイド">?</button>
-
-    <div
-      id="settings-modal"
-      class="modal-overlay hidden"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="settings-title"
-    ></div>
+    <button
+      id="help-btn"
+      class="help-btn"
+      data-i18n="help.label"
+      data-i18n-attr="aria-label"
+      aria-label="使い方ガイド"
+    >
+      ?
+    </button>
 
     <div
       id="getting-started-modal"

--- a/src/components/leftPane/FileInput.ts
+++ b/src/components/leftPane/FileInput.ts
@@ -1,4 +1,5 @@
 import { parseLayout, buildLayoutMeta, type Layout, type LayoutMeta } from "../../lib/layout";
+import { t } from "../../lib/i18n";
 
 /** ドロップゾーンのdrag&dropイベントをセットアップ */
 function initDropzone(
@@ -94,7 +95,7 @@ export function initLayoutInput(
       markLoaded("layout-dropzone", "layout-dropzone-loaded", file.name);
       onLoad(layout, meta, file.name, text);
     } catch (err) {
-      onError("レイアウトファイルの読み込みエラー: " + (err as Error).message);
+      onError(t("error.layout.load", { msg: (err as Error).message }));
     }
   }
 }

--- a/src/components/leftPane/SavedFiles.ts
+++ b/src/components/leftPane/SavedFiles.ts
@@ -1,4 +1,5 @@
 import { listSaved, deleteSaved } from "../../lib/opfs";
+import { t } from "../../lib/i18n";
 
 type OnSelectCallback = (folderId: string) => void;
 
@@ -23,7 +24,7 @@ export async function refreshList(): Promise<void> {
   container.innerHTML = "";
 
   if (entries.length === 0) {
-    container.innerHTML = `<div class="saved-empty">履歴なし</div>`;
+    container.innerHTML = `<div class="saved-empty">${t("saved.empty")}</div>`;
     return;
   }
 
@@ -43,7 +44,7 @@ export async function refreshList(): Promise<void> {
     delBtn.className = "saved-item-del";
     delBtn.type = "button";
     delBtn.textContent = "×";
-    delBtn.setAttribute("aria-label", `${entry.csvName} を削除`);
+    delBtn.setAttribute("aria-label", t("saved.delete", { name: entry.csvName }));
     delBtn.addEventListener("click", async (e) => {
       e.stopPropagation();
       await deleteSaved(entry.folderId);

--- a/src/components/rightPane/AIBubble.ts
+++ b/src/components/rightPane/AIBubble.ts
@@ -1,6 +1,7 @@
 import type { AggResult } from "../../lib/aggregate";
 import type { LayoutMeta } from "../../lib/layout";
 import { isAIAvailable, generateComment } from "../../lib/aiComment";
+import { t } from "../../lib/i18n";
 
 export async function showAIBubble(
   results: AggResult[],
@@ -15,9 +16,9 @@ export async function showAIBubble(
   const bubble = document.createElement("div");
   bubble.className = "ai-bubble";
   bubble.innerHTML = `
-    <button class="ai-bubble-close" aria-label="閉じる">\u00d7</button>
-    <div class="ai-bubble-header">\u2728 AI\u5206\u6790</div>
-    <div class="ai-bubble-body ai-bubble-loading">\u5206\u6790\u4e2d...</div>
+    <button class="ai-bubble-close" aria-label="${t("ai.close")}">\u00d7</button>
+    <div class="ai-bubble-header">${t("ai.header")}</div>
+    <div class="ai-bubble-body ai-bubble-loading">${t("ai.loading")}</div>
   `;
   document.body.appendChild(bubble);
 

--- a/src/components/rightPane/AIBubble.ts
+++ b/src/components/rightPane/AIBubble.ts
@@ -2,6 +2,7 @@ import type { AggResult } from "../../lib/aggregate";
 import type { LayoutMeta } from "../../lib/layout";
 import { isAIAvailable, generateComment } from "../../lib/aiComment";
 import { t } from "../../lib/i18n";
+import { escHtml } from "../shared/escHtml";
 
 export async function showAIBubble(
   results: AggResult[],
@@ -16,7 +17,7 @@ export async function showAIBubble(
   const bubble = document.createElement("div");
   bubble.className = "ai-bubble";
   bubble.innerHTML = `
-    <button class="ai-bubble-close" aria-label="${t("ai.close")}">\u00d7</button>
+    <button class="ai-bubble-close" aria-label="${escHtml(t("ai.close"))}">\u00d7</button>
     <div class="ai-bubble-header">${t("ai.header")}</div>
     <div class="ai-bubble-body ai-bubble-loading">${t("ai.loading")}</div>
   `;

--- a/src/components/rightPane/CrossTable.ts
+++ b/src/components/rightPane/CrossTable.ts
@@ -4,6 +4,7 @@ import type { LayoutMeta } from "../../lib/layout";
 import type { pivot } from "../../lib/pivot";
 import { resolveQuestionLabel, resolveValueLabel, resolveSubLabel } from "../../lib/labelResolver";
 import { escHtml } from "../shared/escHtml";
+import { t } from "../../lib/i18n";
 
 /** Group subs by cross axis using prefixed sub values */
 function groupSubsByCrossAxis(
@@ -53,7 +54,7 @@ export function buildCrossTable(
 
   const caption = document.createElement("caption");
   caption.className = "visually-hidden";
-  caption.textContent = `${questionLabel} のクロス集計結果`;
+  caption.textContent = t("table.caption.cross", { question: questionLabel });
   table.appendChild(caption);
 
   // Build cross-axis groups
@@ -66,14 +67,14 @@ export function buildCrossTable(
 
   const thLabel = document.createElement("th");
   thLabel.rowSpan = 2;
-  thLabel.textContent = "選択肢";
+  thLabel.textContent = t("table.option");
   tr1.appendChild(thLabel);
 
   // Total column group
   const thTotal = document.createElement("th");
   thTotal.colSpan = 2;
   thTotal.className = "cross-group-header gt-group";
-  thTotal.innerHTML = `全体<br><span class="cross-n">n=${weightCol ? gtSub.n.toFixed(1) : gtSub.n.toLocaleString()}</span>`;
+  thTotal.innerHTML = `${t("table.total")}<br><span class="cross-n">n=${weightCol ? gtSub.n.toFixed(1) : gtSub.n.toLocaleString()}</span>`;
   tr1.appendChild(thTotal);
 
   if (crossGroups.length > 0) {

--- a/src/components/rightPane/GtTable.ts
+++ b/src/components/rightPane/GtTable.ts
@@ -3,6 +3,7 @@ import type { LayoutMeta } from "../../lib/layout";
 import type { pivot } from "../../lib/pivot";
 import { resolveQuestionLabel, resolveValueLabel } from "../../lib/labelResolver";
 import { escHtml } from "../shared/escHtml";
+import { t } from "../../lib/i18n";
 
 export function buildGtTable(
   res: AggResult,
@@ -17,13 +18,13 @@ export function buildGtTable(
   const table = document.createElement("table");
   table.className = "gt";
   table.innerHTML = `
-    <caption class="visually-hidden">${escHtml(questionLabel)} の集計結果</caption>
+    <caption class="visually-hidden">${t("table.caption.gt", { question: escHtml(questionLabel) })}</caption>
     <thead>
       <tr>
-        <th>選択肢</th>
+        <th>${t("table.option")}</th>
         <th class="right">n</th>
         <th class="right">%</th>
-        <th aria-hidden="true"><span class="visually-hidden">グラフ</span></th>
+        <th aria-hidden="true"><span class="visually-hidden">${t("table.graph")}</span></th>
       </tr>
     </thead>
     <tbody>

--- a/src/components/rightPane/ResultView.ts
+++ b/src/components/rightPane/ResultView.ts
@@ -3,6 +3,7 @@ import type { LayoutMeta } from "../../lib/layout";
 import { pivot } from "../../lib/pivot";
 import { resolveQuestionLabel } from "../../lib/labelResolver";
 import { escHtml } from "../shared/escHtml";
+import { t } from "../../lib/i18n";
 import { buildToolbar, buildChartOpts } from "./Toolbar";
 import { buildGtTable } from "./GtTable";
 import { buildCrossTable } from "./CrossTable";
@@ -146,7 +147,7 @@ function renderTableContent(
 
     const gtSub = pv.subs.find((s) => s.label === "GT")!;
     const nLabel = weightCol
-      ? `n=${gtSub.n.toFixed(1)}（ウェイト後）`
+      ? `n=${gtSub.n.toFixed(1)}${t("n.weighted")}`
       : `n=${gtSub.n.toLocaleString()}`;
 
     const questionLabel = resolveQuestionLabel(res.question, layoutMeta);

--- a/src/components/rightPane/Toolbar.ts
+++ b/src/components/rightPane/Toolbar.ts
@@ -2,6 +2,7 @@ import type { AggResult } from "../../lib/aggregate";
 import type { LayoutMeta } from "../../lib/layout";
 import { downloadAllCSV } from "../../lib/download";
 import { escHtml } from "../shared/escHtml";
+import { t } from "../../lib/i18n";
 import type { GtChartType } from "./ChartRenderer";
 
 type ViewMode = "table" | "chart";
@@ -22,10 +23,13 @@ export function buildToolbar(
 ): HTMLDivElement {
   const hdr = document.createElement("div");
   hdr.className = "results-header";
+  const weightText = weightCol
+    ? t("result.weight.applied", { col: escHtml(weightCol) })
+    : t("result.weight.none");
   hdr.innerHTML = `
-    <h2>${hasCross ? "クロス集計結果" : "集計結果"}</h2>
+    <h2>${hasCross ? t("result.title.cross") : t("result.title.gt")}</h2>
     <span class="results-meta">
-      ${results.length} 問  ／  ${weightCol ? "ウェイトバック適用: " + escHtml(weightCol) : "実数集計"}
+      ${t("result.meta", { count: results.length, weight: weightText })}
     </span>
   `;
 
@@ -35,11 +39,11 @@ export function buildToolbar(
   const btnTable = document.createElement("button");
   btnTable.className = `view-toggle-btn${currentViewMode === "table" ? " active" : ""}`;
   btnTable.dataset.mode = "table";
-  btnTable.textContent = "テーブル";
+  btnTable.textContent = t("result.view.table");
   const btnChart = document.createElement("button");
   btnChart.className = `view-toggle-btn${currentViewMode === "chart" ? " active" : ""}`;
   btnChart.dataset.mode = "chart";
-  btnChart.textContent = "チャート";
+  btnChart.textContent = t("result.view.chart");
   toggle.appendChild(btnTable);
   toggle.appendChild(btnChart);
 
@@ -53,7 +57,7 @@ export function buildToolbar(
   // CSV export button
   const csvBtn = document.createElement("button");
   csvBtn.className = "csv-export-btn";
-  csvBtn.textContent = "全件CSV出力";
+  csvBtn.textContent = t("result.csv.export");
   csvBtn.addEventListener("click", () => downloadAllCSV(results, weightCol, layoutMeta));
   hdr.appendChild(csvBtn);
 
@@ -74,9 +78,9 @@ export function buildChartOpts(
   const saSelect = document.createElement("select");
   saSelect.className = "chart-type-select";
   saSelect.innerHTML = `
-    <option value="bar-h"${saChartType === "bar-h" ? " selected" : ""}>横棒</option>
-    <option value="bar-v"${saChartType === "bar-v" ? " selected" : ""}>縦棒</option>
-    <option value="obi"${saChartType === "obi" ? " selected" : ""}>帯</option>
+    <option value="bar-h"${saChartType === "bar-h" ? " selected" : ""}>${t("chart.barH")}</option>
+    <option value="bar-v"${saChartType === "bar-v" ? " selected" : ""}>${t("chart.barV")}</option>
+    <option value="obi"${saChartType === "obi" ? " selected" : ""}>${t("chart.obi")}</option>
   `;
   saSelect.addEventListener("change", () => {
     callbacks.onSaChartTypeChange(saSelect.value as GtChartType);
@@ -90,9 +94,9 @@ export function buildChartOpts(
   const maSelect = document.createElement("select");
   maSelect.className = "chart-type-select";
   maSelect.innerHTML = `
-    <option value="bar-h"${maChartType === "bar-h" ? " selected" : ""}>横棒</option>
-    <option value="bar-v"${maChartType === "bar-v" ? " selected" : ""}>縦棒</option>
-    <option value="obi"${maChartType === "obi" ? " selected" : ""}>帯</option>
+    <option value="bar-h"${maChartType === "bar-h" ? " selected" : ""}>${t("chart.barH")}</option>
+    <option value="bar-v"${maChartType === "bar-v" ? " selected" : ""}>${t("chart.barV")}</option>
+    <option value="obi"${maChartType === "obi" ? " selected" : ""}>${t("chart.obi")}</option>
   `;
   maSelect.addEventListener("change", () => {
     callbacks.onMaChartTypeChange(maSelect.value as GtChartType);

--- a/src/components/screens/aggregation/AggregationScreen.ts
+++ b/src/components/screens/aggregation/AggregationScreen.ts
@@ -1,4 +1,5 @@
 import { escHtml } from "../../shared/escHtml";
+import { t } from "../../../lib/i18n";
 
 /** データ概要セクションを描画 */
 export function renderDataSummary(
@@ -8,20 +9,20 @@ export function renderDataSummary(
   const el = document.getElementById("data-summary")!;
   el.innerHTML = `
     <div class="data-summary-row">
-      <span class="data-summary-label">ローデータ</span>
+      <span class="data-summary-label">${t("summary.rawdata")}</span>
       <span class="data-summary-value">${escHtml(csv.fileName)}</span>
     </div>
     <div class="data-summary-row">
       <span class="data-summary-label"></span>
-      <span class="data-summary-value">${csv.rowCount.toLocaleString()} 行 / ${csv.headers.length} 列</span>
+      <span class="data-summary-value">${t("summary.rows", { rows: csv.rowCount.toLocaleString(), cols: csv.headers.length })}</span>
     </div>
     <div class="data-summary-row">
-      <span class="data-summary-label">レイアウト</span>
+      <span class="data-summary-label">${t("summary.layout")}</span>
       <span class="data-summary-value">${escHtml(layout.fileName)}</span>
     </div>
     <div class="data-summary-row">
       <span class="data-summary-label"></span>
-      <span class="data-summary-value">${layout.colCount} 列定義</span>
+      <span class="data-summary-value">${t("summary.colDefs", { count: layout.colCount })}</span>
     </div>
   `;
 }
@@ -30,7 +31,7 @@ export function renderDataSummary(
 export function renderWeightInfo(weightCol: string): void {
   const el = document.getElementById("weight-info")!;
   if (weightCol) {
-    el.textContent = `⚖ ウェイト列: ${weightCol}`;
+    el.textContent = t("weight.label", { col: weightCol });
     el.classList.remove("hidden");
   } else {
     el.classList.add("hidden");

--- a/src/components/shared/GettingStarted.ts
+++ b/src/components/shared/GettingStarted.ts
@@ -1,11 +1,12 @@
 import { t, onLocaleChange } from "../../lib/i18n";
+import { escHtml } from "./escHtml";
 
 const STORAGE_KEY = "temotto-getting-started-dismissed";
 
 function buildModalHTML(): string {
   return `
     <div class="modal-content" role="document">
-      <button class="modal-close" id="gs-close" aria-label="${t("gs.close")}">&times;</button>
+      <button class="modal-close" id="gs-close" aria-label="${escHtml(t("gs.close"))}">&times;</button>
       <h2 id="gs-title" class="modal-title">${t("gs.title")}</h2>
 
       <div class="modal-body">

--- a/src/components/shared/GettingStarted.ts
+++ b/src/components/shared/GettingStarted.ts
@@ -1,53 +1,44 @@
+import { t, onLocaleChange } from "../../lib/i18n";
+
 const STORAGE_KEY = "temotto-getting-started-dismissed";
 
 function buildModalHTML(): string {
   return `
     <div class="modal-content" role="document">
-      <button class="modal-close" id="gs-close" aria-label="閉じる">&times;</button>
-      <h2 id="gs-title" class="modal-title">Temottoへようこそ</h2>
+      <button class="modal-close" id="gs-close" aria-label="${t("gs.close")}">&times;</button>
+      <h2 id="gs-title" class="modal-title">${t("gs.title")}</h2>
 
       <div class="modal-body">
         <section class="modal-section">
-          <h3>インポートファイルの準備</h3>
-          <p>
-            本ツールでは、アンケートの<strong>ローデータファイル</strong>（CSV）と
-            <strong>レイアウトファイル</strong>（JSON）の2つを読み込んで集計を行います。
-          </p>
-          <p>
-            ファイルの変換・整形は<strong>ユーザーご自身</strong>で行ってください。<br>
-            専用の <strong>Agent Skill</strong> を用意していますので、
-            お使いのAIツールに変換作業を任せることができます。
-          </p>
+          <h3>${t("gs.section1.title")}</h3>
+          <p>${t("gs.section1.p1")}</p>
+          <p>${t("gs.section1.p2")}</p>
           <div class="modal-sample-downloads">
-            <p>まずは<strong>サンプルファイル</strong>で試してみましょう：</p>
+            <p>${t("gs.section1.sample")}</p>
             <div class="modal-sample-links">
               <a href="samples/sample_data.csv" download="sample_data.csv" class="modal-sample-link">
                 <span class="modal-sample-icon">&#128196;</span>
-                サンプルローデータ
+                ${t("gs.section1.sampleCsv")}
               </a>
               <a href="samples/sample_layout.json" download="sample_layout.json" class="modal-sample-link">
                 <span class="modal-sample-icon">&#128196;</span>
-                サンプルレイアウト
+                ${t("gs.section1.sampleLayout")}
               </a>
             </div>
           </div>
         </section>
 
         <section class="modal-section">
-          <h3>セキュリティについて</h3>
-          <p>
-            Temottoは<strong>完全サーバーレス</strong>で動作します。
-            すべての処理はお使いのブラウザ内で完結し、
-            アップロードしたデータが外部サーバーに送信されることは一切ありません。
-          </p>
+          <h3>${t("gs.section2.title")}</h3>
+          <p>${t("gs.section2.p1")}</p>
         </section>
 
         <section class="modal-section">
-          <h3>基本的な使い方</h3>
+          <h3>${t("gs.section3.title")}</h3>
           <ol>
-            <li>ローデータファイルとレイアウトファイルを読み込む</li>
-            <li>必要に応じてクロス集計軸を選択する</li>
-            <li>「集計を実行」ボタンをクリック</li>
+            <li>${t("gs.section3.step1")}</li>
+            <li>${t("gs.section3.step2")}</li>
+            <li>${t("gs.section3.step3")}</li>
           </ol>
         </section>
       </div>
@@ -55,9 +46,9 @@ function buildModalHTML(): string {
       <div class="modal-footer">
         <label class="modal-dismiss-label">
           <input type="checkbox" id="gs-dismiss-check">
-          今後表示しない
+          ${t("gs.dismiss")}
         </label>
-        <button class="modal-ok-btn" id="gs-ok">はじめる</button>
+        <button class="modal-ok-btn" id="gs-ok">${t("gs.ok")}</button>
       </div>
     </div>
   `;
@@ -81,13 +72,17 @@ function hide(): void {
   }
 }
 
-export function initGettingStarted(): void {
+function rebuildModal(): void {
   const modal = document.getElementById("getting-started-modal")!;
   modal.innerHTML = buildModalHTML();
-
   document.getElementById("gs-close")!.addEventListener("click", hide);
   document.getElementById("gs-ok")!.addEventListener("click", hide);
+}
 
+export function initGettingStarted(): void {
+  rebuildModal();
+
+  const modal = document.getElementById("getting-started-modal")!;
   modal.addEventListener("click", (e) => {
     if (e.target === modal) hide();
   });
@@ -99,4 +94,6 @@ export function initGettingStarted(): void {
   });
 
   document.getElementById("help-btn")!.addEventListener("click", show);
+
+  onLocaleChange(() => rebuildModal());
 }

--- a/src/components/shared/SettingsModal.ts
+++ b/src/components/shared/SettingsModal.ts
@@ -1,0 +1,150 @@
+import { t, getLocale, setLocale, onLocaleChange } from "../../lib/i18n";
+
+const THEME_KEY = "temotto-theme";
+
+type Theme = "light" | "dark" | "system";
+
+function getStoredTheme(): Theme {
+  const v = localStorage.getItem(THEME_KEY);
+  if (v === "dark" || v === "light" || v === "system") return v;
+  return "system";
+}
+
+function applyTheme(theme: Theme): void {
+  localStorage.setItem(THEME_KEY, theme);
+
+  if (theme === "system") {
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    if (prefersDark) {
+      document.documentElement.dataset.theme = "dark";
+    } else {
+      delete document.documentElement.dataset.theme;
+    }
+  } else if (theme === "dark") {
+    document.documentElement.dataset.theme = "dark";
+  } else {
+    delete document.documentElement.dataset.theme;
+  }
+}
+
+function buildModalHTML(): string {
+  const locale = getLocale();
+  const theme = getStoredTheme();
+
+  return `
+    <div class="modal-content settings-modal-content" role="document">
+      <button class="modal-close" id="settings-close" aria-label="${t("settings.close")}">&times;</button>
+      <h2 id="settings-title" class="modal-title">${t("settings.title")}</h2>
+
+      <div class="modal-body">
+        <div class="settings-group">
+          <label class="settings-label">${t("settings.language")}</label>
+          <div class="settings-options">
+            <label class="settings-radio">
+              <input type="radio" name="settings-lang" value="ja" ${locale === "ja" ? "checked" : ""}>
+              日本語
+            </label>
+            <label class="settings-radio">
+              <input type="radio" name="settings-lang" value="en" ${locale === "en" ? "checked" : ""}>
+              English
+            </label>
+          </div>
+        </div>
+
+        <div class="settings-group">
+          <label class="settings-label">${t("settings.theme")}</label>
+          <div class="settings-options">
+            <label class="settings-radio">
+              <input type="radio" name="settings-theme" value="light" ${theme === "light" ? "checked" : ""}>
+              ${t("settings.theme.light")}
+            </label>
+            <label class="settings-radio">
+              <input type="radio" name="settings-theme" value="dark" ${theme === "dark" ? "checked" : ""}>
+              ${t("settings.theme.dark")}
+            </label>
+            <label class="settings-radio">
+              <input type="radio" name="settings-theme" value="system" ${theme === "system" ? "checked" : ""}>
+              ${t("settings.theme.system")}
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+function show(): void {
+  const modal = document.getElementById("settings-modal")!;
+  modal.innerHTML = buildModalHTML();
+  modal.classList.remove("hidden");
+  document.body.style.overflow = "hidden";
+
+  // Bind events
+  document.getElementById("settings-close")!.addEventListener("click", hide);
+
+  for (const radio of modal.querySelectorAll<HTMLInputElement>('input[name="settings-lang"]')) {
+    radio.addEventListener("change", () => {
+      if (radio.checked) setLocale(radio.value);
+    });
+  }
+
+  for (const radio of modal.querySelectorAll<HTMLInputElement>('input[name="settings-theme"]')) {
+    radio.addEventListener("change", () => {
+      if (radio.checked) applyTheme(radio.value as Theme);
+    });
+  }
+}
+
+function hide(): void {
+  const modal = document.getElementById("settings-modal")!;
+  modal.classList.add("hidden");
+  document.body.style.overflow = "";
+}
+
+export function initSettings(): void {
+  // Apply saved theme on load
+  applyTheme(getStoredTheme());
+
+  // Listen for system theme changes when in "system" mode
+  window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => {
+    if (getStoredTheme() === "system") applyTheme("system");
+  });
+
+  // Settings button
+  document.getElementById("settings-btn")!.addEventListener("click", show);
+
+  // Close on overlay click
+  const modal = document.getElementById("settings-modal")!;
+  modal.addEventListener("click", (e) => {
+    if (e.target === modal) hide();
+  });
+
+  // Close on Escape
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && !modal.classList.contains("hidden")) {
+      hide();
+    }
+  });
+
+  // Rebuild modal content when locale changes (if open)
+  onLocaleChange(() => {
+    if (!modal.classList.contains("hidden")) {
+      modal.innerHTML = buildModalHTML();
+      document.getElementById("settings-close")!.addEventListener("click", hide);
+
+      for (const radio of modal.querySelectorAll<HTMLInputElement>('input[name="settings-lang"]')) {
+        radio.addEventListener("change", () => {
+          if (radio.checked) setLocale(radio.value);
+        });
+      }
+
+      for (const radio of modal.querySelectorAll<HTMLInputElement>(
+        'input[name="settings-theme"]',
+      )) {
+        radio.addEventListener("change", () => {
+          if (radio.checked) applyTheme(radio.value as Theme);
+        });
+      }
+    }
+  });
+}

--- a/src/components/shared/SettingsModal.ts
+++ b/src/components/shared/SettingsModal.ts
@@ -27,124 +27,121 @@ function applyTheme(theme: Theme): void {
   }
 }
 
-function buildModalHTML(): string {
+function buildSegment(
+  name: string,
+  options: { value: string; label: string }[],
+  current: string,
+): string {
+  const buttons = options
+    .map(
+      (o) =>
+        `<button class="seg-btn${o.value === current ? " active" : ""}" data-seg="${name}" data-value="${o.value}">${o.label}</button>`,
+    )
+    .join("");
+  return `<div class="seg-control" data-seg-name="${name}">${buttons}</div>`;
+}
+
+function buildPanelHTML(): string {
   const locale = getLocale();
   const theme = getStoredTheme();
 
   return `
-    <div class="modal-content settings-modal-content" role="document">
-      <button class="modal-close" id="settings-close" aria-label="${t("settings.close")}">&times;</button>
-      <h2 id="settings-title" class="modal-title">${t("settings.title")}</h2>
-
-      <div class="modal-body">
-        <div class="settings-group">
-          <label class="settings-label">${t("settings.language")}</label>
-          <div class="settings-options">
-            <label class="settings-radio">
-              <input type="radio" name="settings-lang" value="ja" ${locale === "ja" ? "checked" : ""}>
-              日本語
-            </label>
-            <label class="settings-radio">
-              <input type="radio" name="settings-lang" value="en" ${locale === "en" ? "checked" : ""}>
-              English
-            </label>
-          </div>
-        </div>
-
-        <div class="settings-group">
-          <label class="settings-label">${t("settings.theme")}</label>
-          <div class="settings-options">
-            <label class="settings-radio">
-              <input type="radio" name="settings-theme" value="light" ${theme === "light" ? "checked" : ""}>
-              ${t("settings.theme.light")}
-            </label>
-            <label class="settings-radio">
-              <input type="radio" name="settings-theme" value="dark" ${theme === "dark" ? "checked" : ""}>
-              ${t("settings.theme.dark")}
-            </label>
-            <label class="settings-radio">
-              <input type="radio" name="settings-theme" value="system" ${theme === "system" ? "checked" : ""}>
-              ${t("settings.theme.system")}
-            </label>
-          </div>
-        </div>
-      </div>
+    <div class="settings-group">
+      <span class="settings-label">${t("settings.language")}</span>
+      ${buildSegment(
+        "lang",
+        [
+          { value: "ja", label: "日本語" },
+          { value: "en", label: "English" },
+        ],
+        locale,
+      )}
+    </div>
+    <div class="settings-group">
+      <span class="settings-label">${t("settings.theme")}</span>
+      ${buildSegment(
+        "theme",
+        [
+          { value: "light", label: t("settings.theme.light") },
+          { value: "dark", label: t("settings.theme.dark") },
+          { value: "system", label: t("settings.theme.system") },
+        ],
+        theme,
+      )}
     </div>
   `;
 }
 
+function bindSegmentEvents(panel: HTMLElement): void {
+  panel.addEventListener("click", (e) => {
+    const btn = (e.target as HTMLElement).closest<HTMLButtonElement>(".seg-btn");
+    if (!btn) return;
+
+    const name = btn.dataset.seg!;
+    const value = btn.dataset.value!;
+
+    // Update active state
+    for (const b of panel.querySelectorAll<HTMLButtonElement>(`[data-seg="${name}"]`)) {
+      b.classList.toggle("active", b === btn);
+    }
+
+    if (name === "lang") {
+      setLocale(value);
+    } else if (name === "theme") {
+      applyTheme(value as Theme);
+    }
+  });
+}
+
+function isOpen(): boolean {
+  return !document.getElementById("settings-panel")!.classList.contains("hidden");
+}
+
 function show(): void {
-  const modal = document.getElementById("settings-modal")!;
-  modal.innerHTML = buildModalHTML();
-  modal.classList.remove("hidden");
-  document.body.style.overflow = "hidden";
-
-  // Bind events
-  document.getElementById("settings-close")!.addEventListener("click", hide);
-
-  for (const radio of modal.querySelectorAll<HTMLInputElement>('input[name="settings-lang"]')) {
-    radio.addEventListener("change", () => {
-      if (radio.checked) setLocale(radio.value);
-    });
-  }
-
-  for (const radio of modal.querySelectorAll<HTMLInputElement>('input[name="settings-theme"]')) {
-    radio.addEventListener("change", () => {
-      if (radio.checked) applyTheme(radio.value as Theme);
-    });
-  }
+  const panel = document.getElementById("settings-panel")!;
+  panel.innerHTML = buildPanelHTML();
+  panel.classList.remove("hidden");
+  bindSegmentEvents(panel);
 }
 
 function hide(): void {
-  const modal = document.getElementById("settings-modal")!;
-  modal.classList.add("hidden");
-  document.body.style.overflow = "";
+  document.getElementById("settings-panel")!.classList.add("hidden");
+}
+
+function toggle(): void {
+  if (isOpen()) {
+    hide();
+  } else {
+    show();
+  }
 }
 
 export function initSettings(): void {
-  // Apply saved theme on load
   applyTheme(getStoredTheme());
 
-  // Listen for system theme changes when in "system" mode
   window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => {
     if (getStoredTheme() === "system") applyTheme("system");
   });
 
-  // Settings button
-  document.getElementById("settings-btn")!.addEventListener("click", show);
+  document.getElementById("settings-btn")!.addEventListener("click", (e) => {
+    e.stopPropagation();
+    toggle();
+  });
 
-  // Close on overlay click
-  const modal = document.getElementById("settings-modal")!;
-  modal.addEventListener("click", (e) => {
-    if (e.target === modal) hide();
+  // Close on outside click
+  document.addEventListener("click", (e) => {
+    if (!isOpen()) return;
+    const wrap = document.querySelector(".settings-wrap")!;
+    if (!wrap.contains(e.target as Node)) hide();
   });
 
   // Close on Escape
   document.addEventListener("keydown", (e) => {
-    if (e.key === "Escape" && !modal.classList.contains("hidden")) {
-      hide();
-    }
+    if (e.key === "Escape" && isOpen()) hide();
   });
 
-  // Rebuild modal content when locale changes (if open)
+  // Rebuild panel content when locale changes (if open)
   onLocaleChange(() => {
-    if (!modal.classList.contains("hidden")) {
-      modal.innerHTML = buildModalHTML();
-      document.getElementById("settings-close")!.addEventListener("click", hide);
-
-      for (const radio of modal.querySelectorAll<HTMLInputElement>('input[name="settings-lang"]')) {
-        radio.addEventListener("change", () => {
-          if (radio.checked) setLocale(radio.value);
-        });
-      }
-
-      for (const radio of modal.querySelectorAll<HTMLInputElement>(
-        'input[name="settings-theme"]',
-      )) {
-        radio.addEventListener("change", () => {
-          if (radio.checked) applyTheme(radio.value as Theme);
-        });
-      }
-    }
+    if (isOpen()) show();
   });
 }

--- a/src/components/shared/SettingsModal.ts
+++ b/src/components/shared/SettingsModal.ts
@@ -74,6 +74,7 @@ function buildPanelHTML(): string {
 
 function bindSegmentEvents(panel: HTMLElement): void {
   panel.addEventListener("click", (e) => {
+    e.stopPropagation();
     const btn = (e.target as HTMLElement).closest<HTMLButtonElement>(".seg-btn");
     if (!btn) return;
 

--- a/src/lib/aiComment.ts
+++ b/src/lib/aiComment.ts
@@ -2,7 +2,7 @@
 
 import type { AggResult } from "./aggregate";
 import type { LayoutMeta } from "./layout";
-import { getLocale } from "./i18n";
+import { getLocale, t } from "./i18n";
 
 // Chrome Prompt API type declarations
 
@@ -43,15 +43,6 @@ export async function isAIAvailable(): Promise<boolean> {
 
 // --- Prompt Payload ---
 
-const SYSTEM_PROMPTS: Record<string, string> = {
-  ja: "あなたはアンケート分析の専門家です。回答は必ず日本語で2〜3文以内にしてください。",
-  en: "You are a survey analysis expert. Keep your response to 2-3 sentences in English.",
-};
-
-const USER_PROMPTS: Record<string, string> = {
-  ja: "上記の集計結果の注目すべき傾向を2〜3文で短く述べてください。箇条書き・見出し・提案・注意点は不要です。",
-  en: "Briefly describe notable trends in the aggregation results above in 2-3 sentences. No bullet points, headings, suggestions, or caveats.",
-};
 
 const MAX_PAYLOAD_CHARS = 3500;
 
@@ -70,11 +61,10 @@ function summarizeResults(
   weightCol: string,
   layoutMeta: LayoutMeta | undefined,
   topN: number,
-  locale: string,
 ): string {
   const lines: string[] = [];
   if (weightCol) {
-    lines.push(locale === "ja" ? `※ウェイト列: ${weightCol}` : `* Weight column: ${weightCol}`);
+    lines.push(t("ai.weight", { col: weightCol }));
   }
 
   for (const res of results) {
@@ -93,12 +83,12 @@ function summarizeResults(
     });
 
     const rest = sorted.length - topN;
-    if (rest > 0) items.push(locale === "ja" ? `...他${rest}件` : `...${rest} more`);
+    if (rest > 0) items.push(t("ai.moreItems", { count: rest }));
     lines.push("  " + items.join(", "));
   }
 
   lines.push("");
-  lines.push(USER_PROMPTS[locale] ?? USER_PROMPTS["en"]);
+  lines.push(t("ai.userPrompt"));
   return lines.join("\n");
 }
 
@@ -107,12 +97,11 @@ export function buildPromptPayload(
   weightCol: string,
   layoutMeta?: LayoutMeta,
 ): string {
-  const locale = getLocale();
   for (const topN of [5, 3, 2]) {
-    const text = summarizeResults(results, weightCol, layoutMeta, topN, locale);
+    const text = summarizeResults(results, weightCol, layoutMeta, topN);
     if (text.length <= MAX_PAYLOAD_CHARS) return text;
   }
-  return summarizeResults(results.slice(0, 20), weightCol, layoutMeta, 2, locale);
+  return summarizeResults(results.slice(0, 20), weightCol, layoutMeta, 2);
 }
 
 // --- Comment Generation ---
@@ -129,7 +118,7 @@ export async function generateComment(
     const locale = getLocale();
     const payload = buildPromptPayload(results, weightCol, layoutMeta);
     const session = await LanguageModel!.create({
-      systemPrompt: SYSTEM_PROMPTS[locale] ?? SYSTEM_PROMPTS["en"],
+      systemPrompt: t("ai.systemPrompt"),
       expectedInputs: [{ type: "text", languages: [locale] }],
       expectedOutputs: [{ type: "text", languages: [locale] }],
     });

--- a/src/lib/aiComment.ts
+++ b/src/lib/aiComment.ts
@@ -43,7 +43,6 @@ export async function isAIAvailable(): Promise<boolean> {
 
 // --- Prompt Payload ---
 
-
 const MAX_PAYLOAD_CHARS = 3500;
 
 function resolveQLabel(col: string, meta?: LayoutMeta): string {

--- a/src/lib/aiComment.ts
+++ b/src/lib/aiComment.ts
@@ -2,6 +2,7 @@
 
 import type { AggResult } from "./aggregate";
 import type { LayoutMeta } from "./layout";
+import { getLocale } from "./i18n";
 
 // Chrome Prompt API type declarations
 
@@ -42,8 +43,15 @@ export async function isAIAvailable(): Promise<boolean> {
 
 // --- Prompt Payload ---
 
-const SYSTEM_PROMPT =
-  "あなたはアンケート分析の専門家です。回答は必ず日本語で2〜3文以内にしてください。";
+const SYSTEM_PROMPTS: Record<string, string> = {
+  ja: "あなたはアンケート分析の専門家です。回答は必ず日本語で2〜3文以内にしてください。",
+  en: "You are a survey analysis expert. Keep your response to 2-3 sentences in English.",
+};
+
+const USER_PROMPTS: Record<string, string> = {
+  ja: "上記の集計結果の注目すべき傾向を2〜3文で短く述べてください。箇条書き・見出し・提案・注意点は不要です。",
+  en: "Briefly describe notable trends in the aggregation results above in 2-3 sentences. No bullet points, headings, suggestions, or caveats.",
+};
 
 const MAX_PAYLOAD_CHARS = 3500;
 
@@ -62,9 +70,12 @@ function summarizeResults(
   weightCol: string,
   layoutMeta: LayoutMeta | undefined,
   topN: number,
+  locale: string,
 ): string {
   const lines: string[] = [];
-  if (weightCol) lines.push(`※ウェイト列: ${weightCol}`);
+  if (weightCol) {
+    lines.push(locale === "ja" ? `※ウェイト列: ${weightCol}` : `* Weight column: ${weightCol}`);
+  }
 
   for (const res of results) {
     const gtCells = res.cells.filter((c) => c.sub === "GT");
@@ -82,14 +93,12 @@ function summarizeResults(
     });
 
     const rest = sorted.length - topN;
-    if (rest > 0) items.push(`...他${rest}件`);
+    if (rest > 0) items.push(locale === "ja" ? `...他${rest}件` : `...${rest} more`);
     lines.push("  " + items.join(", "));
   }
 
   lines.push("");
-  lines.push(
-    "上記の集計結果の注目すべき傾向を2〜3文で短く述べてください。箇条書き・見出し・提案・注意点は不要です。",
-  );
+  lines.push(USER_PROMPTS[locale] ?? USER_PROMPTS["en"]);
   return lines.join("\n");
 }
 
@@ -98,11 +107,12 @@ export function buildPromptPayload(
   weightCol: string,
   layoutMeta?: LayoutMeta,
 ): string {
+  const locale = getLocale();
   for (const topN of [5, 3, 2]) {
-    const text = summarizeResults(results, weightCol, layoutMeta, topN);
+    const text = summarizeResults(results, weightCol, layoutMeta, topN, locale);
     if (text.length <= MAX_PAYLOAD_CHARS) return text;
   }
-  return summarizeResults(results.slice(0, 20), weightCol, layoutMeta, 2);
+  return summarizeResults(results.slice(0, 20), weightCol, layoutMeta, 2, locale);
 }
 
 // --- Comment Generation ---
@@ -116,11 +126,12 @@ export async function generateComment(
     if (results.length === 0) return null;
     if (!(await isAIAvailable())) return null;
 
+    const locale = getLocale();
     const payload = buildPromptPayload(results, weightCol, layoutMeta);
     const session = await LanguageModel!.create({
-      systemPrompt: SYSTEM_PROMPT,
-      expectedInputs: [{ type: "text", languages: ["ja"] }],
-      expectedOutputs: [{ type: "text", languages: ["ja"] }],
+      systemPrompt: SYSTEM_PROMPTS[locale] ?? SYSTEM_PROMPTS["en"],
+      expectedInputs: [{ type: "text", languages: [locale] }],
+      expectedOutputs: [{ type: "text", languages: [locale] }],
     });
 
     try {

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,80 @@
+import ja from "../locales/ja";
+import en from "../locales/en";
+
+const STORAGE_KEY = "temotto-locale";
+const messages: Record<string, Record<string, string>> = { ja, en };
+const supportedLocales = Object.keys(messages);
+
+let currentLocale = "ja";
+const listeners: Array<(locale: string) => void> = [];
+
+/** Get translated string. Supports parameter interpolation: t("key", { name: "X" }) */
+export function t(key: string, params?: Record<string, string | number>): string {
+  let text = messages[currentLocale]?.[key] ?? messages["en"]?.[key] ?? key;
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      text = text.replaceAll(`{${k}}`, String(v));
+    }
+  }
+  return text;
+}
+
+export function getLocale(): string {
+  return currentLocale;
+}
+
+export function setLocale(locale: string): void {
+  if (!supportedLocales.includes(locale)) return;
+  if (locale === currentLocale) return;
+
+  currentLocale = locale;
+  localStorage.setItem(STORAGE_KEY, locale);
+  document.documentElement.lang = locale;
+  translateDOM();
+
+  for (const cb of listeners) cb(locale);
+}
+
+export function onLocaleChange(cb: (locale: string) => void): void {
+  listeners.push(cb);
+}
+
+/** Initialize i18n: detect locale from localStorage or browser setting */
+export function initI18n(): void {
+  const saved = localStorage.getItem(STORAGE_KEY);
+  if (saved && supportedLocales.includes(saved)) {
+    currentLocale = saved;
+  } else {
+    const browserLang = navigator.language.split("-")[0];
+    currentLocale = supportedLocales.includes(browserLang) ? browserLang : "en";
+  }
+  document.documentElement.lang = currentLocale;
+  translateDOM();
+}
+
+/**
+ * Walk DOM and update elements with data-i18n attributes.
+ * - data-i18n="key" → sets textContent
+ * - data-i18n-html="key" → sets innerHTML (for content with HTML tags)
+ * - data-i18n-attr="attrName" + data-i18n="key" → sets attribute value
+ * - data-i18n-placeholder="key" → sets placeholder attribute
+ */
+function translateDOM(): void {
+  for (const el of document.querySelectorAll<HTMLElement>("[data-i18n]")) {
+    const key = el.dataset.i18n!;
+    const attrName = el.dataset.i18nAttr;
+    if (attrName) {
+      el.setAttribute(attrName, t(key));
+    } else {
+      el.textContent = t(key);
+    }
+  }
+  for (const el of document.querySelectorAll<HTMLElement>("[data-i18n-html]")) {
+    const key = el.dataset.i18nHtml!;
+    el.innerHTML = t(key);
+  }
+  for (const el of document.querySelectorAll<HTMLElement>("[data-i18n-placeholder]")) {
+    const key = el.dataset.i18nPlaceholder!;
+    (el as HTMLInputElement).placeholder = t(key);
+  }
+}

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -77,7 +77,8 @@ const en: Record<string, string> = {
   "ai.loading": "Analyzing...",
 
   // AI Prompt
-  "ai.systemPrompt": "You are a survey analysis expert. Keep your response to 2-3 sentences in English.",
+  "ai.systemPrompt":
+    "You are a survey analysis expert. Keep your response to 2-3 sentences in English.",
   "ai.userPrompt":
     "Briefly describe notable trends in the aggregation results above in 2-3 sentences. No bullet points, headings, suggestions, or caveats.",
   "ai.weight": "* Weight column: {col}",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -76,6 +76,13 @@ const en: Record<string, string> = {
   "ai.header": "✨ AI Analysis",
   "ai.loading": "Analyzing...",
 
+  // AI Prompt
+  "ai.systemPrompt": "You are a survey analysis expert. Keep your response to 2-3 sentences in English.",
+  "ai.userPrompt":
+    "Briefly describe notable trends in the aggregation results above in 2-3 sentences. No bullet points, headings, suggestions, or caveats.",
+  "ai.weight": "* Weight column: {col}",
+  "ai.moreItems": "...{count} more",
+
   // Errors
   "error.csv.load": "Error loading raw data file: {msg}",
   "error.layout.load": "Error loading layout file: {msg}",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1,0 +1,119 @@
+const en: Record<string, string> = {
+  // Header
+  "header.subtitle": "SURVEY AGGREGATOR v0.1",
+  "header.settings": "Open settings",
+  "header.back": "Back to data import",
+
+  // DuckDB status
+  "wasm.loading": "Loading DuckDB...",
+
+  // Import screen
+  "import.title": "Load Data",
+  "import.tab.file": "From File",
+  "import.tab.saved": "From History",
+  "import.tab.label": "Data loading method",
+  "import.proceed": "Proceed to Aggregation →",
+
+  // Dropzone
+  "dropzone.csv.icon": "Raw Data",
+  "dropzone.csv.text": "Drop raw data file (csv) here",
+  "dropzone.csv.hint": "or click to select",
+  "dropzone.layout.icon": "Layout",
+  "dropzone.layout.text": "Drop layout file (json) here",
+  "dropzone.layout.hint": "or click to select",
+
+  // Saved files
+  "saved.empty": "No history",
+  "saved.delete": "Delete {name}",
+
+  // Aggregation screen
+  "section.summary": "Data Summary",
+  "section.cross": "Cross-Tabulation Axes (optional)",
+  "section.cross.label": "Cross-tabulation axis selection",
+  "summary.rawdata": "Raw Data",
+  "summary.layout": "Layout",
+  "summary.rows": "{rows} rows / {cols} cols",
+  "summary.colDefs": "{count} column defs",
+  "weight.label": "⚖ Weight column: {col}",
+
+  // Loaded info (import screen)
+  "loaded.csv": "Raw Data: {name}  —  {rows} rows / {cols} cols",
+  "loaded.layout": "Layout: {name}  —  {count} column defs",
+
+  // Run button
+  "run.button": "▶ Run Aggregation",
+
+  // Empty state
+  "empty.text": "Select cross-tabulation axes and run the aggregation",
+
+  // Results
+  "result.title.gt": "Aggregation Results",
+  "result.title.cross": "Cross-Tabulation Results",
+  "result.meta": "{count} questions  /  {weight}",
+  "result.weight.applied": "Weighted: {col}",
+  "result.weight.none": "Unweighted",
+  "result.view.table": "Table",
+  "result.view.chart": "Chart",
+  "result.csv.export": "Export All CSV",
+
+  // Chart type
+  "chart.barH": "Horizontal Bar",
+  "chart.barV": "Vertical Bar",
+  "chart.obi": "Stacked",
+
+  // Table headers
+  "table.option": "Option",
+  "table.graph": "Graph",
+  "table.total": "Total",
+  "table.caption.gt": "Aggregation results for {question}",
+  "table.caption.cross": "Cross-tabulation results for {question}",
+
+  // Weight suffix
+  "n.weighted": " (weighted)",
+
+  // AI Bubble
+  "ai.close": "Close",
+  "ai.header": "✨ AI Analysis",
+  "ai.loading": "Analyzing...",
+
+  // Errors
+  "error.csv.load": "Error loading raw data file: {msg}",
+  "error.layout.load": "Error loading layout file: {msg}",
+  "error.saved.load": "Error loading history data: {msg}",
+  "error.aggregation": "Aggregation error: {msg}",
+
+  // Getting Started modal
+  "gs.close": "Close",
+  "gs.title": "Welcome to Temotto",
+  "gs.section1.title": "Preparing Import Files",
+  "gs.section1.p1":
+    "This tool reads a <strong>raw data file</strong> (CSV) and a <strong>layout file</strong> (JSON) to perform aggregation.",
+  "gs.section1.p2":
+    "Please prepare and format the files yourself.<br>We provide a dedicated <strong>Agent Skill</strong> so you can delegate the conversion to your AI tool.",
+  "gs.section1.sample": "Try it out with <strong>sample files</strong> first:",
+  "gs.section1.sampleCsv": "Sample Raw Data",
+  "gs.section1.sampleLayout": "Sample Layout",
+  "gs.section2.title": "Security",
+  "gs.section2.p1":
+    "Temotto runs <strong>entirely serverless</strong>. All processing happens in your browser, and uploaded data is never sent to any external server.",
+  "gs.section3.title": "Basic Usage",
+  "gs.section3.step1": "Load a raw data file and a layout file",
+  "gs.section3.step2": "Select cross-tabulation axes if needed",
+  "gs.section3.step3": 'Click the "Run Aggregation" button',
+  "gs.dismiss": "Don't show again",
+  "gs.ok": "Get Started",
+
+  // Help button
+  "help.label": "User Guide",
+
+  // Settings modal
+  "settings.title": "Settings",
+  "settings.language": "Language",
+  "settings.theme": "Theme",
+  "settings.theme.light": "Light",
+  "settings.theme.dark": "Dark",
+  "settings.theme.system": "Follow system",
+  "settings.close": "Close",
+};
+
+export default en;

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -1,0 +1,119 @@
+const ja: Record<string, string> = {
+  // Header
+  "header.subtitle": "アンケート集計ツール v0.1",
+  "header.settings": "設定を開く",
+  "header.back": "データ読み込みに戻る",
+
+  // DuckDB status
+  "wasm.loading": "DuckDB 読み込み中...",
+
+  // Import screen
+  "import.title": "データ読み込み",
+  "import.tab.file": "ファイルから",
+  "import.tab.saved": "履歴から",
+  "import.tab.label": "データ読み込み方法",
+  "import.proceed": "集計画面へ進む →",
+
+  // Dropzone
+  "dropzone.csv.icon": "ローデータ",
+  "dropzone.csv.text": "ここにローデータファイル(csv)をドロップ",
+  "dropzone.csv.hint": "またはクリックして選択",
+  "dropzone.layout.icon": "レイアウト",
+  "dropzone.layout.text": "ここにレイアウトファイル(json)をドロップ",
+  "dropzone.layout.hint": "またはクリックして選択",
+
+  // Saved files
+  "saved.empty": "履歴なし",
+  "saved.delete": "{name} を削除",
+
+  // Aggregation screen
+  "section.summary": "データ概要",
+  "section.cross": "クロス集計軸（任意）",
+  "section.cross.label": "クロス集計軸の選択",
+  "summary.rawdata": "ローデータ",
+  "summary.layout": "レイアウト",
+  "summary.rows": "{rows} 行 / {cols} 列",
+  "summary.colDefs": "{count} 列定義",
+  "weight.label": "⚖ ウェイト列: {col}",
+
+  // Loaded info (import screen)
+  "loaded.csv": "ローデータ: {name}  —  {rows} 行 / {cols} 列",
+  "loaded.layout": "レイアウト: {name}  —  {count} 列定義",
+
+  // Run button
+  "run.button": "▶ 集計を実行",
+
+  // Empty state
+  "empty.text": "クロス集計軸を選んで集計を実行してください",
+
+  // Results
+  "result.title.gt": "集計結果",
+  "result.title.cross": "クロス集計結果",
+  "result.meta": "{count} 問  ／  {weight}",
+  "result.weight.applied": "ウェイトバック適用: {col}",
+  "result.weight.none": "実数集計",
+  "result.view.table": "テーブル",
+  "result.view.chart": "チャート",
+  "result.csv.export": "全件CSV出力",
+
+  // Chart type
+  "chart.barH": "横棒",
+  "chart.barV": "縦棒",
+  "chart.obi": "帯",
+
+  // Table headers
+  "table.option": "選択肢",
+  "table.graph": "グラフ",
+  "table.total": "全体",
+  "table.caption.gt": "{question} の集計結果",
+  "table.caption.cross": "{question} のクロス集計結果",
+
+  // Weight suffix
+  "n.weighted": "（ウェイト後）",
+
+  // AI Bubble
+  "ai.close": "閉じる",
+  "ai.header": "✨ AI分析",
+  "ai.loading": "分析中...",
+
+  // Errors
+  "error.csv.load": "ローデータファイルの読み込みエラー: {msg}",
+  "error.layout.load": "レイアウトファイルの読み込みエラー: {msg}",
+  "error.saved.load": "履歴データの読み込みエラー: {msg}",
+  "error.aggregation": "集計エラー: {msg}",
+
+  // Getting Started modal
+  "gs.close": "閉じる",
+  "gs.title": "Temottoへようこそ",
+  "gs.section1.title": "インポートファイルの準備",
+  "gs.section1.p1":
+    "本ツールでは、アンケートの<strong>ローデータファイル</strong>（CSV）と<strong>レイアウトファイル</strong>（JSON）の2つを読み込んで集計を行います。",
+  "gs.section1.p2":
+    "ファイルの変換・整形は<strong>ユーザーご自身</strong>で行ってください。<br>専用の <strong>Agent Skill</strong> を用意していますので、お使いのAIツールに変換作業を任せることができます。",
+  "gs.section1.sample": "まずは<strong>サンプルファイル</strong>で試してみましょう：",
+  "gs.section1.sampleCsv": "サンプルローデータ",
+  "gs.section1.sampleLayout": "サンプルレイアウト",
+  "gs.section2.title": "セキュリティについて",
+  "gs.section2.p1":
+    "Temottoは<strong>完全サーバーレス</strong>で動作します。すべての処理はお使いのブラウザ内で完結し、アップロードしたデータが外部サーバーに送信されることは一切ありません。",
+  "gs.section3.title": "基本的な使い方",
+  "gs.section3.step1": "ローデータファイルとレイアウトファイルを読み込む",
+  "gs.section3.step2": "必要に応じてクロス集計軸を選択する",
+  "gs.section3.step3": "「集計を実行」ボタンをクリック",
+  "gs.dismiss": "今後表示しない",
+  "gs.ok": "はじめる",
+
+  // Help button
+  "help.label": "使い方ガイド",
+
+  // Settings modal
+  "settings.title": "設定",
+  "settings.language": "言語",
+  "settings.theme": "テーマ",
+  "settings.theme.light": "ライト",
+  "settings.theme.dark": "ダーク",
+  "settings.theme.system": "システム設定に従う",
+  "settings.close": "閉じる",
+};
+
+export default ja;

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -76,6 +76,13 @@ const ja: Record<string, string> = {
   "ai.header": "✨ AI分析",
   "ai.loading": "分析中...",
 
+  // AI Prompt
+  "ai.systemPrompt": "あなたはアンケート分析の専門家です。回答は必ず日本語で2〜3文以内にしてください。",
+  "ai.userPrompt":
+    "上記の集計結果の注目すべき傾向を2〜3文で短く述べてください。箇条書き・見出し・提案・注意点は不要です。",
+  "ai.weight": "※ウェイト列: {col}",
+  "ai.moreItems": "...他{count}件",
+
   // Errors
   "error.csv.load": "ローデータファイルの読み込みエラー: {msg}",
   "error.layout.load": "レイアウトファイルの読み込みエラー: {msg}",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -77,7 +77,8 @@ const ja: Record<string, string> = {
   "ai.loading": "分析中...",
 
   // AI Prompt
-  "ai.systemPrompt": "あなたはアンケート分析の専門家です。回答は必ず日本語で2〜3文以内にしてください。",
+  "ai.systemPrompt":
+    "あなたはアンケート分析の専門家です。回答は必ず日本語で2〜3文以内にしてください。",
   "ai.userPrompt":
     "上記の集計結果の注目すべき傾向を2〜3文で短く述べてください。箇条書き・見出し・提案・注意点は不要です。",
   "ai.weight": "※ウェイト列: {col}",

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,18 +12,22 @@ import {
 import { saveData, loadSaved } from "./lib/opfs";
 import { initSavedFiles, refreshList } from "./components/leftPane/SavedFiles";
 import { initGettingStarted } from "./components/shared/GettingStarted";
+import { initSettings } from "./components/shared/SettingsModal";
 import { showProceedButton } from "./components/screens/import/ImportScreen";
 import {
   renderDataSummary,
   renderWeightInfo,
 } from "./components/screens/aggregation/AggregationScreen";
+import { initI18n, onLocaleChange, t } from "./lib/i18n";
+
+// Initialize i18n first (before any UI rendering)
+initI18n();
 
 // Currently loaded CSV / Layout data
 let currentCsv: { text: string; fileName: string; headers: string[]; rowCount: number } | null =
   null;
 let currentLayout: { json: string; fileName: string; meta: LayoutMeta } | null = null;
 
-// 画面切り替え
 function switchScreen(screen: "import" | "aggregation"): void {
   const main = document.querySelector("main")!;
   main.dataset.screen = screen;
@@ -32,32 +36,7 @@ function switchScreen(screen: "import" | "aggregation"): void {
   backBtn.classList.toggle("hidden", screen === "import");
 }
 
-// テーマ切り替え
-function initThemeToggle(): void {
-  const toggle = document.getElementById("theme-toggle")!;
-  const saved = localStorage.getItem("temotto-theme");
-  if (saved === "dark") {
-    document.documentElement.dataset.theme = "dark";
-    toggle.textContent = "☀️";
-    toggle.setAttribute("aria-label", "ライトモードに切り替え");
-  }
-  toggle.addEventListener("click", () => {
-    const isDark = document.documentElement.dataset.theme === "dark";
-    if (isDark) {
-      delete document.documentElement.dataset.theme;
-      toggle.textContent = "🌙";
-      toggle.setAttribute("aria-label", "ダークモードに切り替え");
-      localStorage.setItem("temotto-theme", "light");
-    } else {
-      document.documentElement.dataset.theme = "dark";
-      toggle.textContent = "☀️";
-      toggle.setAttribute("aria-label", "ライトモードに切り替え");
-      localStorage.setItem("temotto-theme", "dark");
-    }
-  });
-}
-
-initThemeToggle();
+initSettings();
 initGettingStarted();
 
 // Start DuckDB Wasm initialization in the background
@@ -76,13 +55,10 @@ function initAfterBothLoaded(): void {
   document.getElementById("run-btn")!.classList.remove("hidden");
   (document.getElementById("run-btn") as HTMLButtonElement).disabled = false;
 
-  // インポート画面: 「集計画面へ進む」ボタンを表示
   showProceedButton();
 
-  // 読み込み済みデータ情報を表示（インポート画面用）
   updateLoadedInfo();
 
-  // 集計画面: データ概要・ウェイト情報を描画
   renderDataSummary(
     {
       fileName: currentCsv.fileName,
@@ -100,7 +76,6 @@ function initAfterBothLoaded(): void {
   renderWeightInfo(weightCol);
 }
 
-// 読み込み済みデータ情報を表示（インポート画面用）
 function updateLoadedInfo(): void {
   const el = document.getElementById("loaded-data-info")!;
   if (!currentCsv && !currentLayout) {
@@ -110,17 +85,45 @@ function updateLoadedInfo(): void {
   const lines: string[] = [];
   if (currentCsv) {
     lines.push(
-      `ローデータ: ${currentCsv.fileName}  —  ${currentCsv.rowCount.toLocaleString()} 行 / ${currentCsv.headers.length} 列`,
+      t("loaded.csv", {
+        name: currentCsv.fileName,
+        rows: currentCsv.rowCount.toLocaleString(),
+        cols: currentCsv.headers.length,
+      }),
     );
   }
   if (currentLayout) {
     lines.push(
-      `レイアウト: ${currentLayout.fileName}  —  ${Object.keys(currentLayout.meta.colTypes).length} 列定義`,
+      t("loaded.layout", {
+        name: currentLayout.fileName,
+        count: Object.keys(currentLayout.meta.colTypes).length,
+      }),
     );
   }
   el.textContent = lines.join("\n");
   el.classList.remove("hidden");
 }
+
+// Re-render locale-sensitive parts when language changes
+onLocaleChange(() => {
+  updateLoadedInfo();
+  if (currentCsv && currentLayout) {
+    renderDataSummary(
+      {
+        fileName: currentCsv.fileName,
+        rowCount: currentCsv.rowCount,
+        headers: currentCsv.headers,
+      },
+      {
+        fileName: currentLayout.fileName,
+        colCount: Object.keys(currentLayout.meta.colTypes).length,
+      },
+    );
+    const weightCol =
+      Object.entries(currentLayout.meta.colTypes).find(([, t]) => t === "weight")?.[0] ?? "";
+    renderWeightInfo(weightCol);
+  }
+});
 
 // Auto-save to OPFS when both CSV and layout are loaded
 async function trySaveToOPFS(): Promise<void> {
@@ -148,7 +151,7 @@ async function onCSVLoaded(csvText: string, fileName: string): Promise<void> {
     initAfterBothLoaded();
     trySaveToOPFS();
   } catch (e) {
-    showError("ローデータファイルの読み込みエラー: " + (e as Error).message);
+    showError(t("error.csv.load", { msg: (e as Error).message }));
   }
 }
 
@@ -185,7 +188,7 @@ async function loadFromSaved(folderId: string): Promise<void> {
     updateLoadedInfo();
     initAfterBothLoaded();
   } catch (e) {
-    showError("履歴データの読み込みエラー: " + (e as Error).message);
+    showError(t("error.saved.load", { msg: (e as Error).message }));
   }
 }
 
@@ -218,7 +221,7 @@ async function runAggregation(): Promise<void> {
     });
     renderResults(results, weightCol, currentCsv.rowCount, currentLayout.meta, crossCols);
   } catch (e) {
-    showError("集計エラー: " + (e as Error).message);
+    showError(t("error.aggregation", { msg: (e as Error).message }));
     console.error(e);
   }
 }
@@ -270,10 +273,9 @@ initLayoutInput(onLayoutLoaded, (msg) => showError(msg));
 initSavedFiles(loadFromSaved);
 
 document.getElementById("run-btn")!.addEventListener("click", () => {
-  runAggregation().catch((e) => showError("集計エラー: " + (e as Error).message));
+  runAggregation().catch((e) => showError(t("error.aggregation", { msg: (e as Error).message })));
 });
 
-// 画面遷移ボタン
 document.getElementById("proceed-btn")!.addEventListener("click", () => {
   switchScreen("aggregation");
 });

--- a/src/style.css
+++ b/src/style.css
@@ -256,7 +256,7 @@ header span {
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-lg);
   padding: var(--space-4);
-  min-width: 240px;
+  width: 300px;
   z-index: 100;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -223,7 +223,7 @@ header span {
   justify-content: flex-end;
 }
 
-.theme-toggle {
+.settings-btn {
   background: transparent;
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
@@ -237,9 +237,51 @@ header span {
   color: var(--text);
 }
 
-.theme-toggle:hover {
+.settings-btn:hover {
   background: var(--surface2);
   border-color: var(--border-strong);
+}
+
+/* Settings modal */
+.settings-modal-content {
+  max-width: 400px;
+}
+
+.settings-group {
+  margin-bottom: var(--space-5);
+}
+
+.settings-group:last-child {
+  margin-bottom: 0;
+}
+
+.settings-label {
+  display: block;
+  font-weight: 600;
+  font-size: var(--text-sm);
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: var(--space-3);
+}
+
+.settings-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+.settings-radio {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  cursor: pointer;
+  font-size: var(--text-sm);
+  color: var(--text);
+}
+
+.settings-radio input[type="radio"] {
+  accent-color: var(--accent);
 }
 
 .status-dot {

--- a/src/style.css
+++ b/src/style.css
@@ -223,6 +223,10 @@ header span {
   justify-content: flex-end;
 }
 
+.settings-wrap {
+  position: relative;
+}
+
 .settings-btn {
   background: transparent;
   border: 1px solid var(--border);
@@ -242,13 +246,22 @@ header span {
   border-color: var(--border-strong);
 }
 
-/* Settings modal */
-.settings-modal-content {
-  max-width: 400px;
+/* Settings dropdown panel */
+.settings-panel {
+  position: absolute;
+  top: calc(100% + var(--space-2));
+  right: 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  padding: var(--space-4);
+  min-width: 240px;
+  z-index: 100;
 }
 
 .settings-group {
-  margin-bottom: var(--space-5);
+  margin-bottom: var(--space-4);
 }
 
 .settings-group:last-child {
@@ -258,30 +271,46 @@ header span {
 .settings-label {
   display: block;
   font-weight: 600;
-  font-size: var(--text-sm);
+  font-size: var(--text-xs);
   color: var(--muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  margin-bottom: var(--space-3);
+  margin-bottom: var(--space-2);
 }
 
-.settings-options {
+/* Segment control */
+.seg-control {
   display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-3);
+  background: var(--surface2);
+  border-radius: var(--radius-md);
+  padding: 2px;
+  gap: 2px;
 }
 
-.settings-radio {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
+.seg-btn {
+  flex: 1;
+  padding: var(--space-1) var(--space-3);
+  border: none;
+  border-radius: calc(var(--radius-md) - 2px);
+  background: transparent;
+  color: var(--muted);
+  font-size: var(--text-xs);
   cursor: pointer;
-  font-size: var(--text-sm);
+  transition:
+    background 0.15s,
+    color 0.15s,
+    box-shadow 0.15s;
+  white-space: nowrap;
+}
+
+.seg-btn:hover {
   color: var(--text);
 }
 
-.settings-radio input[type="radio"] {
-  accent-color: var(--accent);
+.seg-btn.active {
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
 .status-dot {


### PR DESCRIPTION
## Summary
- 自前i18nモジュールによる日本語/英語の多言語対応を実装（ブラウザ言語設定での自動判定 + 手動切り替え）
- ヘッダー右の歯車アイコンからドロップダウンパネルで言語・テーマ（ライト/ダーク/システム）を即時切り替え可能に
- AI分析コメントも言語設定に連動して日本語/英語で生成

## Test plan
- [ ] 日本語ブラウザで初回アクセス時に日本語UIが表示されること
- [ ] 英語ブラウザで初回アクセス時に英語UIが表示されること
- [ ] 設定パネルで言語を切り替えるとUI全体が即時反映されること
- [ ] 設定パネルでテーマ（ライト/ダーク/システム）を切り替えると即時反映されること
- [ ] リロード後もlocalStorageから言語・テーマが復元されること
- [ ] 集計実行後の結果テーブル・ツールバーが選択言語で表示されること
- [ ] 「使い方ガイド」モーダルが選択言語で表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)