### PR TITLE
refactor: AggregationContextにresultsを統合しpropsバケツリレーを除去

### DIFF
--- a/src/components/AggregationScreen.tsx
+++ b/src/components/AggregationScreen.tsx
@@ -1,10 +1,7 @@
 import { useState } from "preact/hooks";
 import CrossConfig from "./aggregation/CrossConfig";
 import ResultView from "./aggregation/ResultView";
-import {
-  AggregationContext,
-  type AggregationContextValue,
-} from "./aggregation/AggregationContext";
+import { AggregationContext, type AggregationContextValue } from "./aggregation/AggregationContext";
 import { runDuckDBAggregation } from "../lib/duckdbBridge";
 import { buildQuestionDefs } from "../lib/layout";
 import { questionKey } from "../lib/agg/aggregate";

--- a/src/components/AggregationScreen.tsx
+++ b/src/components/AggregationScreen.tsx
@@ -1,10 +1,13 @@
 import { useState } from "preact/hooks";
 import CrossConfig from "./aggregation/CrossConfig";
 import ResultView from "./aggregation/ResultView";
-import { AggregationContext } from "./aggregation/AggregationContext";
+import {
+  AggregationContext,
+  type AggregationContextValue,
+} from "./aggregation/AggregationContext";
 import { runDuckDBAggregation } from "../lib/duckdbBridge";
-import { buildQuestionDefs, type LayoutMeta } from "../lib/layout";
-import { questionKey, type AggResult, type QuestionDef } from "../lib/agg/aggregate";
+import { buildQuestionDefs } from "../lib/layout";
+import { questionKey } from "../lib/agg/aggregate";
 import { t } from "../lib/i18n";
 import { ToggleButton, ToggleGroup } from "./shared/ToggleButton";
 import type { CsvData, LayoutData } from "../lib/types";
@@ -26,12 +29,7 @@ export default function AggregationScreen({ csv, layout }: AggregationScreenProp
   });
   const [weightEnabled, setWeightEnabled] = useState(true);
   const [errorMsg, setErrorMsg] = useState("");
-  const [aggResults, setAggResults] = useState<{
-    results: AggResult[];
-    weightCol: string;
-    layoutMeta: LayoutMeta;
-    crossCols: QuestionDef[];
-  } | null>(null);
+  const [aggCtx, setAggCtx] = useState<AggregationContextValue | null>(null);
 
   async function runAggregation(): Promise<void> {
     setErrorMsg("");
@@ -45,11 +43,12 @@ export default function AggregationScreen({ csv, layout }: AggregationScreenProp
         weight_col: wCol,
         cross_cols: crossCols,
       });
