### PR TITLE
refactor: ImportScreenのUI要素をサブコンポーネントに分割

### DIFF
--- a/src/components/ImportScreen.tsx
+++ b/src/components/ImportScreen.tsx
@@ -1,10 +1,13 @@
 import { useCallback, useRef, useState } from "preact/hooks";
-import type { JSX } from "preact";
 import { parseLayout, buildLayoutMeta } from "../lib/layout";
 import { loadCSV } from "../lib/duckdbBridge";
 import { saveData, loadSaved } from "../lib/opfs";
 import { t } from "../lib/i18n";
-import { Dropzone } from "./import/Dropzone";
+
+import { TabBar } from "./import/TabBar";
+import { FileUploadPanel } from "./import/FileUploadPanel";
+import { HelpButton } from "./import/HelpButton";
+import { LoadedInfo } from "./import/LoadedInfo";
 import { SavedFilesList, triggerSavedFilesRefresh, useSavedFiles } from "./import/SavedFiles";
 import { GettingStartedModal } from "./import/GettingStarted";
 import type { CsvData, LayoutData } from "../lib/types";
@@ -28,7 +31,6 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
   const [loadedInfo, setLoadedInfo] = useState<string | null>(null);
   const [gsOpen, setGsOpen] = useState(false);
 
-  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const csvRef = useRef<CsvData | null>(null);
   const layoutRef = useRef<LayoutData | null>(null);
 
@@ -137,57 +139,12 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
     }
   }
 
