### PR TITLE
refactor: インポート画面を左右2カラムレイアウトに刷新

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,76 +48,50 @@
       <div id="import-screen" class="import-screen">
         <div class="import-card">
           <h2 class="import-card-title" data-i18n="import.title">データ読み込み</h2>
-          <div
-            class="load-tabs"
-            role="tablist"
-            data-i18n="import.tab.label"
-            data-i18n-attr="aria-label"
-            aria-label="データ読み込み方法"
-          >
-            <button
-              class="load-tab active"
-              role="tab"
-              aria-selected="true"
-              aria-controls="tab-file"
-              id="tab-btn-file"
-              data-tab="file"
-              data-i18n="import.tab.file"
-            >
-              ファイルから
-            </button>
-            <button
-              class="load-tab"
-              role="tab"
-              aria-selected="false"
-              aria-controls="tab-saved"
-              id="tab-btn-saved"
-              data-tab="saved"
-              data-i18n="import.tab.saved"
-            >
-              履歴から
-            </button>
-          </div>
-          <div class="load-tab-panel" id="tab-file" role="tabpanel" aria-labelledby="tab-btn-file">
-            <div class="dropzone" id="csv-dropzone" data-accept=".csv">
-              <input type="file" id="file-input" accept=".csv" class="dropzone-input" />
-              <div class="dropzone-content">
-                <span class="dropzone-icon" data-i18n="dropzone.csv.icon">ローデータ</span>
-                <span class="dropzone-text" data-i18n="dropzone.csv.text"
-                  >ここにローデータファイル(csv)をドロップ</span
-                >
-                <span class="dropzone-hint" data-i18n="dropzone.csv.hint"
-                  >またはクリックして選択</span
-                >
+          <div class="import-layout">
+            <!-- 左パネル: 入力エリア -->
+            <div class="import-input">
+              <div class="dropzone-row">
+                <div class="dropzone" id="csv-dropzone" data-accept=".csv">
+                  <input type="file" id="file-input" accept=".csv" class="dropzone-input" />
+                  <div class="dropzone-content">
+                    <span class="dropzone-icon" data-i18n="dropzone.csv.icon">ローデータ</span>
+                    <span class="dropzone-text" data-i18n="dropzone.csv.text"
+                      >ここにローデータファイル(csv)をドロップ</span
+                    >
+                    <span class="dropzone-hint" data-i18n="dropzone.csv.hint"
+                      >またはクリックして選択</span
+                    >
+                  </div>
+                  <div class="dropzone-loaded hidden" id="csv-dropzone-loaded"></div>
+                </div>
+                <div class="dropzone" id="layout-dropzone" data-accept=".json">
+                  <input type="file" id="layout-file-input" accept=".json" class="dropzone-input" />
+                  <div class="dropzone-content">
+                    <span class="dropzone-icon" data-i18n="dropzone.layout.icon">レイアウト</span>
+                    <span class="dropzone-text" data-i18n="dropzone.layout.text"
+                      >ここにレイアウトファイル(json)をドロップ</span
+                    >
+                    <span class="dropzone-hint" data-i18n="dropzone.layout.hint"
+                      >またはクリックして選択</span
+                    >
+                  </div>
+                  <div class="dropzone-loaded hidden" id="layout-dropzone-loaded"></div>
+                </div>
               </div>
-              <div class="dropzone-loaded hidden" id="csv-dropzone-loaded"></div>
+              <div class="import-history">
+                <h3 class="import-history-title" data-i18n="import.history">履歴</h3>
+                <div class="import-history-list" id="saved-files-list"></div>
+              </div>
             </div>
