### PR TITLE
refactor: ImportScreenに読み込み責務を移動

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,29 +1,17 @@
 import { useCallback, useEffect, useState } from "preact/hooks";
-import { initDuckDB, loadCSV } from "./lib/duckdbBridge";
-import { parseLayout, buildLayoutMeta, type Layout, type LayoutMeta } from "./lib/layout";
-import { saveData, loadSaved } from "./lib/opfs";
-import { triggerSavedFilesRefresh } from "./components/leftPane/SavedFiles";
+import { initDuckDB } from "./lib/duckdbBridge";
 import { initGettingStarted } from "./components/shared/GettingStarted";
 import { initSettings } from "./components/shared/SettingsModal";
 import ImportScreen from "./components/screens/import/ImportScreen";
 import AggregationScreen from "./components/screens/aggregation/AggregationScreen";
 import { onLocaleChange, t } from "./lib/i18n";
 import { mountStatusDot } from "./components/shared/StatusDot";
-
-type CsvData = { text: string; fileName: string; headers: string[]; rowCount: number };
-type LayoutData = { json: string; fileName: string; meta: LayoutMeta };
-
-// Module-level state (will be converted to useState in later phases)
-let currentCsv: CsvData | null = null;
-let currentLayout: LayoutData | null = null;
+import type { CsvData, LayoutData } from "./lib/types";
 
 export default function App() {
   const [screen, setScreen] = useState<"import" | "aggregation">("import");
   const [, setTick] = useState(0);
-  const [csvFileName, setCsvFileName] = useState<string | null>(null);
-  const [layoutFileName, setLayoutFileName] = useState<string | null>(null);
-  const [showProceed, setShowProceed] = useState(false);
-  const [loadedInfo, setLoadedInfo] = useState<string | null>(null);
+  const [loadedData, setLoadedData] = useState<{ csv: CsvData; layout: LayoutData } | null>(null);
   const isImport = screen === "import";
 
   // Re-render on locale change
@@ -31,97 +19,9 @@ export default function App() {
     onLocaleChange(() => setTick((n) => n + 1));
   }, []);
 