-  function activateTab(idx: number) {
-    setActiveTab(TABS[idx].key);
-    tabRefs.current[idx]?.focus();
-  }
-
-  function handleTabKeyDown(e: JSX.TargetedKeyboardEvent<HTMLButtonElement>, idx: number) {
-    const len = TABS.length;
-    if (e.key === "ArrowRight" || e.key === "ArrowDown") {
-      e.preventDefault();
-      activateTab((idx + 1) % len);
-    } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
-      e.preventDefault();
-      activateTab((idx - 1 + len) % len);
-    } else if (e.key === "Home") {
-      e.preventDefault();
-      activateTab(0);
-    } else if (e.key === "End") {
-      e.preventDefault();
-      activateTab(len - 1);
-    }
-  }
-
   return (
     <div class="flex items-center justify-center p-6">
       <div class="w-full max-w-[480px] rounded-xl border border-border bg-surface p-8 shadow-md">
         <h2 class="mb-5 text-xl font-bold text-text">{t("import.title")}</h2>
 
-        {/* Tabs */}
-        <div class="mb-3 flex" role="tablist" aria-label={t("import.tab.label")}>
-          {TABS.map((tab, i) => {
-            const isActive = activeTab === tab.key;
-            return (
-              <button
-                key={tab.key}
-                ref={(el) => {
-                  tabRefs.current[i] = el;
-                }}
-                class="flex-1 cursor-pointer border border-border bg-surface px-0 py-2 text-[0.875rem] font-medium text-text-secondary transition-[background,color,border-color] duration-150 first:rounded-l-sm last:rounded-r-sm last:border-l-0 data-[active=true]:border-accent data-[active=true]:bg-accent data-[active=true]:text-accent-contrast"
-                role="tab"
-                aria-selected={isActive}
-                aria-controls={`tab-${tab.key}`}
-                data-active={String(isActive)}
-                tabIndex={isActive ? 0 : -1}
-                onClick={() => setActiveTab(tab.key)}
-                onKeyDown={(e) => handleTabKeyDown(e, i)}
-              >
-                {t(tab.labelKey)}
-              </button>
-            );
-          })}
-        </div>
+        <TabBar tabs={TABS} activeTab={activeTab} onTabChange={(key) => setActiveTab(key as Tab)} />
 
         {/* File Tab */}
         <div
@@ -196,24 +153,12 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
           role="tabpanel"
           aria-labelledby="tab-btn-file"
         >
-          <Dropzone
-            accept=".csv"
-            icon={t("dropzone.csv.icon")}
-            text={t("dropzone.csv.text")}
-            hint={t("dropzone.csv.hint")}
-            loadedFileName={csvFileName}
-            onFile={handleCsvFile}
+          <FileUploadPanel
+            csvFileName={csvFileName}
+            layoutFileName={layoutFileName}
+            onCsvFile={handleCsvFile}
+            onLayoutFile={handleLayoutFile}
           />
-          <div class="mt-3">
-            <Dropzone
-              accept=".json"
-              icon={t("dropzone.layout.icon")}
-              text={t("dropzone.layout.text")}
-              hint={t("dropzone.layout.hint")}
-              loadedFileName={layoutFileName}
-              onFile={handleLayoutFile}
-            />
-          </div>
         </div>
 
         {/* Saved Tab */}
@@ -232,15 +177,7 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
           </div>
         </div>
 
-        {/* Loaded data info */}
-        {loadedInfo && (
-          <div
-            class="mt-3 whitespace-pre-line rounded-lg border border-accent-light bg-accent-bg px-4 py-3 text-[0.875rem] leading-normal text-text-secondary"
-            aria-live="polite"
-          >
-            {loadedInfo}
-          </div>
-        )}
+        <LoadedInfo info={loadedInfo} />
 
         {/* Proceed button */}
         {showProceed && (
@@ -253,14 +190,7 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
         )}
       </div>
 
-      {/* Help Button */}
-      <button
-        class="fixed bottom-5 left-5 z-900 flex h-10 w-10 cursor-pointer items-center justify-center rounded-full border-[1.5px] border-border-strong bg-surface text-base font-bold text-text-secondary shadow-[0_2px_8px_rgba(0,0,0,0.12)] transition-[background,color,transform] duration-150 hover:scale-[1.08] hover:border-[var(--color-primary-500)] hover:bg-[var(--color-primary-50)] hover:text-[var(--color-primary-700)]"
-        aria-label={t("help.label")}
-        onClick={() => setGsOpen(true)}
-      >
-        ?
-      </button>
+      <HelpButton onClick={() => setGsOpen(true)} />
 
       {/* Getting Started Modal */}
       <GettingStartedModal open={gsOpen} onClose={() => setGsOpen(false)} />

--- a/src/components/import/FileUploadPanel.tsx
+++ b/src/components/import/FileUploadPanel.tsx
@@ -1,0 +1,39 @@
+import { t } from "../../lib/i18n";
+import { Dropzone } from "./Dropzone";
+
+interface FileUploadPanelProps {
+  csvFileName: string | null;
+  layoutFileName: string | null;
+  onCsvFile: (file: File) => void;
+  onLayoutFile: (file: File) => void;
+}
+
+export function FileUploadPanel({
+  csvFileName,
+  layoutFileName,
+  onCsvFile,
+  onLayoutFile,
+}: FileUploadPanelProps) {
+  return (
+    <>
+      <Dropzone
+        accept=".csv"
+        icon={t("dropzone.csv.icon")}
+        text={t("dropzone.csv.text")}
+        hint={t("dropzone.csv.hint")}
+        loadedFileName={csvFileName}
+        onFile={onCsvFile}
+      />
+      <div class="mt-3">
+        <Dropzone
+          accept=".json"
+          icon={t("dropzone.layout.icon")}
+          text={t("dropzone.layout.text")}
+          hint={t("dropzone.layout.hint")}
+          loadedFileName={layoutFileName}
+          onFile={onLayoutFile}
+        />
+      </div>
+    </>
+  );
+}

--- a/src/components/import/HelpButton.tsx
+++ b/src/components/import/HelpButton.tsx
@@ -1,0 +1,17 @@
+import { t } from "../../lib/i18n";
+
+interface HelpButtonProps {
+  onClick: () => void;
+}
+
+export function HelpButton({ onClick }: HelpButtonProps) {
+  return (
+    <button
+      class="fixed bottom-5 left-5 z-900 flex h-10 w-10 cursor-pointer items-center justify-center rounded-full border-[1.5px] border-border-strong bg-surface text-base font-bold text-text-secondary shadow-[0_2px_8px_rgba(0,0,0,0.12)] transition-[background,color,transform] duration-150 hover:scale-[1.08] hover:border-[var(--color-primary-500)] hover:bg-[var(--color-primary-50)] hover:text-[var(--color-primary-700)]"
+      aria-label={t("help.label")}
+      onClick={onClick}
+    >
+      ?
+    </button>
+  );
+}

--- a/src/components/import/LoadedInfo.tsx
+++ b/src/components/import/LoadedInfo.tsx
@@ -1,0 +1,16 @@
+interface LoadedInfoProps {
+  info: string | null;
+}
+
+export function LoadedInfo({ info }: LoadedInfoProps) {
+  if (!info) return null;
+
+  return (
+    <div
+      class="mt-3 whitespace-pre-line rounded-lg border border-accent-light bg-accent-bg px-4 py-3 text-[0.875rem] leading-normal text-text-secondary"
+      aria-live="polite"
+    >
+      {info}
+    </div>
+  );
+}

--- a/src/components/import/TabBar.tsx
+++ b/src/components/import/TabBar.tsx
@@ -1,0 +1,66 @@
+import { useRef } from "preact/hooks";
+import type { JSX } from "preact";
+import { t } from "../../lib/i18n";
+
+interface TabDef {
+  key: string;
+  labelKey: string;
+}
+
+interface TabBarProps {
+  tabs: TabDef[];
+  activeTab: string;
+  onTabChange: (key: string) => void;
+}
+
+export function TabBar({ tabs, activeTab, onTabChange }: TabBarProps) {
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  function activateTab(idx: number) {
+    onTabChange(tabs[idx].key);
+    tabRefs.current[idx]?.focus();
+  }
+
+  function handleKeyDown(e: JSX.TargetedKeyboardEvent<HTMLButtonElement>, idx: number) {
+    const len = tabs.length;
+    if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+      e.preventDefault();
+      activateTab((idx + 1) % len);
+    } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+      e.preventDefault();
+      activateTab((idx - 1 + len) % len);
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      activateTab(0);
+    } else if (e.key === "End") {
+      e.preventDefault();
+      activateTab(len - 1);
+    }
+  }
+
+  return (
+    <div class="mb-3 flex" role="tablist" aria-label={t("import.tab.label")}>
+      {tabs.map((tab, i) => {
+        const isActive = activeTab === tab.key;
+        return (
+          <button
+            key={tab.key}
+            ref={(el) => {
+              tabRefs.current[i] = el;
+            }}
+            class="flex-1 cursor-pointer border border-border bg-surface px-0 py-2 text-[0.875rem] font-medium text-text-secondary transition-[background,color,border-color] duration-150 first:rounded-l-sm last:rounded-r-sm last:border-l-0 data-[active=true]:border-accent data-[active=true]:bg-accent data-[active=true]:text-accent-contrast"
+            role="tab"
+            aria-selected={isActive}
+            aria-controls={`tab-${tab.key}`}
+            data-active={String(isActive)}
+            tabIndex={isActive ? 0 : -1}
+            onClick={() => onTabChange(tab.key)}
+            onKeyDown={(e) => handleKeyDown(e, i)}
+          >
+            {t(tab.labelKey)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- ImportScreenからTabBar、FileUploadPanel、HelpButton、LoadedInfoの4つのコンポーネントを`src/components/import/`に抽出
- ImportScreenにはビジネスロジック（ファイル読み込み、OPFS保存、状態管理）のみを残し、UIの組み立てをシンプルに
- 機能変更なし（純粋なリファクタリング）

## Test plan
- [ ] `pnpm build` が通ること
- [ ] ブラウザでImportScreenを表示し、タブ切替・ファイルアップロード・保存データ読み込み・ヘルプボタンが動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)