### PR TITLE
feat: 集計画面遷移時にGT集計を自動実行

### DIFF
--- a/src/components/AggregationScreen.tsx
+++ b/src/components/AggregationScreen.tsx
@@ -1,4 +1,4 @@
-import { useState } from "preact/hooks";
+import { useEffect, useRef, useState } from "preact/hooks";
 import CrossConfig from "./aggregation/CrossConfig";
 import ResultView from "./aggregation/ResultView";
 import { AggregationContext, type AggregationContextValue } from "./aggregation/AggregationContext";
@@ -27,6 +27,14 @@ export default function AggregationScreen({ csv, layout }: AggregationScreenProp
   const [weightEnabled, setWeightEnabled] = useState(true);
   const [errorMsg, setErrorMsg] = useState("");
   const [aggCtx, setAggCtx] = useState<AggregationContextValue | null>(null);
+
+  const didAutoRun = useRef(false);
+  useEffect(() => {
+    if (!didAutoRun.current) {
+      didAutoRun.current = true;
+      runAggregation();
+    }
+  }, []);
 
   async function runAggregation(): Promise<void> {
     setErrorMsg("");


### PR DESCRIPTION
## Summary
- 集計画面へ遷移した際にGT集計を自動実行し、結果をすぐに表示するようにした
- `useEffect` + `useRef` で初回マウント時のみ実行、二重実行を防止

## Test plan
- [ ] CSVとレイアウトをアップロードし「集計画面へ進む」ボタンを押す
- [ ] 集計画面遷移直後にGT結果が表示されることを確認
- [ ] クロス軸を選択して集計ボタンを押し、クロス集計が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)