-            <div class="dropzone" id="layout-dropzone" data-accept=".json">
-              <input type="file" id="layout-file-input" accept=".json" class="dropzone-input" />
-              <div class="dropzone-content">
-                <span class="dropzone-icon" data-i18n="dropzone.layout.icon">レイアウト</span>
-                <span class="dropzone-text" data-i18n="dropzone.layout.text"
-                  >ここにレイアウトファイル(json)をドロップ</span
-                >
-                <span class="dropzone-hint" data-i18n="dropzone.layout.hint"
-                  >またはクリックして選択</span
-                >
-              </div>
-              <div class="dropzone-loaded hidden" id="layout-dropzone-loaded"></div>
+            <!-- 右パネル: プレビュー -->
+            <div class="import-preview">
+              <div id="loaded-data-info" class="loaded-data-info hidden" aria-live="polite"></div>
+              <button class="proceed-btn hidden" id="proceed-btn" data-i18n="import.proceed">
+                集計画面へ進む →
+              </button>
             </div>
           </div>
-          <div
-            class="load-tab-panel hidden"
-            id="tab-saved"
-            role="tabpanel"
-            aria-labelledby="tab-btn-saved"
-          >
-            <div id="saved-files-list"></div>
-          </div>
-          <div id="loaded-data-info" class="loaded-data-info hidden" aria-live="polite"></div>
-          <button class="proceed-btn hidden" id="proceed-btn" data-i18n="import.proceed">
-            集計画面へ進む →
-          </button>
         </div>
       </div>
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -9,9 +9,7 @@ const en: Record<string, string> = {
 
   // Import screen
   "import.title": "Load Data",
-  "import.tab.file": "From File",
-  "import.tab.saved": "From History",
-  "import.tab.label": "Data loading method",
+  "import.history": "History",
   "import.proceed": "Proceed to Aggregation →",
 
   // Dropzone

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -9,9 +9,7 @@ const ja: Record<string, string> = {
 
   // Import screen
   "import.title": "データ読み込み",
-  "import.tab.file": "ファイルから",
-  "import.tab.saved": "履歴から",
-  "import.tab.label": "データ読み込み方法",
+  "import.history": "履歴",
   "import.proceed": "集計画面へ進む →",
 
   // Dropzone

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -225,47 +225,6 @@ async function runAggregation(): Promise<void> {
   }
 }
 
-// Tab switching
-const tabs = Array.from(document.querySelectorAll<HTMLButtonElement>(".load-tab"));
-
-function activateTab(tab: HTMLButtonElement): void {
-  for (const t of tabs) {
-    const isActive = t === tab;
-    t.classList.toggle("active", isActive);
-    t.setAttribute("aria-selected", String(isActive));
-    t.tabIndex = isActive ? 0 : -1;
-  }
-  const target = tab.dataset.tab!;
-  document.getElementById("tab-file")!.classList.toggle("hidden", target !== "file");
-  document.getElementById("tab-saved")!.classList.toggle("hidden", target !== "saved");
-  tab.focus();
-}
-
-// Set inactive tabs to tabIndex=-1
-for (const t of tabs) {
-  if (!t.classList.contains("active")) t.tabIndex = -1;
-}
-
-for (const tab of tabs) {
-  tab.addEventListener("click", () => activateTab(tab));
-  tab.addEventListener("keydown", (e: KeyboardEvent) => {
-    const idx = tabs.indexOf(tab);
-    if (e.key === "ArrowRight" || e.key === "ArrowDown") {
-      e.preventDefault();
-      activateTab(tabs[(idx + 1) % tabs.length]);
-    } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
-      e.preventDefault();
-      activateTab(tabs[(idx - 1 + tabs.length) % tabs.length]);
-    } else if (e.key === "Home") {
-      e.preventDefault();
-      activateTab(tabs[0]);
-    } else if (e.key === "End") {
-      e.preventDefault();
-      activateTab(tabs[tabs.length - 1]);
-    }
-  });
-}
-
 // Event binding
 initCsvInput(onCSVLoaded, (msg) => showError(msg));
 initLayoutInput(onLayoutLoaded, (msg) => showError(msg));

