### PR TITLE
refactor: ResultViewからChartContent/TableContentを分離

### DIFF
--- a/src/components/aggregation/ChartContent.tsx
+++ b/src/components/aggregation/ChartContent.tsx
@@ -1,4 +1,4 @@
-/** Chart rendering component */
+/** Chart content: grid layout + individual chart cards */
 
 import { useRef, useEffect } from "preact/hooks";
 import type { AggResult, QuestionDef } from "../../lib/agg/aggregate";
@@ -13,12 +13,41 @@ import type { ChartConfiguration } from "chart.js";
 
 export type GtChartType = "bar-h" | "bar-v" | "obi";
 
+interface ChartContentProps {
+  results: AggResult[];
+  hasCross: boolean;
+  saChartType: GtChartType;
+  maChartType: GtChartType;
+}
+
+export function ChartContent({ results, hasCross, saChartType, maChartType }: ChartContentProps) {
+  return (
+    <div
+      class={
+        hasCross
+          ? "grid grid-cols-[1fr] gap-6"
+          : "grid grid-cols-[repeat(auto-fill,minmax(400px,1fr))] gap-6"
+      }
+    >
+      {results.map((res) => (
+        <ChartCard
+          key={res.question}
+          res={res}
+          gtChartType={res.type === "SA" ? saChartType : maChartType}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ─── Individual chart card ──────────────────────────────────
+
 interface ChartCardProps {
   res: AggResult;
   gtChartType: GtChartType;
 }
 
-export function ChartCard({ res, gtChartType }: ChartCardProps) {
+function ChartCard({ res, gtChartType }: ChartCardProps) {
   const { layoutMeta, crossCols } = useAggregation();
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const chartRef = useRef<Chart | null>(null);

--- a/src/components/aggregation/ResultView.tsx
+++ b/src/components/aggregation/ResultView.tsx
@@ -48,7 +48,6 @@ export default function ResultView({ results }: ResultViewProps) {
   return (
     <>
       <Toolbar
-        hasCross={hasCross}
         results={results}
         currentViewMode={viewMode}
         callbacks={callbacks}

--- a/src/components/aggregation/ResultView.tsx
+++ b/src/components/aggregation/ResultView.tsx
@@ -2,11 +2,9 @@ import { useEffect, useState } from "preact/hooks";
 import type { AggResult } from "../../lib/agg/aggregate";
 import { pivot } from "../../lib/agg/pivot";
 import { Toolbar, ViewOpts, type PctDirection, type ViewMode } from "./Toolbar";
-import { GtTable } from "./GtTable";
-import { CrossTable } from "./CrossTable";
+import { ChartContent, type GtChartType } from "./ChartContent";
+import { TableContent } from "./TableContent";
 import { AIBubble } from "./AIBubble";
-import { ChartCard, type GtChartType } from "./ChartRenderer";
-import { ResultCard } from "./ResultCard";
 
 export interface ResultViewProps {
   results: AggResult[];
@@ -47,11 +45,7 @@ export default function ResultView({ results }: ResultViewProps) {
 
   return (
     <>
-      <Toolbar
-        results={results}
-        currentViewMode={viewMode}
-        callbacks={callbacks}
-      />
+      <Toolbar results={results} currentViewMode={viewMode} callbacks={callbacks} />
       {showViewOpts && (
         <ViewOpts
           currentViewMode={viewMode}
@@ -74,79 +68,5 @@ export default function ResultView({ results }: ResultViewProps) {
       )}
       <AIBubble results={results} />
     </>
-  );
-}
-
-// --- Sub-components ---
-
-function ChartContent({
-  results,
-  hasCross,
-  saChartType,
-  maChartType,
-}: {
-  results: AggResult[];
-  hasCross: boolean;
-  saChartType: GtChartType;
-  maChartType: GtChartType;
-}) {
-  return (
-    <div
-      class={
-        hasCross
-          ? "grid grid-cols-[1fr] gap-6"
-          : "grid grid-cols-[repeat(auto-fill,minmax(400px,1fr))] gap-6"
-      }
-    >
-      {results.map((res) => (
-        <ChartCard
-          key={res.question}
-          res={res}
-          gtChartType={res.type === "SA" ? saChartType : maChartType}
-        />
-      ))}
-    </div>
-  );
-}
-
-function TableContent({
-  results,
-  hasCross,
-  pctDirection,
-}: {
-  results: AggResult[];
-  hasCross: boolean;
-  pctDirection: PctDirection;
-}) {
-  const allGtCells = results.flatMap((r) => r.cells.filter((c) => c.sub === "GT"));
-  const maxPct = Math.max(...allGtCells.map((c) => c.pct), 0);
-
-  return (
-    <div
-      class={
-        hasCross
-          ? "grid grid-cols-[1fr] gap-6"
-          : "grid grid-cols-[repeat(auto-fill,minmax(360px,1fr))] gap-6"
-      }
-    >
-      {results.map((res) => {
-        const pv = pivot(res.cells);
-        const isCross = pv.subs.length > 1;
-
-        return (
-          <ResultCard
-            key={res.question}
-            res={res}
-            extraClass={isCross ? "overflow-x-auto" : undefined}
-          >
-            {isCross ? (
-              <CrossTable res={res} pv={pv} pctDir={pctDirection} />
-            ) : (
-              <GtTable res={res} pv={pv} maxPct={maxPct} />
-            )}
-          </ResultCard>
-        );
-      })}
-    </div>
   );
 }

--- a/src/components/aggregation/TableContent.tsx
+++ b/src/components/aggregation/TableContent.tsx
@@ -1,0 +1,46 @@
+import type { AggResult } from "../../lib/agg/aggregate";
+import { pivot } from "../../lib/agg/pivot";
+import type { PctDirection } from "./Toolbar";
+import { GtTable } from "./GtTable";
+import { CrossTable } from "./CrossTable";
+import { ResultCard } from "./ResultCard";
+
+interface TableContentProps {
+  results: AggResult[];
+  hasCross: boolean;
+  pctDirection: PctDirection;
+}
+
+export function TableContent({ results, hasCross, pctDirection }: TableContentProps) {
+  const allGtCells = results.flatMap((r) => r.cells.filter((c) => c.sub === "GT"));
+  const maxPct = Math.max(...allGtCells.map((c) => c.pct), 0);
+
+  return (
+    <div
+      class={
+        hasCross
+          ? "grid grid-cols-[1fr] gap-6"
+          : "grid grid-cols-[repeat(auto-fill,minmax(360px,1fr))] gap-6"
+      }
+    >
+      {results.map((res) => {
+        const pv = pivot(res.cells);
+        const isCross = pv.subs.length > 1;
+
+        return (
+          <ResultCard
+            key={res.question}
+            res={res}
+            extraClass={isCross ? "overflow-x-auto" : undefined}
+          >
+            {isCross ? (
+              <CrossTable res={res} pv={pv} pctDir={pctDirection} />
+            ) : (
+              <GtTable res={res} pv={pv} maxPct={maxPct} />
+            )}
+          </ResultCard>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/aggregation/Toolbar.tsx
+++ b/src/components/aggregation/Toolbar.tsx
@@ -16,7 +16,6 @@ export interface ToolbarCallbacks {
 }
 
 interface ToolbarProps {
-  hasCross: boolean;
   results: AggResult[];
   currentViewMode: ViewMode;
   callbacks: ToolbarCallbacks;

--- a/src/components/aggregation/Toolbar.tsx
+++ b/src/components/aggregation/Toolbar.tsx
@@ -1,7 +1,7 @@
 import type { AggResult } from "../../lib/agg/aggregate";
 import { downloadAllCSV } from "../../lib/agg/download";
 import { t } from "../../lib/i18n";
-import type { GtChartType } from "./ChartRenderer";
+import type { GtChartType } from "./ChartContent";
 import { ToggleButton, ToggleGroup } from "../shared/ToggleButton";
 import { useAggregation } from "./AggregationContext";
 

--- a/src/lib/labels.ts
+++ b/src/lib/labels.ts
@@ -1,4 +1,4 @@
-/** Label resolution utility (shared by ResultTable / ChartRenderer) */
+/** Label resolution utility (shared by table / chart components) */
 
 import type { QuestionDef } from "./agg/aggregate";
 import { parseCrossSub } from "./agg/aggregate";


### PR DESCRIPTION
## Summary
- Toolbarコンポーネントから未使用の`hasCross` propを削除
- `ChartRenderer.tsx`を`ChartContent.tsx`にリネームし、グリッドレイアウト(`ChartContent`)を統合
- `TableContent`を`TableContent.tsx`に切り出し
- `ResultView.tsx`をstate管理と切替ロジックに集中（153行→76行）

## Test plan
- [x] `pnpm build` 成功を確認済み
- [ ] テーブル表示モードで GT / クロス集計が正常に表示されること
- [ ] チャート表示モードで SA / MA チャートが正常に表示されること
- [ ] テーブル⇔チャート切り替えが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)