### PR TITLE
refactor: hasCrossをpivot()算出からcrossCols由来に変更

### DIFF
--- a/src/components/aggregation/ChartContent.tsx
+++ b/src/components/aggregation/ChartContent.tsx
@@ -15,12 +15,13 @@ export type GtChartType = "bar-h" | "bar-v" | "obi";
 
 interface ChartContentProps {
   results: AggResult[];
-  hasCross: boolean;
   saChartType: GtChartType;
   maChartType: GtChartType;
 }
 
-export function ChartContent({ results, hasCross, saChartType, maChartType }: ChartContentProps) {
+export function ChartContent({ results, saChartType, maChartType }: ChartContentProps) {
+  const { crossCols } = useAggregation();
+  const hasCross = crossCols.length > 0;
   return (
     <div
       class={

--- a/src/components/aggregation/ChartContent.tsx
+++ b/src/components/aggregation/ChartContent.tsx
@@ -11,12 +11,12 @@ import { ResultCard } from "./ResultCard";
 
 import type { ChartConfiguration } from "chart.js";
 
-export type GtChartType = "bar-h" | "bar-v" | "obi";
+export type ChartType = "bar-h" | "bar-v" | "obi";
 
 interface ChartContentProps {
   results: AggResult[];
-  saChartType: GtChartType;
-  maChartType: GtChartType;
+  saChartType: ChartType;
+  maChartType: ChartType;
 }
 
 export function ChartContent({ results, saChartType, maChartType }: ChartContentProps) {
@@ -45,7 +45,7 @@ export function ChartContent({ results, saChartType, maChartType }: ChartContent
 
 interface ChartCardProps {
   res: AggResult;
-  gtChartType: GtChartType;
+  gtChartType: ChartType;
 }
 
 function ChartCard({ res, gtChartType }: ChartCardProps) {
@@ -98,7 +98,7 @@ function ChartCard({ res, gtChartType }: ChartCardProps) {
 function buildGtChart(
   canvas: HTMLCanvasElement,
   pv: ReturnType<typeof pivot>,
-  chartType: GtChartType,
+  chartType: ChartType,
   res: AggResult,
   theme: ReturnType<typeof getThemeColors>,
   layoutMeta: LayoutMeta,
@@ -190,7 +190,7 @@ function buildGtChart(
 function buildCrossChart(
   canvas: HTMLCanvasElement,
   pv: ReturnType<typeof pivot>,
-  gtChartType: GtChartType,
+  gtChartType: ChartType,
   res: AggResult,
   theme: ReturnType<typeof getThemeColors>,
   layoutMeta: LayoutMeta,

--- a/src/components/aggregation/ResultView.tsx
+++ b/src/components/aggregation/ResultView.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from "preact/hooks";
 import type { AggResult } from "../../lib/agg/aggregate";
-import { pivot } from "../../lib/agg/pivot";
 import { Toolbar, ViewOpts, type PctDirection, type ViewMode } from "./Toolbar";
 import { ChartContent, type GtChartType } from "./ChartContent";
 import { TableContent } from "./TableContent";
 import { AIBubble } from "./AIBubble";
+import { useAggregation } from "./AggregationContext";
 
 export interface ResultViewProps {
   results: AggResult[];
@@ -29,10 +29,8 @@ export default function ResultView({ results }: ResultViewProps) {
     return () => observer.disconnect();
   }, []);
 
-  const hasCross = results.some((r) => {
-    const { subs } = pivot(r.cells);
-    return subs.length > 1;
-  });
+  const { crossCols } = useAggregation();
+  const hasCross = crossCols.length > 0;
 
   const callbacks = {
     onViewModeChange: setViewMode,
@@ -49,7 +47,6 @@ export default function ResultView({ results }: ResultViewProps) {
       {showViewOpts && (
         <ViewOpts
           currentViewMode={viewMode}
-          hasCross={hasCross}
           currentPctDirection={pctDirection}
           saChartType={saChartType}
           maChartType={maChartType}
@@ -57,14 +54,9 @@ export default function ResultView({ results }: ResultViewProps) {
         />
       )}
       {viewMode === "chart" ? (
-        <ChartContent
-          results={results}
-          hasCross={hasCross}
-          saChartType={saChartType}
-          maChartType={maChartType}
-        />
+        <ChartContent results={results} saChartType={saChartType} maChartType={maChartType} />
       ) : (
-        <TableContent results={results} hasCross={hasCross} pctDirection={pctDirection} />
+        <TableContent results={results} pctDirection={pctDirection} />
       )}
       <AIBubble results={results} />
     </>

--- a/src/components/aggregation/ResultView.tsx
+++ b/src/components/aggregation/ResultView.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "preact/hooks";
 import type { AggResult } from "../../lib/agg/aggregate";
 import { Toolbar, ViewOpts, type PctDirection, type ViewMode } from "./Toolbar";
-import { ChartContent, type GtChartType } from "./ChartContent";
+import { ChartContent, type ChartType } from "./ChartContent";
 import { TableContent } from "./TableContent";
 import { AIBubble } from "./AIBubble";
 import { useAggregation } from "./AggregationContext";
@@ -12,8 +12,8 @@ export interface ResultViewProps {
 
 export default function ResultView({ results }: ResultViewProps) {
   const [viewMode, setViewMode] = useState<ViewMode>("table");
-  const [saChartType, setSaChartType] = useState<GtChartType>("bar-h");
-  const [maChartType, setMaChartType] = useState<GtChartType>("bar-h");
+  const [saChartType, setSaChartType] = useState<ChartType>("bar-h");
+  const [maChartType, setMaChartType] = useState<ChartType>("bar-h");
   const [pctDirection, setPctDirection] = useState<PctDirection>("vertical");
   const [, setThemeTick] = useState(0);
 

--- a/src/components/aggregation/TableContent.tsx
+++ b/src/components/aggregation/TableContent.tsx
@@ -4,14 +4,16 @@ import type { PctDirection } from "./Toolbar";
 import { GtTable } from "./GtTable";
 import { CrossTable } from "./CrossTable";
 import { ResultCard } from "./ResultCard";
+import { useAggregation } from "./AggregationContext";
 
 interface TableContentProps {
   results: AggResult[];
-  hasCross: boolean;
   pctDirection: PctDirection;
 }
 
-export function TableContent({ results, hasCross, pctDirection }: TableContentProps) {
+export function TableContent({ results, pctDirection }: TableContentProps) {
+  const { crossCols } = useAggregation();
+  const hasCross = crossCols.length > 0;
   const allGtCells = results.flatMap((r) => r.cells.filter((c) => c.sub === "GT"));
   const maxPct = Math.max(...allGtCells.map((c) => c.pct), 0);
 

--- a/src/components/aggregation/Toolbar.tsx
+++ b/src/components/aggregation/Toolbar.tsx
@@ -63,7 +63,6 @@ export function Toolbar({ results, currentViewMode, callbacks }: ToolbarProps) {
 
 interface ViewOptsProps {
   currentViewMode: ViewMode;
-  hasCross: boolean;
   currentPctDirection: PctDirection;
   saChartType: GtChartType;
   maChartType: GtChartType;
@@ -100,12 +99,13 @@ function ChartTypeSelect({
 
 export function ViewOpts({
   currentViewMode,
-  hasCross,
   currentPctDirection,
   saChartType,
   maChartType,
   callbacks,
 }: ViewOptsProps) {
+  const { crossCols } = useAggregation();
+  const hasCross = crossCols.length > 0;
   return (
     <div class="mb-4 flex items-center justify-end gap-4 text-[0.8125rem] text-text-secondary">
       {currentViewMode === "chart" && (

--- a/src/components/aggregation/Toolbar.tsx
+++ b/src/components/aggregation/Toolbar.tsx
@@ -1,7 +1,7 @@
 import type { AggResult } from "../../lib/agg/aggregate";
 import { downloadAllCSV } from "../../lib/agg/download";
 import { t } from "../../lib/i18n";
-import type { GtChartType } from "./ChartContent";
+import type { ChartType } from "./ChartContent";
 import { ToggleButton, ToggleGroup } from "../shared/ToggleButton";
 import { useAggregation } from "./AggregationContext";
 
@@ -10,8 +10,8 @@ export type PctDirection = "vertical" | "horizontal";
 
 export interface ToolbarCallbacks {
   onViewModeChange: (mode: ViewMode) => void;
-  onSaChartTypeChange: (type: GtChartType) => void;
-  onMaChartTypeChange: (type: GtChartType) => void;
+  onSaChartTypeChange: (type: ChartType) => void;
+  onMaChartTypeChange: (type: ChartType) => void;
   onPctDirectionChange: (dir: PctDirection) => void;
 }
 
@@ -64,8 +64,8 @@ export function Toolbar({ results, currentViewMode, callbacks }: ToolbarProps) {
 interface ViewOptsProps {
   currentViewMode: ViewMode;
   currentPctDirection: PctDirection;
-  saChartType: GtChartType;
-  maChartType: GtChartType;
+  saChartType: ChartType;
+  maChartType: ChartType;
   callbacks: Pick<
     ToolbarCallbacks,
     "onSaChartTypeChange" | "onMaChartTypeChange" | "onPctDirectionChange"
@@ -78,8 +78,8 @@ function ChartTypeSelect({
   onChange,
 }: {
   label: string;
-  value: GtChartType;
-  onChange: (type: GtChartType) => void;
+  value: ChartType;
+  onChange: (type: ChartType) => void;
 }) {
   return (
     <label>
@@ -87,7 +87,7 @@ function ChartTypeSelect({
       <select
         class="cursor-pointer rounded-sm border border-border bg-surface px-2 py-1 text-[0.8125rem] text-text"
         value={value}
-        onChange={(e) => onChange((e.target as HTMLSelectElement).value as GtChartType)}
+        onChange={(e) => onChange((e.target as HTMLSelectElement).value as ChartType)}
       >
         <option value="bar-h">{t("chart.barH")}</option>
         <option value="bar-v">{t("chart.barV")}</option>


### PR DESCRIPTION
## Summary
- `hasCross` の算出を毎レンダーごとの `pivot()` 呼び出しから `AggregationContext.crossCols.length > 0` に変更
- ResultView → ChartContent / TableContent / ViewOpts への `hasCross` prop受け渡しを廃止し、各コンポーネントが直接contextから導出するように統一
- 不要になった `pivot` インポートを ResultView から削除

## Test plan
- [ ] GT集計（クロスなし）でテーブル・チャート表示が正常に動作すること
- [ ] クロス集計ありでテーブル・チャートが1カラムレイアウトになること
- [ ] クロス集計時にテーブルモードで縦%/横%トグルが表示されること
- [ ] `pnpm build` が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)