### PR TITLE
feat: 設定パネルにAI分析コメントのON/OFFトグルを追加

### DIFF
--- a/src/components/rightPane/AIBubble.ts
+++ b/src/components/rightPane/AIBubble.ts
@@ -1,15 +1,16 @@
 import type { AggResult } from "../../lib/agg/aggregate";
 import type { LayoutMeta } from "../../lib/layout";
-import { isAIAvailable, generateComment } from "../../lib/aiComment";
+import { generateComment } from "../../lib/aiComment";
 import { t } from "../../lib/i18n";
 import { escHtml } from "../shared/escHtml";
+import { isAICommentEnabled } from "../shared/SettingsModal";
 
 export async function showAIBubble(
   results: AggResult[],
   weightCol: string,
   layoutMeta?: LayoutMeta,
 ): Promise<void> {
-  if (!(await isAIAvailable())) return;
+  if (!isAICommentEnabled()) return;
 
   // Remove existing bubble if any
   document.querySelector(".ai-bubble")?.remove();

--- a/src/components/shared/SettingsModal.ts
+++ b/src/components/shared/SettingsModal.ts
@@ -1,8 +1,17 @@
 import { t, getLocale, setLocale, onLocaleChange } from "../../lib/i18n";
 
 const THEME_KEY = "temotto-theme";
+const AI_KEY = "temotto-ai-comment";
 
 type Theme = "light" | "dark" | "system";
+
+export function isAICommentEnabled(): boolean {
+  return localStorage.getItem(AI_KEY) !== "off";
+}
+
+function setAIComment(on: boolean): void {
+  localStorage.setItem(AI_KEY, on ? "on" : "off");
+}
 
 function getStoredTheme(): Theme {
   const v = localStorage.getItem(THEME_KEY);
@@ -41,11 +50,11 @@ function buildSegment(
   return `<div class="seg-control" data-seg-name="${name}">${buttons}</div>`;
 }
 
-function buildPanelHTML(): string {
+async function buildPanelHTML(): Promise<string> {
   const locale = getLocale();
   const theme = getStoredTheme();
 
-  return `
+  let html = `
     <div class="settings-group">
       <span class="settings-label">${t("settings.language")}</span>
       ${buildSegment(
@@ -70,6 +79,25 @@ function buildPanelHTML(): string {
       )}
     </div>
   `;
+
+  if (typeof LanguageModel !== "undefined" && (await LanguageModel.availability()) !== "no") {
+    const aiVal = isAICommentEnabled() ? "on" : "off";
+    html += `
+    <div class="settings-group">
+      <span class="settings-label">${t("settings.ai")}</span>
+      ${buildSegment(
+        "ai",
+        [
+          { value: "on", label: t("settings.ai.on") },
+          { value: "off", label: t("settings.ai.off") },
+        ],
+        aiVal,
+      )}
+    </div>
+    `;
+  }
+
+  return html;
 }
 
 function bindSegmentEvents(panel: HTMLElement): void {
@@ -90,6 +118,8 @@ function bindSegmentEvents(panel: HTMLElement): void {
       setLocale(value);
     } else if (name === "theme") {
       applyTheme(value as Theme);
+    } else if (name === "ai") {
+      setAIComment(value === "on");
     }
   });
 }
@@ -98,9 +128,9 @@ function isOpen(): boolean {
   return !document.getElementById("settings-panel")!.classList.contains("hidden");
 }
 
-function show(): void {
+async function show(): Promise<void> {
   const panel = document.getElementById("settings-panel")!;
-  panel.innerHTML = buildPanelHTML();
+  panel.innerHTML = await buildPanelHTML();
   panel.classList.remove("hidden");
   bindSegmentEvents(panel);
 }

--- a/src/lib/aiComment.ts
+++ b/src/lib/aiComment.ts
@@ -29,18 +29,6 @@ declare global {
   var LanguageModel: LanguageModelStatic | undefined;
 }
 
-// --- Feature Detection ---
-
-export async function isAIAvailable(): Promise<boolean> {
-  try {
-    if (typeof LanguageModel === "undefined") return false;
-    const status = await LanguageModel.availability();
-    return status !== "no";
-  } catch {
-    return false;
-  }
-}
-
 // --- Prompt Payload ---
 
 const MAX_PAYLOAD_CHARS = 3500;
@@ -112,7 +100,6 @@ export async function generateComment(
 ): Promise<string | null> {
   try {
     if (results.length === 0) return null;
-    if (!(await isAIAvailable())) return null;
 
     const locale = getLocale();
     const payload = buildPromptPayload(results, weightCol, layoutMeta);

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -121,6 +121,9 @@ const en: Record<string, string> = {
   "settings.theme.light": "Light",
   "settings.theme.dark": "Dark",
   "settings.theme.system": "Follow system",
+  "settings.ai": "AI Analysis Comment",
+  "settings.ai.on": "ON",
+  "settings.ai.off": "OFF",
   "settings.close": "Close",
 };
 

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -121,6 +121,9 @@ const ja: Record<string, string> = {
   "settings.theme.light": "ライト",
   "settings.theme.dark": "ダーク",
   "settings.theme.system": "システム設定に従う",
+  "settings.ai": "AI分析コメント",
+  "settings.ai.on": "ON",
+  "settings.ai.off": "OFF",
   "settings.close": "閉じる",
 };
 


### PR DESCRIPTION
## Summary
- 設定パネルにAI分析コメントのON/OFFトグルを追加（Chrome Built-in AI対応ブラウザでのみ表示）
- OFFにすると集計実行時のAIバブル生成をスキップ
- `isAIAvailable`をaiComment.tsからSettingsModalにインライン化し、責務を整理

## Test plan
- [ ] Chrome Built-in AI対応ブラウザで設定パネルにAIトグルが表示されることを確認
- [ ] 非対応ブラウザではトグルが表示されないことを確認
- [ ] ONの状態で集計実行→AIバブルが表示されることを確認
- [ ] OFFの状態で集計実行→AIバブルが表示されないことを確認
- [ ] 設定がlocalStorageに永続化されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)