### PR TITLE
refactor: AggregationContextを導入しprop drillingを解消

### DIFF
--- a/src/components/AggregationScreen.tsx
+++ b/src/components/AggregationScreen.tsx
@@ -132,17 +132,17 @@ export default function AggregationScreen({ csv, layout }: AggregationScreenProp
       {/* Right Panel */}
       <div class="overflow-y-auto bg-bg p-6" role="region" aria-label={t("section.results")}>
         {aggResults ? (
-          <AggregationContext.Provider
-            value={{
-              layoutMeta: aggResults.layoutMeta,
-              weightCol: aggResults.weightCol,
-              crossCols: aggResults.crossCols,
-            }}
-          >
-            <div aria-live="polite">
+          <div aria-live="polite">
+            <AggregationContext.Provider
+              value={{
+                layoutMeta: aggResults.layoutMeta,
+                weightCol: aggResults.weightCol,
+                crossCols: aggResults.crossCols,
+              }}
+            >
               <ResultView results={aggResults.results} />
-            </div>
-          </AggregationContext.Provider>
+            </AggregationContext.Provider>
+          </div>
         ) : (
           <div class="flex h-full flex-col items-center justify-center gap-3 text-muted">
             <span class="text-[2.5rem]" aria-hidden="true">

--- a/src/components/AggregationScreen.tsx
+++ b/src/components/AggregationScreen.tsx
@@ -1,6 +1,7 @@
 import { useState } from "preact/hooks";
 import CrossConfig from "./aggregation/CrossConfig";
 import ResultView from "./aggregation/ResultView";
+import { AggregationContext } from "./aggregation/AggregationContext";
 import { runDuckDBAggregation } from "../lib/duckdbBridge";
 import { buildQuestionDefs, type LayoutMeta } from "../lib/layout";
 import { questionKey, type AggResult, type QuestionDef } from "../lib/agg/aggregate";
@@ -28,7 +29,6 @@ export default function AggregationScreen({ csv, layout }: AggregationScreenProp
   const [aggResults, setAggResults] = useState<{
     results: AggResult[];
     weightCol: string;
-    rawN: number;
     layoutMeta: LayoutMeta;
     crossCols: QuestionDef[];
   } | null>(null);
@@ -48,7 +48,6 @@ export default function AggregationScreen({ csv, layout }: AggregationScreenProp
       setAggResults({
         results,
         weightCol: wCol,
-        rawN: csv.rowCount,
         layoutMeta: layout.meta,
         crossCols,
       });
@@ -133,15 +132,17 @@ export default function AggregationScreen({ csv, layout }: AggregationScreenProp
       {/* Right Panel */}
       <div class="overflow-y-auto bg-bg p-6" role="region" aria-label={t("section.results")}>
         {aggResults ? (
-          <div aria-live="polite">
-            <ResultView
-              results={aggResults.results}
-              weightCol={aggResults.weightCol}
-              rawN={aggResults.rawN}
-              layoutMeta={aggResults.layoutMeta}
-              crossCols={aggResults.crossCols}
-            />
-          </div>
+          <AggregationContext.Provider
+            value={{
+              layoutMeta: aggResults.layoutMeta,
+              weightCol: aggResults.weightCol,
+              crossCols: aggResults.crossCols,
+            }}
+          >
+            <div aria-live="polite">
+              <ResultView results={aggResults.results} />
+            </div>
+          </AggregationContext.Provider>
         ) : (
           <div class="flex h-full flex-col items-center justify-center gap-3 text-muted">
             <span class="text-[2.5rem]" aria-hidden="true">

--- a/src/components/aggregation/AIBubble.tsx
+++ b/src/components/aggregation/AIBubble.tsx
@@ -1,17 +1,16 @@
 import { useState, useEffect } from "preact/hooks";
 import type { AggResult } from "../../lib/agg/aggregate";
-import type { LayoutMeta } from "../../lib/layout";
 import { generateComment } from "../../lib/aiComment";
 import { t } from "../../lib/i18n";
 import { isAICommentEnabled } from "../header/SettingsModal";
+import { useAggregation } from "./AggregationContext";
 
 interface AIBubbleProps {
   results: AggResult[];
-  weightCol: string;
-  layoutMeta?: LayoutMeta;
 }
 
-export function AIBubble({ results, weightCol, layoutMeta }: AIBubbleProps) {
+export function AIBubble({ results }: AIBubbleProps) {
+  const { weightCol, layoutMeta } = useAggregation();
   const [comment, setComment] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [visible, setVisible] = useState(true);

--- a/src/components/aggregation/AggregationContext.ts
+++ b/src/components/aggregation/AggregationContext.ts
@@ -1,0 +1,18 @@
+import { createContext } from "preact";
+import { useContext } from "preact/hooks";
+import type { LayoutMeta } from "../../lib/layout";
+import type { QuestionDef } from "../../lib/agg/aggregate";
+
+export interface AggregationContextValue {
+  layoutMeta: LayoutMeta;
+  weightCol: string;
+  crossCols: QuestionDef[];
+}
+
+export const AggregationContext = createContext<AggregationContextValue | null>(null);
+
+export function useAggregation(): AggregationContextValue {
+  const ctx = useContext(AggregationContext);
+  if (!ctx) throw new Error("useAggregation must be used within AggregationContext.Provider");
+  return ctx;
+}

--- a/src/components/aggregation/ChartRenderer.tsx
+++ b/src/components/aggregation/ChartRenderer.tsx
@@ -81,7 +81,7 @@ function buildGtChart(
   chartType: GtChartType,
   res: AggResult,
   theme: ReturnType<typeof getThemeColors>,
-  layoutMeta?: LayoutMeta,
+  layoutMeta: LayoutMeta | undefined,
 ): Chart {
   const { mains, lookup } = pv;
   const labels = mains.map((m) => resolveValueLabel(res.type, res.question, m, layoutMeta));
@@ -173,8 +173,8 @@ function buildCrossChart(
   gtChartType: GtChartType,
   res: AggResult,
   theme: ReturnType<typeof getThemeColors>,
-  layoutMeta?: LayoutMeta,
-  crossCols?: QuestionDef[],
+  layoutMeta: LayoutMeta | undefined,
+  crossCols: QuestionDef[],
 ): Chart {
   const { mains, subs, lookup } = pv;
   const crossSubs = subs.filter((s) => s.label !== "GT");

--- a/src/components/aggregation/ChartRenderer.tsx
+++ b/src/components/aggregation/ChartRenderer.tsx
@@ -6,6 +6,7 @@ import type { LayoutMeta } from "../../lib/layout";
 import { pivot } from "../../lib/agg/pivot";
 import { Chart, getSeriesColor, getThemeColors } from "../../lib/chartConfig";
 import { resolveQuestionLabel, resolveValueLabel, resolveSubLabel } from "../../lib/labels";
+import { useAggregation } from "./AggregationContext";
 
 import type { ChartConfiguration } from "chart.js";
 
@@ -14,11 +15,10 @@ export type GtChartType = "bar-h" | "bar-v" | "obi";
 interface ChartCardProps {
   res: AggResult;
   gtChartType: GtChartType;
-  layoutMeta?: LayoutMeta;
-  crossCols?: QuestionDef[];
 }
 
-export function ChartCard({ res, gtChartType, layoutMeta, crossCols }: ChartCardProps) {
+export function ChartCard({ res, gtChartType }: ChartCardProps) {
+  const { layoutMeta, crossCols } = useAggregation();
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const chartRef = useRef<Chart | null>(null);
 

--- a/src/components/aggregation/CrossTable.tsx
+++ b/src/components/aggregation/CrossTable.tsx
@@ -1,12 +1,11 @@
-import { render } from "preact";
 import type { AggResult, QuestionDef } from "../../lib/agg/aggregate";
 import { questionKey, parseCrossSub } from "../../lib/agg/aggregate";
-import type { LayoutMeta } from "../../lib/layout";
 import type { pivot } from "../../lib/agg/pivot";
 import { resolveQuestionLabel, resolveValueLabel, resolveSubLabel } from "../../lib/labels";
 import { t } from "../../lib/i18n";
 import type { PctDirection } from "./Toolbar";
 import { Th, Td } from "./TableCells";
+import { useAggregation } from "./AggregationContext";
 
 type SubInfo = { label: string; n: number };
 
@@ -57,25 +56,17 @@ const MONO = "text-right tabular-nums font-mono";
 interface VerticalCrossTableProps {
   res: AggResult;
   pv: ReturnType<typeof pivot>;
-  weightCol: string;
-  layoutMeta?: LayoutMeta;
-  crossCols?: QuestionDef[];
 }
 
-function VerticalCrossTable({
-  res,
-  pv,
-  weightCol,
-  layoutMeta,
-  crossCols,
-}: VerticalCrossTableProps) {
+function VerticalCrossTable({ res, pv }: VerticalCrossTableProps) {
+  const { layoutMeta, weightCol, crossCols } = useAggregation();
   const { mains, subs, lookup } = pv;
   const gtSub = subs.find((s) => s.label === "GT")!;
   const crossSubs = subs.filter((s) => s.label !== "GT");
   const questionLabel = resolveQuestionLabel(res.question, layoutMeta);
 
   const crossGroups =
-    crossCols && crossCols.length > 0 ? groupSubsByCrossAxis(crossSubs, crossCols, res.type) : [];
+    crossCols.length > 0 ? groupSubsByCrossAxis(crossSubs, crossCols, res.type) : [];
   const hasMultipleAxes = crossGroups.length > 1;
 
   // Precompute axis group boundary indices
@@ -181,31 +172,18 @@ function VerticalCrossTable({
 
 // ─── Transposed (Horizontal %) Table ────────────────────────
 
-interface TransposedCrossTableProps {
-  res: AggResult;
-  pv: ReturnType<typeof pivot>;
-  weightCol: string;
-  layoutMeta?: LayoutMeta;
-  crossCols?: QuestionDef[];
-}
-
 function TransposedSubRow({
   sub,
   mains,
   lookup,
   mainGtCounts,
-  weightCol,
-  layoutMeta,
-  crossCols,
 }: {
   sub: SubInfo;
   mains: string[];
   lookup: Map<string, { count: number; pct: number }>;
   mainGtCounts: Map<string, number>;
-  weightCol: string;
-  layoutMeta?: LayoutMeta;
-  crossCols?: QuestionDef[];
 }) {
+  const { layoutMeta, weightCol, crossCols } = useAggregation();
   return (
     <tr>
       <td
@@ -229,13 +207,13 @@ function TransposedSubRow({
   );
 }
 
-function TransposedCrossTable({
-  res,
-  pv,
-  weightCol,
-  layoutMeta,
-  crossCols,
-}: TransposedCrossTableProps) {
+interface TransposedCrossTableProps {
+  res: AggResult;
+  pv: ReturnType<typeof pivot>;
+}
+
+function TransposedCrossTable({ res, pv }: TransposedCrossTableProps) {
+  const { layoutMeta, weightCol, crossCols } = useAggregation();
   const { mains, subs, lookup } = pv;
   const gtSub = subs.find((s) => s.label === "GT")!;
   const crossSubs = subs.filter((s) => s.label !== "GT");
@@ -248,7 +226,7 @@ function TransposedCrossTable({
   }
 
   const crossGroups =
-    crossCols && crossCols.length > 0 ? groupSubsByCrossAxis(crossSubs, crossCols, res.type) : [];
+    crossCols.length > 0 ? groupSubsByCrossAxis(crossSubs, crossCols, res.type) : [];
 
   return (
     <table class="w-full border-collapse text-sm tabular-nums min-w-[400px]">
@@ -311,9 +289,6 @@ function TransposedCrossTable({
                     mains={mains}
                     lookup={lookup}
                     mainGtCounts={mainGtCounts}
-                    weightCol={weightCol}
-                    layoutMeta={layoutMeta}
-                    crossCols={crossCols}
                   />
                 ))}
               </>
@@ -325,9 +300,6 @@ function TransposedCrossTable({
                 mains={mains}
                 lookup={lookup}
                 mainGtCounts={mainGtCounts}
-                weightCol={weightCol}
-                layoutMeta={layoutMeta}
-                crossCols={crossCols}
               />
             ))}
       </tbody>
@@ -340,55 +312,12 @@ function TransposedCrossTable({
 interface CrossTableProps {
   res: AggResult;
   pv: ReturnType<typeof pivot>;
-  weightCol: string;
   pctDir: PctDirection;
-  layoutMeta?: LayoutMeta;
-  crossCols?: QuestionDef[];
 }
 
-export function CrossTable({ res, pv, weightCol, pctDir, layoutMeta, crossCols }: CrossTableProps) {
+export function CrossTable({ res, pv, pctDir }: CrossTableProps) {
   if (pctDir === "horizontal") {
-    return (
-      <TransposedCrossTable
-        res={res}
-        pv={pv}
-        weightCol={weightCol}
-        layoutMeta={layoutMeta}
-        crossCols={crossCols}
-      />
-    );
+    return <TransposedCrossTable res={res} pv={pv} />;
   }
-  return (
-    <VerticalCrossTable
-      res={res}
-      pv={pv}
-      weightCol={weightCol}
-      layoutMeta={layoutMeta}
-      crossCols={crossCols}
-    />
-  );
-}
-
-/** Bridge: render CrossTable into a container div for vanilla DOM callers */
-export function buildCrossTable(
-  res: AggResult,
-  pv: ReturnType<typeof pivot>,
-  weightCol: string,
-  pctDir: PctDirection,
-  layoutMeta?: LayoutMeta,
-  crossCols?: QuestionDef[],
-): HTMLDivElement {
-  const container = document.createElement("div");
-  render(
-    <CrossTable
-      res={res}
-      pv={pv}
-      weightCol={weightCol}
-      pctDir={pctDir}
-      layoutMeta={layoutMeta}
-      crossCols={crossCols}
-    />,
-    container,
-  );
-  return container;
+  return <VerticalCrossTable res={res} pv={pv} />;
 }

--- a/src/components/aggregation/GtTable.tsx
+++ b/src/components/aggregation/GtTable.tsx
@@ -1,20 +1,18 @@
-import { render } from "preact";
 import type { AggResult } from "../../lib/agg/aggregate";
-import type { LayoutMeta } from "../../lib/layout";
 import type { pivot } from "../../lib/agg/pivot";
 import { resolveQuestionLabel, resolveValueLabel } from "../../lib/labels";
 import { t } from "../../lib/i18n";
 import { Th, Td } from "./TableCells";
+import { useAggregation } from "./AggregationContext";
 
 interface GtTableProps {
   res: AggResult;
   pv: ReturnType<typeof pivot>;
-  weightCol: string;
   maxPct: number;
-  layoutMeta?: LayoutMeta;
 }
 
-export function GtTable({ res, pv, weightCol, maxPct, layoutMeta }: GtTableProps) {
+export function GtTable({ res, pv, maxPct }: GtTableProps) {
+  const { layoutMeta, weightCol } = useAggregation();
   const { mains, lookup } = pv;
   const questionLabel = resolveQuestionLabel(res.question, layoutMeta);
 
@@ -60,20 +58,4 @@ export function GtTable({ res, pv, weightCol, maxPct, layoutMeta }: GtTableProps
       </tbody>
     </table>
   );
-}
-
-/** Bridge: render GtTable into a container div for vanilla DOM callers */
-export function buildGtTable(
-  res: AggResult,
-  pv: ReturnType<typeof pivot>,
-  weightCol: string,
-  maxPct: number,
-  layoutMeta?: LayoutMeta,
-): HTMLDivElement {
-  const container = document.createElement("div");
-  render(
-    <GtTable res={res} pv={pv} weightCol={weightCol} maxPct={maxPct} layoutMeta={layoutMeta} />,
-    container,
-  );
-  return container;
 }

--- a/src/components/aggregation/ResultView.tsx
+++ b/src/components/aggregation/ResultView.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "preact/hooks";
-import type { AggResult, QuestionDef } from "../../lib/agg/aggregate";
-import type { LayoutMeta } from "../../lib/layout";
+import type { AggResult } from "../../lib/agg/aggregate";
 import { pivot } from "../../lib/agg/pivot";
 import { resolveQuestionLabel } from "../../lib/labels";
 import { Toolbar, ViewOpts, type PctDirection, type ViewMode } from "./Toolbar";
@@ -8,16 +7,13 @@ import { GtTable } from "./GtTable";
 import { CrossTable } from "./CrossTable";
 import { AIBubble } from "./AIBubble";
 import { ChartCard, type GtChartType } from "./ChartRenderer";
+import { useAggregation } from "./AggregationContext";
 
 export interface ResultViewProps {
   results: AggResult[];
-  weightCol: string;
-  rawN: number;
-  layoutMeta?: LayoutMeta;
-  crossCols?: QuestionDef[];
 }
 
-export default function ResultView({ results, weightCol, layoutMeta, crossCols }: ResultViewProps) {
+export default function ResultView({ results }: ResultViewProps) {
   const [viewMode, setViewMode] = useState<ViewMode>("table");
   const [saChartType, setSaChartType] = useState<GtChartType>("bar-h");
   const [maChartType, setMaChartType] = useState<GtChartType>("bar-h");
@@ -55,9 +51,7 @@ export default function ResultView({ results, weightCol, layoutMeta, crossCols }
       <Toolbar
         hasCross={hasCross}
         results={results}
-        weightCol={weightCol}
         currentViewMode={viewMode}
-        layoutMeta={layoutMeta}
         callbacks={callbacks}
       />
       {showViewOpts && (
@@ -76,20 +70,11 @@ export default function ResultView({ results, weightCol, layoutMeta, crossCols }
           hasCross={hasCross}
           saChartType={saChartType}
           maChartType={maChartType}
-          layoutMeta={layoutMeta}
-          crossCols={crossCols}
         />
       ) : (
-        <TableContent
-          results={results}
-          weightCol={weightCol}
-          hasCross={hasCross}
-          pctDirection={pctDirection}
-          layoutMeta={layoutMeta}
-          crossCols={crossCols}
-        />
+        <TableContent results={results} hasCross={hasCross} pctDirection={pctDirection} />
       )}
-      <AIBubble results={results} weightCol={weightCol} layoutMeta={layoutMeta} />
+      <AIBubble results={results} />
     </>
   );
 }
@@ -101,15 +86,11 @@ function ChartContent({
   hasCross,
   saChartType,
   maChartType,
-  layoutMeta,
-  crossCols,
 }: {
   results: AggResult[];
   hasCross: boolean;
   saChartType: GtChartType;
   maChartType: GtChartType;
-  layoutMeta?: LayoutMeta;
-  crossCols?: QuestionDef[];
 }) {
   return (
     <div
@@ -124,8 +105,6 @@ function ChartContent({
           key={res.question}
           res={res}
           gtChartType={res.type === "SA" ? saChartType : maChartType}
-          layoutMeta={layoutMeta}
-          crossCols={crossCols}
         />
       ))}
     </div>
@@ -134,19 +113,14 @@ function ChartContent({
 
 function TableContent({
   results,
-  weightCol,
   hasCross,
   pctDirection,
-  layoutMeta,
-  crossCols,
 }: {
   results: AggResult[];
-  weightCol: string;
   hasCross: boolean;
   pctDirection: PctDirection;
-  layoutMeta?: LayoutMeta;
-  crossCols?: QuestionDef[];
 }) {
+  const { layoutMeta, weightCol } = useAggregation();
   const allGtCells = results.flatMap((r) => r.cells.filter((c) => c.sub === "GT"));
   const maxPct = Math.max(...allGtCells.map((c) => c.pct), 0);
 
@@ -184,22 +158,9 @@ function TableContent({
               <span class="ml-auto text-[0.8125rem] text-muted">{nLabel}</span>
             </div>
             {isCross ? (
-              <CrossTable
-                res={res}
-                pv={pv}
-                weightCol={weightCol}
-                pctDir={pctDirection}
-                layoutMeta={layoutMeta}
-                crossCols={crossCols}
-              />
+              <CrossTable res={res} pv={pv} pctDir={pctDirection} />
             ) : (
-              <GtTable
-                res={res}
-                pv={pv}
-                weightCol={weightCol}
-                maxPct={maxPct}
-                layoutMeta={layoutMeta}
-              />
+              <GtTable res={res} pv={pv} maxPct={maxPct} />
             )}
           </div>
         );

--- a/src/components/aggregation/Toolbar.tsx
+++ b/src/components/aggregation/Toolbar.tsx
@@ -1,9 +1,9 @@
 import type { AggResult } from "../../lib/agg/aggregate";
-import type { LayoutMeta } from "../../lib/layout";
 import { downloadAllCSV } from "../../lib/agg/download";
 import { t } from "../../lib/i18n";
 import type { GtChartType } from "./ChartRenderer";
 import { ToggleButton, ToggleGroup } from "../shared/ToggleButton";
+import { useAggregation } from "./AggregationContext";
 
 export type ViewMode = "table" | "chart";
 export type PctDirection = "vertical" | "horizontal";
@@ -18,19 +18,12 @@ export interface ToolbarCallbacks {
 interface ToolbarProps {
   hasCross: boolean;
   results: AggResult[];
-  weightCol: string;
   currentViewMode: ViewMode;
-  layoutMeta: LayoutMeta | undefined;
   callbacks: ToolbarCallbacks;
 }
 
-export function Toolbar({
-  results,
-  weightCol,
-  currentViewMode,
-  layoutMeta,
-  callbacks,
-}: ToolbarProps) {
+export function Toolbar({ results, currentViewMode, callbacks }: ToolbarProps) {
+  const { weightCol, layoutMeta } = useAggregation();
   const weightText = weightCol
     ? t("result.weight.applied", { col: weightCol })
     : t("result.weight.none");


### PR DESCRIPTION
## Summary
- `layoutMeta` / `weightCol` / `crossCols` の3つのpropsが最大4階層・9コンポーネントにバケツリレーされていた問題を、Preact `createContext` + `useAggregation()` カスタムフックで解消
- 不要になった旧ブリッジ関数 `buildGtTable` / `buildCrossTable` を削除
- 結果として **117行削減**（+66 / -183）

## Test plan
- [x] `pnpm check` (fmt:check + lint + tsc --noEmit) パス
- [x] `pnpm test` (vitest 72テスト) パス
- [ ] 手動確認：CSV + Layout読み込み → GT/クロス集計 → 表・チャート・CSV出力

🤖 Generated with [Claude Code](https://claude.com/claude-code)