-  function updateLoadedInfo(): void {
-    if (!currentCsv && !currentLayout) {
-      setLoadedInfo(null);
-      return;
-    }
-    const lines: string[] = [];
-    if (currentCsv) lines.push(currentCsv.fileName);
-    if (currentLayout) lines.push(currentLayout.fileName);
-    if (currentCsv) {
-      lines.push(
-        t("summary.rows", {
-          rows: currentCsv.rowCount.toLocaleString(),
-          cols: currentCsv.headers.length,
-        }),
-      );
-    }
-    setLoadedInfo(lines.join("\n"));
-  }
-
-  function checkBothLoaded(): void {
-    if (!currentCsv || !currentLayout) return;
-    setShowProceed(true);
-    updateLoadedInfo();
-  }
-
-  async function trySaveToOPFS(): Promise<void> {
-    if (!currentCsv || !currentLayout) return;
-    try {
-      await saveData(
-        currentCsv.fileName,
-        currentCsv.text,
-        currentLayout.fileName,
-        currentLayout.json,
-      );
-      triggerSavedFilesRefresh();
-    } catch (e) {
-      console.warn("OPFS save failed:", e);
-    }
-  }
-
-  const onCsvFile = useCallback(async (csvText: string, fileName: string) => {
-    try {
-      const result = await loadCSV(csvText);
-      currentCsv = {
-        text: csvText,
-        fileName,
-        headers: result.headers,
-        rowCount: result.rowCount,
-      };
-      setCsvFileName(fileName);
-      updateLoadedInfo();
-      checkBothLoaded();
-      trySaveToOPFS();
-    } catch (e) {
-      console.error("CSV load failed:", e);
-    }
-  }, []);
-
-  const onLayoutFile = useCallback(
-    (_layout: Layout, meta: LayoutMeta, fileName: string, rawText: string) => {
-      currentLayout = { json: rawText, fileName, meta };
-      setLayoutFileName(fileName);
-      updateLoadedInfo();
-      checkBothLoaded();
-      trySaveToOPFS();
-    },
-    [],
-  );
-
-  const onLoadFromSaved = useCallback(async (folderId: string) => {
-    try {
-      const { csvText, csvName, layoutJson, layoutName } = await loadSaved(folderId);
-      const layout = parseLayout(layoutJson);
-      const meta = buildLayoutMeta(layout);
-      const result = await loadCSV(csvText);
-
-      currentCsv = {
-        text: csvText,
-        fileName: csvName,
-        headers: result.headers,
-        rowCount: result.rowCount,
-      };
-      currentLayout = { json: layoutJson, fileName: layoutName, meta };
-
-      setCsvFileName(csvName);
-      setLayoutFileName(layoutName);
-      updateLoadedInfo();
-      checkBothLoaded();
-    } catch (e) {
-      console.error("Saved data load failed:", e);
-    }
+  const handleComplete = useCallback((csv: CsvData, layout: LayoutData) => {
+    setLoadedData({ csv, layout });
+    setScreen("aggregation");
   }, []);
 
   // Imperative initialization (runs once after mount)
@@ -168,19 +68,9 @@ export default function App() {
         style={{ gridTemplateColumns: isImport ? "1fr" : "360px 1fr" }}
       >
         {isImport ? (
-          <ImportScreen
-            csvFileName={csvFileName}
-            layoutFileName={layoutFileName}
-            showProceed={showProceed}
-            loadedInfo={loadedInfo}
-            onCsvFile={onCsvFile}
-            onLayoutFile={onLayoutFile}
-            onLoadFromSaved={onLoadFromSaved}
-            onProceed={() => setScreen("aggregation")}
-          />
+          <ImportScreen onComplete={handleComplete} />
         ) : (
-          currentCsv &&
-          currentLayout && <AggregationScreen csv={currentCsv} layout={currentLayout} />
+          loadedData && <AggregationScreen csv={loadedData.csv} layout={loadedData.layout} />
         )}
       </main>
 

--- a/src/components/screens/aggregation/AggregationScreen.tsx
+++ b/src/components/screens/aggregation/AggregationScreen.tsx
@@ -6,9 +6,7 @@ import { buildQuestionDefs, type LayoutMeta } from "../../../lib/layout";
 import { questionKey, type AggResult, type QuestionDef } from "../../../lib/agg/aggregate";
 import { t } from "../../../lib/i18n";
 import { ToggleButton, ToggleGroup } from "../../shared/ToggleButton";
-
-type CsvData = { text: string; fileName: string; headers: string[]; rowCount: number };
-type LayoutData = { json: string; fileName: string; meta: LayoutMeta };
+import type { CsvData, LayoutData } from "../../../lib/types";
 
 interface AggregationScreenProps {
   csv: CsvData;

--- a/src/components/screens/import/ImportScreen.tsx
+++ b/src/components/screens/import/ImportScreen.tsx
@@ -1,21 +1,17 @@
 import { useCallback, useRef, useState } from "preact/hooks";
 import type { JSX } from "preact";
-import { parseLayout, buildLayoutMeta, type Layout, type LayoutMeta } from "../../../lib/layout";
+import { parseLayout, buildLayoutMeta } from "../../../lib/layout";
+import { loadCSV } from "../../../lib/duckdbBridge";
+import { saveData, loadSaved } from "../../../lib/opfs";
 import { t } from "../../../lib/i18n";
 import { Dropzone } from "./Dropzone";
-import { SavedFilesList, useSavedFiles } from "../../leftPane/SavedFiles";
+import { SavedFilesList, triggerSavedFilesRefresh, useSavedFiles } from "../../leftPane/SavedFiles";
+import type { CsvData, LayoutData } from "../../../lib/types";
 
 type Tab = "file" | "saved";
 
 interface ImportScreenProps {
-  csvFileName: string | null;
-  layoutFileName: string | null;
-  showProceed: boolean;
-  loadedInfo: string | null;
-  onCsvFile: (csvText: string, fileName: string) => void;
-  onLayoutFile: (layout: Layout, meta: LayoutMeta, fileName: string, rawText: string) => void;
-  onLoadFromSaved: (folderId: string) => void;
-  onProceed: () => void;
+  onComplete: (csv: CsvData, layout: LayoutData) => void;
 }
 
 const TABS: { key: Tab; labelKey: string }[] = [
@@ -23,38 +19,121 @@ const TABS: { key: Tab; labelKey: string }[] = [
   { key: "saved", labelKey: "import.tab.saved" },
 ];
 
-export default function ImportScreen({
-  csvFileName,
-  layoutFileName,
-  showProceed,
-  loadedInfo,
-  onCsvFile,
-  onLayoutFile,
-  onLoadFromSaved,
-  onProceed,
-}: ImportScreenProps) {
+export default function ImportScreen({ onComplete }: ImportScreenProps) {
   const [activeTab, setActiveTab] = useState<Tab>("file");
+  const [csvFileName, setCsvFileName] = useState<string | null>(null);
+  const [layoutFileName, setLayoutFileName] = useState<string | null>(null);
+  const [showProceed, setShowProceed] = useState(false);
+  const [loadedInfo, setLoadedInfo] = useState<string | null>(null);
+
   const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const csvRef = useRef<CsvData | null>(null);
+  const layoutRef = useRef<LayoutData | null>(null);
 
   const { entries, deleteEntry } = useSavedFiles();
 
-  const handleCsvFile = useCallback(
-    async (file: File) => {
-      const text = await file.text();
-      onCsvFile(text, file.name);
-    },
-    [onCsvFile],
-  );
+  function updateLoadedInfo(): void {
+    const csv = csvRef.current;
+    const layout = layoutRef.current;
+    if (!csv && !layout) {
+      setLoadedInfo(null);
+      return;
+    }
+    const lines: string[] = [];
+    if (csv) lines.push(csv.fileName);
+    if (layout) lines.push(layout.fileName);
+    if (csv) {
+      lines.push(
+        t("summary.rows", {
+          rows: csv.rowCount.toLocaleString(),
+          cols: csv.headers.length,
+        }),
+      );
+    }
+    setLoadedInfo(lines.join("\n"));
+  }
 
-  const handleLayoutFile = useCallback(
-    async (file: File) => {
+  function checkBothLoaded(): void {
+    if (!csvRef.current || !layoutRef.current) return;
+    setShowProceed(true);
+    updateLoadedInfo();
+  }
+
+  async function trySaveToOPFS(): Promise<void> {
+    const csv = csvRef.current;
+    const layout = layoutRef.current;
+    if (!csv || !layout) return;
+    try {
+      await saveData(csv.fileName, csv.text, layout.fileName, layout.json);
+      triggerSavedFilesRefresh();
+    } catch (e) {
+      console.warn("OPFS save failed:", e);
+    }
+  }
+
+  const handleCsvFile = useCallback(async (file: File) => {
+    try {
+      const text = await file.text();
+      const result = await loadCSV(text);
+      csvRef.current = {
+        text,
+        fileName: file.name,
+        headers: result.headers,
+        rowCount: result.rowCount,
+      };
+      setCsvFileName(file.name);
+      updateLoadedInfo();
+      checkBothLoaded();
+      trySaveToOPFS();
+    } catch (e) {
+      console.error("CSV load failed:", e);
+    }
+  }, []);
+
+  const handleLayoutFile = useCallback(async (file: File) => {
+    try {
       const text = await file.text();
       const layout = parseLayout(text);
       const meta = buildLayoutMeta(layout);
-      onLayoutFile(layout, meta, file.name, text);
-    },
-    [onLayoutFile],
-  );
+      layoutRef.current = { json: text, fileName: file.name, meta };
+      setLayoutFileName(file.name);
+      updateLoadedInfo();
+      checkBothLoaded();
+      trySaveToOPFS();
+    } catch (e) {
+      console.error("Layout load failed:", e);
+    }
+  }, []);
+
+  const handleLoadFromSaved = useCallback(async (folderId: string) => {
+    try {
+      const { csvText, csvName, layoutJson, layoutName } = await loadSaved(folderId);
+      const layout = parseLayout(layoutJson);
+      const meta = buildLayoutMeta(layout);
+      const result = await loadCSV(csvText);
+
+      csvRef.current = {
+        text: csvText,
+        fileName: csvName,
+        headers: result.headers,
+        rowCount: result.rowCount,
+      };
+      layoutRef.current = { json: layoutJson, fileName: layoutName, meta };
+
+      setCsvFileName(csvName);
+      setLayoutFileName(layoutName);
+      updateLoadedInfo();
+      checkBothLoaded();
+    } catch (e) {
+      console.error("Saved data load failed:", e);
+    }
+  }, []);
+
+  function handleProceed(): void {
+    if (csvRef.current && layoutRef.current) {
+      onComplete(csvRef.current, layoutRef.current);
+    }
+  }
 
   function activateTab(idx: number) {
     setActiveTab(TABS[idx].key);
@@ -145,7 +224,7 @@ export default function ImportScreen({
           <div class="flex flex-col gap-2">
             <SavedFilesList
               entries={entries}
-              onSelectEntry={onLoadFromSaved}
+              onSelectEntry={handleLoadFromSaved}
               onDeleteEntry={deleteEntry}
             />
           </div>
@@ -165,7 +244,7 @@ export default function ImportScreen({
         {showProceed && (
           <button
             class="mt-5 min-h-12 w-full cursor-pointer rounded-lg border-none bg-accent px-4 py-3 text-base font-bold tracking-[0.02em] text-accent-contrast transition-[background] duration-150 hover:bg-accent-hover active:bg-[var(--color-primary-900)]"
-            onClick={onProceed}
+            onClick={handleProceed}
           >
             {t("import.proceed")}
           </button>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,4 @@
+import type { LayoutMeta } from "./layout";
+
+export type CsvData = { text: string; fileName: string; headers: string[]; rowCount: number };
+export type LayoutData = { json: string; fileName: string; meta: LayoutMeta };


### PR DESCRIPTION
## Summary
- ImportScreenのpropsを8個→1個(`onComplete`)に削減
- CSV読み込み・レイアウト解析・OPFS保存・保存データ読み込みのロジックをApp.tsxからImportScreenに移動
- `CsvData`/`LayoutData`の重複型定義を`src/lib/types.ts`に共通化

## Test plan
- [ ] `npm run check` パス確認済み
- [ ] `npm run test` パス確認済み
- [ ] CSVアップロード → レイアウトアップロード → 情報表示 → 進むボタン → 集計画面表示
- [ ] 保存済みデータからの読み込み
- [ ] 戻るボタン → 再アップロード

🤖 Generated with [Claude Code](https://claude.com/claude-code)