-      setAggResults({
+      setAggCtx({
         results,
         weightCol: wCol,
         layoutMeta: layout.meta,
         crossCols,
+        hasCross: crossCols.length > 0,
       });
     } catch (e) {
       setErrorMsg(t("error.aggregation", { msg: (e as Error).message }));
@@ -131,16 +130,10 @@ export default function AggregationScreen({ csv, layout }: AggregationScreenProp
 
       {/* Right Panel */}
       <div class="overflow-y-auto bg-bg p-6" role="region" aria-label={t("section.results")}>
-        {aggResults ? (
+        {aggCtx ? (
           <div aria-live="polite">
-            <AggregationContext.Provider
-              value={{
-                layoutMeta: aggResults.layoutMeta,
-                weightCol: aggResults.weightCol,
-                crossCols: aggResults.crossCols,
-              }}
-            >
-              <ResultView results={aggResults.results} />
+            <AggregationContext.Provider value={aggCtx}>
+              <ResultView />
             </AggregationContext.Provider>
           </div>
         ) : (

--- a/src/components/aggregation/AIBubble.tsx
+++ b/src/components/aggregation/AIBubble.tsx
@@ -1,16 +1,11 @@
 import { useState, useEffect } from "preact/hooks";
-import type { AggResult } from "../../lib/agg/aggregate";
 import { generateComment } from "../../lib/aiComment";
 import { t } from "../../lib/i18n";
 import { isAICommentEnabled } from "../header/SettingsModal";
 import { useAggregation } from "./AggregationContext";
 
-interface AIBubbleProps {
-  results: AggResult[];
-}
-
-export function AIBubble({ results }: AIBubbleProps) {
-  const { weightCol, layoutMeta } = useAggregation();
+export function AIBubble() {
+  const { results, weightCol, layoutMeta } = useAggregation();
   const [comment, setComment] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [visible, setVisible] = useState(true);

--- a/src/components/aggregation/AggregationContext.ts
+++ b/src/components/aggregation/AggregationContext.ts
@@ -1,12 +1,14 @@
 import { createContext } from "preact";
 import { useContext } from "preact/hooks";
 import type { LayoutMeta } from "../../lib/layout";
-import type { QuestionDef } from "../../lib/agg/aggregate";
+import type { AggResult, QuestionDef } from "../../lib/agg/aggregate";
 
 export interface AggregationContextValue {
+  results: AggResult[];
   layoutMeta: LayoutMeta;
   weightCol: string;
   crossCols: QuestionDef[];
+  hasCross: boolean;
 }
 
 export const AggregationContext = createContext<AggregationContextValue | null>(null);

--- a/src/components/aggregation/ChartContent.tsx
+++ b/src/components/aggregation/ChartContent.tsx
@@ -14,14 +14,12 @@ import type { ChartConfiguration } from "chart.js";
 export type ChartType = "bar-h" | "bar-v" | "obi";
 
 interface ChartContentProps {
-  results: AggResult[];
   saChartType: ChartType;
   maChartType: ChartType;
 }
 
-export function ChartContent({ results, saChartType, maChartType }: ChartContentProps) {
-  const { crossCols } = useAggregation();
-  const hasCross = crossCols.length > 0;
+export function ChartContent({ saChartType, maChartType }: ChartContentProps) {
+  const { results, hasCross } = useAggregation();
   return (
     <div
       class={

--- a/src/components/aggregation/ResultView.tsx
+++ b/src/components/aggregation/ResultView.tsx
@@ -1,16 +1,10 @@
 import { useEffect, useState } from "preact/hooks";
-import type { AggResult } from "../../lib/agg/aggregate";
 import { Toolbar, ViewOpts, type PctDirection, type ViewMode } from "./Toolbar";
 import { ChartContent, type ChartType } from "./ChartContent";
 import { TableContent } from "./TableContent";
 import { AIBubble } from "./AIBubble";
-import { useAggregation } from "./AggregationContext";
 
-export interface ResultViewProps {
-  results: AggResult[];
-}
-
-export default function ResultView({ results }: ResultViewProps) {
+export default function ResultView() {
   const [viewMode, setViewMode] = useState<ViewMode>("table");
   const [saChartType, setSaChartType] = useState<ChartType>("bar-h");
   const [maChartType, setMaChartType] = useState<ChartType>("bar-h");
@@ -29,9 +23,6 @@ export default function ResultView({ results }: ResultViewProps) {
     return () => observer.disconnect();
   }, []);
 
-  const { crossCols } = useAggregation();
-  const hasCross = crossCols.length > 0;
-
   const callbacks = {
     onViewModeChange: setViewMode,
     onSaChartTypeChange: setSaChartType,
@@ -39,26 +30,22 @@ export default function ResultView({ results }: ResultViewProps) {
     onPctDirectionChange: setPctDirection,
   };
 
-  const showViewOpts = viewMode === "chart" || (viewMode === "table" && hasCross);
-
   return (
     <>
-      <Toolbar results={results} currentViewMode={viewMode} callbacks={callbacks} />
-      {showViewOpts && (
-        <ViewOpts
-          currentViewMode={viewMode}
-          currentPctDirection={pctDirection}
-          saChartType={saChartType}
-          maChartType={maChartType}
-          callbacks={callbacks}
-        />
-      )}
+      <Toolbar currentViewMode={viewMode} callbacks={callbacks} />
+      <ViewOpts
+        currentViewMode={viewMode}
+        currentPctDirection={pctDirection}
+        saChartType={saChartType}
+        maChartType={maChartType}
+        callbacks={callbacks}
+      />
       {viewMode === "chart" ? (
-        <ChartContent results={results} saChartType={saChartType} maChartType={maChartType} />
+        <ChartContent saChartType={saChartType} maChartType={maChartType} />
       ) : (
-        <TableContent results={results} pctDirection={pctDirection} />
+        <TableContent pctDirection={pctDirection} />
       )}
-      <AIBubble results={results} />
+      <AIBubble />
     </>
   );
 }

--- a/src/components/aggregation/TableContent.tsx
+++ b/src/components/aggregation/TableContent.tsx
@@ -1,4 +1,3 @@
-import type { AggResult } from "../../lib/agg/aggregate";
 import { pivot } from "../../lib/agg/pivot";
 import type { PctDirection } from "./Toolbar";
 import { GtTable } from "./GtTable";
@@ -7,13 +6,11 @@ import { ResultCard } from "./ResultCard";
 import { useAggregation } from "./AggregationContext";
 
 interface TableContentProps {
-  results: AggResult[];
   pctDirection: PctDirection;
 }
 
-export function TableContent({ results, pctDirection }: TableContentProps) {
-  const { crossCols } = useAggregation();
-  const hasCross = crossCols.length > 0;
+export function TableContent({ pctDirection }: TableContentProps) {
+  const { results, hasCross } = useAggregation();
   const allGtCells = results.flatMap((r) => r.cells.filter((c) => c.sub === "GT"));
   const maxPct = Math.max(...allGtCells.map((c) => c.pct), 0);
 

--- a/src/components/aggregation/Toolbar.tsx
+++ b/src/components/aggregation/Toolbar.tsx
@@ -1,4 +1,3 @@
-import type { AggResult } from "../../lib/agg/aggregate";
 import { downloadAllCSV } from "../../lib/agg/download";
 import { t } from "../../lib/i18n";
 import type { ChartType } from "./ChartContent";
@@ -16,13 +15,12 @@ export interface ToolbarCallbacks {
 }
 
 interface ToolbarProps {
-  results: AggResult[];
   currentViewMode: ViewMode;
   callbacks: ToolbarCallbacks;
 }
 
-export function Toolbar({ results, currentViewMode, callbacks }: ToolbarProps) {
-  const { weightCol, layoutMeta } = useAggregation();
+export function Toolbar({ currentViewMode, callbacks }: ToolbarProps) {
+  const { results, weightCol, layoutMeta } = useAggregation();
   const weightText = weightCol
     ? t("result.weight.applied", { col: weightCol })
     : t("result.weight.none");
@@ -104,11 +102,16 @@ export function ViewOpts({
   maChartType,
   callbacks,
 }: ViewOptsProps) {
-  const { crossCols } = useAggregation();
-  const hasCross = crossCols.length > 0;
+  const { hasCross } = useAggregation();
+
+  const showChart = currentViewMode === "chart";
+  const showPctToggle = currentViewMode === "table" && hasCross;
+
+  if (!showChart && !showPctToggle) return null;
+
   return (
     <div class="mb-4 flex items-center justify-end gap-4 text-[0.8125rem] text-text-secondary">
-      {currentViewMode === "chart" && (
+      {showChart && (
         <>
           <ChartTypeSelect
             label="SA:"
@@ -122,7 +125,7 @@ export function ViewOpts({
           />
         </>
       )}
-      {currentViewMode === "table" && hasCross && (
+      {showPctToggle && (
         <ToggleGroup class="ml-auto">
           <ToggleButton
             active={currentPctDirection === "vertical"}


### PR DESCRIPTION
## Summary
- `AggregationContextValue`に`results`を追加し、`aggResults` stateと`AggregationContext.Provider`のvalue組み立てを`aggCtx`に統一
- `ResultView`/`Toolbar`/`ChartContent`/`TableContent`/`AIBubble`から`results` propsを除去し、すべてContext経由に変更
- `ViewOpts`が自身で表示判定（`return null`）するようにし、親の`showViewOpts`ガードを削除
- `hasCross`をContextに追加し、各コンポーネントでの`crossCols.length > 0`重複算出を除去

## Test plan
- [ ] GT集計・クロス集計の結果表示が正常に動作すること
- [ ] テーブル/チャート切り替え、%方向切り替えが正常に動作すること
- [ ] CSV出力が正常に動作すること
- [ ] AIコメントが正常に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)