### PR TITLE
refactor: UI表示の簡素化と統一

### DIFF
--- a/src/components/rightPane/ResultView.tsx
+++ b/src/components/rightPane/ResultView.tsx
@@ -4,7 +4,6 @@ import type { AggResult, QuestionDef } from "../../lib/agg/aggregate";
 import type { LayoutMeta } from "../../lib/layout";
 import { pivot } from "../../lib/agg/pivot";
 import { resolveQuestionLabel } from "../../lib/labelResolver";
-import { t } from "../../lib/i18n";
 import { Toolbar, ViewOpts, type PctDirection, type ViewMode } from "./Toolbar";
 import { GtTable } from "./GtTable";
 import { CrossTable } from "./CrossTable";
@@ -144,7 +143,7 @@ function TableContent({
 
         const gtSub = pv.subs.find((s) => s.label === "GT")!;
         const nLabel = weightCol
-          ? `n=${gtSub.n.toFixed(1)}${t("n.weighted")}`
+          ? `n=${gtSub.n.toFixed(1)}`
           : `n=${gtSub.n.toLocaleString()}`;
 
         const questionLabel = resolveQuestionLabel(res.question, layoutMeta);

--- a/src/components/rightPane/Toolbar.tsx
+++ b/src/components/rightPane/Toolbar.tsx
@@ -24,7 +24,6 @@ interface ToolbarProps {
 }
 
 export function Toolbar({
-  hasCross,
   results,
   weightCol,
   currentViewMode,
@@ -37,7 +36,7 @@ export function Toolbar({
 
   return (
     <div class="results-header">
-      <h2>{hasCross ? t("result.title.cross") : t("result.title.gt")}</h2>
+      <h2>{t("result.title.gt")}</h2>
       <span class="results-meta">
         {t("result.meta", { count: results.length, weight: weightText })}
       </span>

--- a/src/components/screens/aggregation/AggregationScreen.tsx
+++ b/src/components/screens/aggregation/AggregationScreen.tsx
@@ -10,23 +10,16 @@ function DataSummary({
 }) {
   return (
     <>
-      <div class="data-summary-row">
-        <span class="data-summary-label">{t("summary.rawdata")}</span>
+      <div class="data-summary-row indent">
         <span class="data-summary-value">{csv.fileName}</span>
       </div>
-      <div class="data-summary-row">
-        <span class="data-summary-label" />
+      <div class="data-summary-row indent">
+        <span class="data-summary-value">{layout.fileName}</span>
+      </div>
+      <div class="data-summary-row indent">
         <span class="data-summary-value">
           {t("summary.rows", { rows: csv.rowCount.toLocaleString(), cols: csv.headers.length })}
         </span>
-      </div>
-      <div class="data-summary-row">
-        <span class="data-summary-label">{t("summary.layout")}</span>
-        <span class="data-summary-value">{layout.fileName}</span>
-      </div>
-      <div class="data-summary-row">
-        <span class="data-summary-label" />
-        <span class="data-summary-value">{t("summary.colDefs", { count: layout.colCount })}</span>
       </div>
     </>
   );

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -28,12 +28,9 @@ const en: Record<string, string> = {
 
   // Aggregation screen
   "section.summary": "Data Summary",
-  "section.cross": "Cross-Tabulation Axes (optional)",
+  "section.cross": "Cross-Tabulation Axes",
   "section.cross.label": "Cross-tabulation axis selection",
-  "summary.rawdata": "Raw Data",
-  "summary.layout": "Layout",
-  "summary.rows": "{rows} rows / {cols} cols",
-  "summary.colDefs": "{count} column defs",
+  "summary.rows": "{rows} rows {cols} cols",
   "weight.label": "Weight-back ({col})",
   "weight.on": "ON",
   "weight.off": "OFF",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -35,10 +35,6 @@ const en: Record<string, string> = {
   "weight.on": "ON",
   "weight.off": "OFF",
 
-  // Loaded info (import screen)
-  "loaded.csv": "Raw Data: {name}  —  {rows} rows / {cols} cols",
-  "loaded.layout": "Layout: {name}  —  {count} column defs",
-
   // Run button
   "run.button": "▶ Run Aggregation",
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -43,7 +43,6 @@ const en: Record<string, string> = {
 
   // Results
   "result.title.gt": "Aggregation Results",
-  "result.title.cross": "Cross-Tabulation Results",
   "result.meta": "{count} questions  /  {weight}",
   "result.weight.applied": "Weighted: {col}",
   "result.weight.none": "Unweighted",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -65,9 +65,6 @@ const en: Record<string, string> = {
   "table.caption.gt": "Aggregation results for {question}",
   "table.caption.cross": "Cross-tabulation results for {question}",
 
-  // Weight suffix
-  "n.weighted": " (weighted)",
-
   // AI Bubble
   "ai.close": "Close",
   "ai.header": "✨ AI Analysis",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -28,12 +28,9 @@ const ja: Record<string, string> = {
 
   // Aggregation screen
   "section.summary": "データ概要",
-  "section.cross": "クロス集計軸（任意）",
+  "section.cross": "クロス集計軸",
   "section.cross.label": "クロス集計軸の選択",
-  "summary.rawdata": "ローデータ",
-  "summary.layout": "レイアウト",
-  "summary.rows": "{rows} 行 / {cols} 列",
-  "summary.colDefs": "{count} 列定義",
+  "summary.rows": "{rows} 行 {cols} 列",
   "weight.label": "ウェイトバック ({col})",
   "weight.on": "ON",
   "weight.off": "OFF",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -35,10 +35,6 @@ const ja: Record<string, string> = {
   "weight.on": "ON",
   "weight.off": "OFF",
 
-  // Loaded info (import screen)
-  "loaded.csv": "ローデータ: {name}  —  {rows} 行 / {cols} 列",
-  "loaded.layout": "レイアウト: {name}  —  {count} 列定義",
-
   // Run button
   "run.button": "▶ 集計を実行",
 

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -43,7 +43,6 @@ const ja: Record<string, string> = {
 
   // Results
   "result.title.gt": "集計結果",
-  "result.title.cross": "クロス集計結果",
   "result.meta": "{count} 問  ／  {weight}",
   "result.weight.applied": "ウェイトバック適用: {col}",
   "result.weight.none": "実数集計",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -65,9 +65,6 @@ const ja: Record<string, string> = {
   "table.caption.gt": "{question} の集計結果",
   "table.caption.cross": "{question} のクロス集計結果",
 
-  // Weight suffix
-  "n.weighted": "（ウェイト後）",
-
   // AI Bubble
   "ai.close": "閉じる",
   "ai.header": "✨ AI分析",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -85,19 +85,16 @@ function updateLoadedInfo(): void {
   }
   const lines: string[] = [];
   if (currentCsv) {
-    lines.push(
-      t("loaded.csv", {
-        name: currentCsv.fileName,
-        rows: currentCsv.rowCount.toLocaleString(),
-        cols: currentCsv.headers.length,
-      }),
-    );
+    lines.push(currentCsv.fileName);
   }
   if (currentLayout) {
+    lines.push(currentLayout.fileName);
+  }
+  if (currentCsv) {
     lines.push(
-      t("loaded.layout", {
-        name: currentLayout.fileName,
-        count: Object.keys(currentLayout.meta.colTypes).length,
+      t("summary.rows", {
+        rows: currentCsv.rowCount.toLocaleString(),
+        cols: currentCsv.headers.length,
       }),
     );
   }

--- a/src/style.css
+++ b/src/style.css
@@ -479,13 +479,8 @@ main[data-screen="import"] ~ .help-btn {
   margin-bottom: var(--space-1);
 }
 
-.data-summary-label {
-  font-size: var(--text-xs);
-  color: var(--muted);
-  min-width: 5rem;
-  flex-shrink: 0;
-  font-weight: 700;
-  letter-spacing: 0.04em;
+.data-summary-row.indent {
+  padding-left: var(--space-4);
 }
 
 .data-summary-value {


### PR DESCRIPTION
## Summary
- データ概要欄をファイル名2行+行列数1行の3行表示に簡素化
- インポート画面のファイル情報表示を集計画面と同じ形式に統一
- ウェイト後nラベルから「（ウェイト後）」表記を削除
- 結果タイトルをGT/クロス共通で「集計結果」に統一
- 不要になった翻訳キー・CSS・importを削除（-59行）

## Test plan
- [ ] CSV+レイアウト読み込み後、インポート画面にファイル名+行列数が3行で表示される
- [ ] 集計画面のデータ概要欄が同じ形式で表示される
- [ ] ウェイト適用時に `n=13.8` のみ表示される（「ウェイト後」なし）
- [ ] GT集計・クロス集計ともに「集計結果」と表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)