### PR TITLE
refactor: ResultCard抽出とChartRenderer型修正

### DIFF
--- a/src/components/aggregation/ChartRenderer.tsx
+++ b/src/components/aggregation/ChartRenderer.tsx
@@ -5,8 +5,9 @@ import type { AggResult, QuestionDef } from "../../lib/agg/aggregate";
 import type { LayoutMeta } from "../../lib/layout";
 import { pivot } from "../../lib/agg/pivot";
 import { Chart, getSeriesColor, getThemeColors } from "../../lib/chartConfig";
-import { resolveQuestionLabel, resolveValueLabel, resolveSubLabel } from "../../lib/labels";
+import { resolveValueLabel, resolveSubLabel } from "../../lib/labels";
 import { useAggregation } from "./AggregationContext";
+import { ResultCard } from "./ResultCard";
 
 import type { ChartConfiguration } from "chart.js";
 
@@ -24,9 +25,6 @@ export function ChartCard({ res, gtChartType }: ChartCardProps) {
 
   const pv = pivot(res.cells);
   const isCross = pv.subs.length > 1;
-  const questionLabel = resolveQuestionLabel(res.question, layoutMeta);
-  const hasLabel = questionLabel !== res.question;
-  const gtSub = pv.subs.find((s) => s.label === "GT")!;
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -57,19 +55,11 @@ export function ChartCard({ res, gtChartType }: ChartCardProps) {
   }, [res, gtChartType, layoutMeta, crossCols]);
 
   return (
-    <div class="overflow-hidden rounded-xl border border-border bg-surface shadow-sm">
-      <div class="flex items-baseline gap-3 p-4 border-b border-border">
-        <div class="flex flex-col gap-0.5 min-w-0">
-          <span class="font-bold text-sm text-accent">{questionLabel}</span>
-          {hasLabel && <span class="text-xs text-muted tracking-[0.04em]">{res.question}</span>}
-        </div>
-        <span class="text-xs text-muted tracking-[0.04em]">{res.type}</span>
-        <span class="ml-auto text-[0.8125rem] text-muted">n={gtSub.n.toLocaleString()}</span>
-      </div>
+    <ResultCard res={res}>
       <div class={`p-4 ${isCross ? "h-[400px]" : "h-80"}`}>
         <canvas ref={canvasRef} />
       </div>
-    </div>
+    </ResultCard>
   );
 }
 

