### PR TITLE
chore: dependenciesとdevDependenciesの整理

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,17 +18,17 @@
   },
   "dependencies": {
     "@duckdb/duckdb-wasm": "^1.33.1-dev18.0",
-    "@preact/preset-vite": "^2.10.3",
-    "@tailwindcss/vite": "^4.2.1",
     "chart.js": "^4.5.1",
-    "preact": "^10.28.4",
-    "tailwindcss": "^4.2.1",
-    "typescript": "^5.9.3",
-    "vite": "^7.3.1"
+    "preact": "^10.28.4"
   },
   "devDependencies": {
+    "@preact/preset-vite": "^2.10.3",
+    "@tailwindcss/vite": "^4.2.1",
     "oxfmt": "^0.35.0",
     "oxlint": "^1.50.0",
+    "tailwindcss": "^4.2.1",
+    "typescript": "^5.9.3",
+    "vite": "^7.3.1",
     "vite-plugin-top-level-await": "^1.6.0",
     "vite-plugin-wasm": "^3.5.0",
     "vitest": "^4.0.18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,18 +11,25 @@ importers:
       '@duckdb/duckdb-wasm':
         specifier: ^1.33.1-dev18.0
         version: 1.33.1-dev18.0
-      '@preact/preset-vite':
-        specifier: ^2.10.3
-        version: 2.10.3(@babel/core@7.29.0)(preact@10.28.4)(rollup@4.59.0)(vite@7.3.1(@types/node@20.19.34)(jiti@2.6.1)(lightningcss@1.31.1))
-      '@tailwindcss/vite':
-        specifier: ^4.2.1
-        version: 4.2.1(vite@7.3.1(@types/node@20.19.34)(jiti@2.6.1)(lightningcss@1.31.1))
       chart.js:
         specifier: ^4.5.1
         version: 4.5.1
       preact:
         specifier: ^10.28.4
         version: 10.28.4
+    devDependencies:
+      '@preact/preset-vite':
+        specifier: ^2.10.3
+        version: 2.10.3(@babel/core@7.29.0)(preact@10.28.4)(rollup@4.59.0)(vite@7.3.1(@types/node@20.19.34)(jiti@2.6.1)(lightningcss@1.31.1))
+      '@tailwindcss/vite':
+        specifier: ^4.2.1
+        version: 4.2.1(vite@7.3.1(@types/node@20.19.34)(jiti@2.6.1)(lightningcss@1.31.1))
+      oxfmt:
+        specifier: ^0.35.0
+        version: 0.35.0
+      oxlint:
+        specifier: ^1.50.0
+        version: 1.50.0
       tailwindcss:
         specifier: ^4.2.1
         version: 4.2.1
@@ -32,13 +39,6 @@ importers:
       vite:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@20.19.34)(jiti@2.6.1)(lightningcss@1.31.1)
-    devDependencies:
-      oxfmt:
-        specifier: ^0.35.0
-        version: 0.35.0
-      oxlint:
-        specifier: ^1.50.0
-        version: 1.50.0
       vite-plugin-top-level-await:
         specifier: ^1.6.0
         version: 1.6.0(@swc/helpers@0.5.19)(rollup@4.59.0)(vite@7.3.1(@types/node@20.19.34)(jiti@2.6.1)(lightningcss@1.31.1))


### PR DESCRIPTION
## Summary
- ビルド/開発時のみ使用するパッケージを `dependencies` → `devDependencies` に移動
- 移動対象: `@preact/preset-vite`, `@tailwindcss/vite`, `tailwindcss`, `typescript`, `vite`
- `dependencies` にはランタイムで必要な `@duckdb/duckdb-wasm`, `chart.js`, `preact` のみ残す

## Test plan
- [x] `pnpm check` (fmt:check + lint + tsc --noEmit) 通過確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)