--- a/src/style.css
+++ b/src/style.css
@@ -410,7 +410,7 @@ main[data-screen="import"] ~ .help-btn {
   box-shadow: var(--shadow-md);
   padding: var(--space-8);
   width: 100%;
-  max-width: 480px;
+  max-width: 720px;
 }
 
 .import-card-title {
@@ -418,6 +418,63 @@ main[data-screen="import"] ~ .help-btn {
   font-weight: 700;
   color: var(--text);
   margin-bottom: var(--space-5);
+}
+
+.import-layout {
+  display: flex;
+  gap: var(--space-6);
+}
+
+.import-input {
+  flex: 1;
+  min-width: 0;
+}
+
+.dropzone-row {
+  display: flex;
+  gap: var(--space-3);
+}
+
+.dropzone-row .dropzone {
+  flex: 1;
+  margin-top: 0;
+}
+
+.import-history {
+  margin-top: var(--space-5);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--border);
+}
+
+.import-history-title {
+  font-size: var(--text-sm);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  margin-bottom: var(--space-3);
+}
+
+.import-history-list {
+  max-height: 160px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.import-preview {
+  width: 200px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.import-preview .loaded-data-info {
+  margin-top: 0;
+}
+
+.import-preview .proceed-btn {
+  margin-top: auto;
 }
 
 .proceed-btn {
@@ -520,6 +577,15 @@ main[data-screen="import"] ~ .help-btn {
   .import-card {
     max-width: 100%;
   }
+  .import-layout {
+    flex-direction: column;
+  }
+  .import-preview {
+    width: 100%;
+  }
+  .dropzone-row {
+    flex-direction: column;
+  }
 }
 
 /* === Left Panel === */
@@ -545,48 +611,6 @@ main[data-screen="import"] ~ .help-btn {
   margin-bottom: var(--space-3);
 }
 
-/* Load Tabs */
-.load-tabs {
-  display: flex;
-  gap: 0;
-  margin-bottom: var(--space-3);
-}
-
-.load-tab {
-  flex: 1;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  color: var(--text-secondary);
-  font-family: var(--font-family-base);
-  font-size: var(--text-base);
-  font-weight: 500;
-  padding: var(--space-2) 0;
-  cursor: pointer;
-  transition:
-    background 0.15s,
-    color 0.15s,
-    border-color 0.15s;
-}
-
-.load-tab:first-child {
-  border-radius: var(--radius-sm) 0 0 var(--radius-sm);
-}
-.load-tab:last-child {
-  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
-  border-left: none;
-}
-
-.load-tab.active {
-  background: var(--accent);
-  color: var(--accent-contrast);
-  border-color: var(--accent);
-}
-
-.load-tab-panel {
-  height: 250px;
-  overflow-y: auto;
-}
-
 /* Dropzone */
 .dropzone {
   position: relative;
@@ -599,10 +623,6 @@ main[data-screen="import"] ~ .help-btn {
     border-color 0.15s,
     background 0.15s;
   margin-top: var(--space-3);
-}
-
-.dropzone:first-child {
-  margin-top: 0;
 }
 
 .dropzone:hover {


### PR DESCRIPTION
## Summary
- タブUI（「ファイルから」「履歴から」）を廃止し、左右2カラムの1画面構成に変更
- 左パネル: CSVとJSONのドロップゾーンを横並び配置 + その下に履歴リストを直接表示
- 右パネル: ファイル情報プレビュー + 「集計画面へ進む」ボタン
- タブ切替ロジック（main.tsx ~40行）と関連CSS/i18nキーを削除

## Test plan
- [ ] ドロップゾーンにCSV/JSONをドロップして右パネルにファイル情報が表示されることを確認
- [ ] 履歴から選択しても同じく右パネルに反映されることを確認
- [ ] 両ファイル読み込み後「集計画面へ進む」ボタンが表示され、遷移できることを確認
- [ ] モバイル幅（768px以下）で縦積みレイアウトにフォールバックすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)