### PR TITLE
refactor: オーケストレーターをcomponents/直下に移動

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,9 +2,9 @@ import { useCallback, useEffect, useState } from "preact/hooks";
 import { initDuckDB } from "./lib/duckdbBridge";
 import { initGettingStarted } from "./components/import/GettingStarted";
 import { initTheme } from "./components/header/SettingsModal";
-import Header from "./components/header/Header";
-import ImportScreen from "./components/import/ImportScreen";
-import AggregationScreen from "./components/aggregation/AggregationScreen";
+import Header from "./components/Header";
+import ImportScreen from "./components/ImportScreen";
+import AggregationScreen from "./components/AggregationScreen";
 import { onLocaleChange, t } from "./lib/i18n";
 import type { CsvData, LayoutData } from "./lib/types";
 

--- a/src/components/AggregationScreen.tsx
+++ b/src/components/AggregationScreen.tsx
@@ -1,12 +1,12 @@
 import { useState } from "preact/hooks";
-import CrossConfig from "./CrossConfig";
-import ResultView from "./ResultView";
-import { runDuckDBAggregation } from "../../lib/duckdbBridge";
-import { buildQuestionDefs, type LayoutMeta } from "../../lib/layout";
-import { questionKey, type AggResult, type QuestionDef } from "../../lib/agg/aggregate";
-import { t } from "../../lib/i18n";
-import { ToggleButton, ToggleGroup } from "../shared/ToggleButton";
-import type { CsvData, LayoutData } from "../../lib/types";
+import CrossConfig from "./aggregation/CrossConfig";
+import ResultView from "./aggregation/ResultView";
+import { runDuckDBAggregation } from "../lib/duckdbBridge";
+import { buildQuestionDefs, type LayoutMeta } from "../lib/layout";
+import { questionKey, type AggResult, type QuestionDef } from "../lib/agg/aggregate";
+import { t } from "../lib/i18n";
+import { ToggleButton, ToggleGroup } from "./shared/ToggleButton";
+import type { CsvData, LayoutData } from "../lib/types";
 
 interface AggregationScreenProps {
   csv: CsvData;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,6 @@
-import { t } from "../../lib/i18n";
-import { SettingsRoot } from "./SettingsModal";
-import WasmStatus from "./WasmStatus";
+import { t } from "../lib/i18n";
+import { SettingsRoot } from "./header/SettingsModal";
+import WasmStatus from "./header/WasmStatus";
 
 interface HeaderProps {
   isImport: boolean;

--- a/src/components/ImportScreen.tsx
+++ b/src/components/ImportScreen.tsx
@@ -1,12 +1,12 @@
 import { useCallback, useRef, useState } from "preact/hooks";
 import type { JSX } from "preact";
-import { parseLayout, buildLayoutMeta } from "../../lib/layout";
-import { loadCSV } from "../../lib/duckdbBridge";
-import { saveData, loadSaved } from "../../lib/opfs";
-import { t } from "../../lib/i18n";
-import { Dropzone } from "./Dropzone";
-import { SavedFilesList, triggerSavedFilesRefresh, useSavedFiles } from "./SavedFiles";
-import type { CsvData, LayoutData } from "../../lib/types";
+import { parseLayout, buildLayoutMeta } from "../lib/layout";
+import { loadCSV } from "../lib/duckdbBridge";
+import { saveData, loadSaved } from "../lib/opfs";
+import { t } from "../lib/i18n";
+import { Dropzone } from "./import/Dropzone";
+import { SavedFilesList, triggerSavedFilesRefresh, useSavedFiles } from "./import/SavedFiles";
+import type { CsvData, LayoutData } from "../lib/types";
 
 type Tab = "file" | "saved";
 


### PR DESCRIPTION
## Summary
- `ImportScreen.tsx`, `AggregationScreen.tsx`, `Header.tsx` をサブディレクトリから `components/` 直下に移動
- サブディレクトリには部品コンポーネントのみ残す構成に変更
- `components/` を開いた瞬間にオーケストレーターが一覧できるようになる

## Test plan
- [x] `pnpm check` (fmt, lint, tsc) パス
- [x] `pnpm test` (64テスト) パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)