--- a/src/components/aggregation/ChartRenderer.tsx
+++ b/src/components/aggregation/ChartRenderer.tsx
@@ -81,7 +81,7 @@ function buildGtChart(
   chartType: GtChartType,
   res: AggResult,
   theme: ReturnType<typeof getThemeColors>,
-  layoutMeta: LayoutMeta | undefined,
+  layoutMeta: LayoutMeta,
 ): Chart {
   const { mains, lookup } = pv;
   const labels = mains.map((m) => resolveValueLabel(res.type, res.question, m, layoutMeta));
@@ -173,7 +173,7 @@ function buildCrossChart(
   gtChartType: GtChartType,
   res: AggResult,
   theme: ReturnType<typeof getThemeColors>,
-  layoutMeta: LayoutMeta | undefined,
+  layoutMeta: LayoutMeta,
   crossCols: QuestionDef[],
 ): Chart {
   const { mains, subs, lookup } = pv;

--- a/src/components/aggregation/ResultCard.tsx
+++ b/src/components/aggregation/ResultCard.tsx
@@ -1,0 +1,38 @@
+import type { ComponentChildren } from "preact";
+import type { AggResult } from "../../lib/agg/aggregate";
+import { pivot } from "../../lib/agg/pivot";
+import { resolveQuestionLabel } from "../../lib/labels";
+import { useAggregation } from "./AggregationContext";
+
+interface ResultCardProps {
+  res: AggResult;
+  extraClass?: string;
+  children: ComponentChildren;
+}
+
+export function ResultCard({ res, extraClass, children }: ResultCardProps) {
+  const { layoutMeta, weightCol } = useAggregation();
+
+  const pv = pivot(res.cells);
+  const gtSub = pv.subs.find((s) => s.label === "GT")!;
+  const nLabel = weightCol ? `n=${gtSub.n.toFixed(1)}` : `n=${gtSub.n.toLocaleString()}`;
+
+  const questionLabel = resolveQuestionLabel(res.question, layoutMeta);
+  const hasLabel = questionLabel !== res.question;
+
+  return (
+    <div
+      class={`overflow-hidden rounded-xl border border-border bg-surface shadow-sm${extraClass ? ` ${extraClass}` : ""}`}
+    >
+      <div class="flex items-baseline gap-3 border-b border-border p-4">
+        <div class="flex min-w-0 flex-col gap-[2px]">
+          <span class="text-[0.875rem] font-bold text-accent">{questionLabel}</span>
+          {hasLabel && <span class="text-xs tracking-[0.04em] text-muted">{res.question}</span>}
+        </div>
+        <span class="text-xs tracking-[0.04em] text-muted">{res.type}</span>
+        <span class="ml-auto text-[0.8125rem] text-muted">{nLabel}</span>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/components/aggregation/ResultView.tsx
+++ b/src/components/aggregation/ResultView.tsx
@@ -1,13 +1,12 @@
 import { useEffect, useState } from "preact/hooks";
 import type { AggResult } from "../../lib/agg/aggregate";
 import { pivot } from "../../lib/agg/pivot";
-import { resolveQuestionLabel } from "../../lib/labels";
 import { Toolbar, ViewOpts, type PctDirection, type ViewMode } from "./Toolbar";
 import { GtTable } from "./GtTable";
 import { CrossTable } from "./CrossTable";
 import { AIBubble } from "./AIBubble";
 import { ChartCard, type GtChartType } from "./ChartRenderer";
-import { useAggregation } from "./AggregationContext";
+import { ResultCard } from "./ResultCard";
 
 export interface ResultViewProps {
   results: AggResult[];
@@ -120,7 +119,6 @@ function TableContent({
   hasCross: boolean;
   pctDirection: PctDirection;
 }) {
-  const { layoutMeta, weightCol } = useAggregation();
   const allGtCells = results.flatMap((r) => r.cells.filter((c) => c.sub === "GT"));
   const maxPct = Math.max(...allGtCells.map((c) => c.pct), 0);
 
@@ -136,33 +134,18 @@ function TableContent({
         const pv = pivot(res.cells);
         const isCross = pv.subs.length > 1;
 
-        const gtSub = pv.subs.find((s) => s.label === "GT")!;
-        const nLabel = weightCol ? `n=${gtSub.n.toFixed(1)}` : `n=${gtSub.n.toLocaleString()}`;
-
-        const questionLabel = resolveQuestionLabel(res.question, layoutMeta);
-        const hasLabel = questionLabel !== res.question;
-
         return (
-          <div
-            class={`overflow-hidden rounded-xl border border-border bg-surface shadow-sm${isCross ? " overflow-x-auto" : ""}`}
+          <ResultCard
             key={res.question}
+            res={res}
+            extraClass={isCross ? "overflow-x-auto" : undefined}
           >
-            <div class="flex items-baseline gap-3 border-b border-border p-4">
-              <div class="flex min-w-0 flex-col gap-[2px]">
-                <span class="text-[0.875rem] font-bold text-accent">{questionLabel}</span>
-                {hasLabel && (
-                  <span class="text-xs tracking-[0.04em] text-muted">{res.question}</span>
-                )}
-              </div>
-              <span class="text-xs tracking-[0.04em] text-muted">{res.type}</span>
-              <span class="ml-auto text-[0.8125rem] text-muted">{nLabel}</span>
-            </div>
             {isCross ? (
               <CrossTable res={res} pv={pv} pctDir={pctDirection} />
             ) : (
               <GtTable res={res} pv={pv} maxPct={maxPct} />
             )}
-          </div>
+          </ResultCard>
         );
       })}
     </div>


### PR DESCRIPTION
## Summary
- `buildGtChart` / `buildCrossChart` の `layoutMeta` 引数型を `LayoutMeta | undefined` → `LayoutMeta` に修正（Context経由で必ず値が渡るため）
- `ResultCard` コンポーネントを新規作成し、`TableContent` と `ChartCard` で重複していたカード枠+ヘッダー描画を統一
- `ChartCard` で weight 未考慮だった n 値表示を修正

## Test plan
- [ ] `pnpm check` パス確認済み
- [ ] dev サーバーで GT テーブル / クロステーブル / チャート表示を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)