### PR TITLE
refactor: Public APIをファイル先頭に配置

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ interface Cell { main: string; sub: string; n: number; count: number; pct: numbe
 - Module-level variables as app state (no state management library); migrating toward hooks
 - UI language is Japanese
 - Formatting: oxfmt; Linting: oxlint; Testing: vitest
+- File ordering: `imports → exports (Public API) → internal implementation`. Props interfaces stay with their exported component
 
 ## Vite Config Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,18 +25,18 @@ pnpm fmt:check     # oxfmt --check
 
 ### Data Flow
 
-1. User uploads CSV → `Dropzone.ts` → `duckdbBridge.loadCSV()` (registers as DuckDB view)
-2. User uploads JSON layout → `LayoutDropzone.ts` → `layout.parseLayout()` + `buildLayoutMeta()`
-3. Both loaded → `main.tsx:initAfterBothLoaded()` builds `QuestionDef[]`, shows CrossConfig UI
-4. User clicks run → `aggregator.aggregate()` executes SQL queries → returns `AggResult[]` (flat `Cell[]` arrays)
-5. `ResultTable.renderResults()` calls `pivot()` to convert `Cell[]` → grid, then renders HTML tables
+1. User uploads CSV → `Dropzone.tsx` → `duckdbBridge.loadCSV()` (registers as DuckDB view)
+2. User uploads JSON layout → `Dropzone.tsx` → `layout.parseLayout()` + `buildLayoutMeta()`
+3. Both loaded → `ImportScreen` calls `onComplete` → `AggregationScreen` builds `QuestionDef[]`
+4. User clicks run → `aggregate()` executes SQL queries → returns `AggResult[]` (flat `Cell[]` arrays)
+5. `ResultView` / `GtTable` / `CrossTable` call `pivot()` to convert `Cell[]` → grid, then render tables
 6. CSV download: `download.downloadAllCSV()` re-pivots and outputs BOM-prefixed UTF-8 CSV
 
 ### Module Responsibilities
 
 - **`src/components/`** — UI: event handling and DOM rendering only
 - **`src/lib/`** — Pure logic (aggregation SQL, DuckDB bridge, layout parsing, pivot, CSV export)
-- `aggregator.ts` — Core: builds and runs SQL for SA/MA GT and all cross-tab combinations (SA×SA, SA×MA, MA×SA, MA×MA)
+- `agg/aggregate.ts` — Entry point; `gtAggregator.ts` / `crossAggregator.ts` build and run SQL for SA/MA GT and cross-tab (SA×SA, SA×MA, MA×SA, MA×MA)
 - `duckdbBridge.ts` — DuckDB Wasm lifecycle (init, CSV load, query execution). Module-level singleton state
 - `pivot.ts` — Converts flat `Cell[]` into `{ mains, subs, lookup }` grid structure using `\0`-separated composite keys in Maps
 
@@ -54,11 +54,9 @@ interface Cell { main: string; sub: string; n: number; count: number; pct: numbe
 - All CSV columns read as `VARCHAR` (`all_varchar=true`); weight uses `TRY_CAST` to float
 - SQL column names escaped via `esc()` helper (double-quote escaping)
 - MA truthy values: `'1'` only
-- Component files: PascalCase `.tsx` (`GtTable.tsx`); lib files: camelCase `.ts` (`aggregator.ts`)
-- Components export Preact function components; bridge functions (`build*`) wrap them for legacy vanilla DOM callers
-- Component initializers: `init*`; DOM renderers: `render*`; Preact components: PascalCase functions
-- Module-level variables as app state (no state management library); migrating toward hooks
-- UI language is Japanese
+- Component files: PascalCase `.tsx` (`GtTable.tsx`); lib files: camelCase `.ts` (`aggregate.ts`)
+- Components export Preact function components; PascalCase functions
+- Module-level singleton state for infrastructure (`duckdbBridge`, `i18n`); UI state uses hooks + Context
 - Formatting: oxfmt; Linting: oxlint; Testing: vitest
 - File ordering: `imports → exports (Public API) → internal implementation`. Props interfaces stay with their exported component
 

--- a/src/components/AggregationScreen.tsx
+++ b/src/components/AggregationScreen.tsx
@@ -154,8 +154,6 @@ export default function AggregationScreen({ csv, layout }: AggregationScreenProp
   );
 }
 
-// --- Sub-components ---
-
 export function DataSummary({
   csv,
   layout,

--- a/src/components/ImportScreen.tsx
+++ b/src/components/ImportScreen.tsx
@@ -10,40 +10,8 @@ import { SavedFilesList, triggerSavedFilesRefresh, useSavedFiles } from "./impor
 import { GettingStartedModal } from "./import/GettingStarted";
 import type { CsvData, LayoutData } from "../lib/types";
 
-type Tab = "file" | "saved";
-
 interface ImportScreenProps {
   onComplete: (csv: CsvData, layout: LayoutData) => void;
-}
-
-const TABS: { key: Tab; labelKey: string }[] = [
-  { key: "file", labelKey: "import.tab.file" },
-  { key: "saved", labelKey: "import.tab.saved" },
-];
-
-function LoadedInfo({ info }: { info: string | null }) {
-  if (!info) return null;
-
-  return (
-    <div
-      class="mt-3 whitespace-pre-line rounded-lg border border-accent-light bg-accent-bg px-4 py-3 text-[0.875rem] leading-normal text-text-secondary"
-      aria-live="polite"
-    >
-      {info}
-    </div>
-  );
-}
-
-function HelpButton({ onClick }: { onClick: () => void }) {
-  return (
-    <button
-      class="fixed bottom-5 left-5 z-900 flex h-10 w-10 cursor-pointer items-center justify-center rounded-full border-[1.5px] border-border-strong bg-surface text-base font-bold text-text-secondary shadow-[0_2px_8px_rgba(0,0,0,0.12)] transition-[background,color,transform] duration-150 hover:scale-[1.08] hover:border-[var(--color-primary-500)] hover:bg-[var(--color-primary-50)] hover:text-[var(--color-primary-700)]"
-      aria-label={t("help.label")}
-      onClick={onClick}
-    >
-      ?
-    </button>
-  );
 }
 
 export default function ImportScreen({ onComplete }: ImportScreenProps) {
@@ -218,5 +186,39 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
       {/* Getting Started Modal */}
       <GettingStartedModal open={gsOpen} onClose={() => setGsOpen(false)} />
     </div>
+  );
+}
+
+// ─── Internal ───────────────────────────────────────────────
+
+type Tab = "file" | "saved";
+
+const TABS: { key: Tab; labelKey: string }[] = [
+  { key: "file", labelKey: "import.tab.file" },
+  { key: "saved", labelKey: "import.tab.saved" },
+];
+
+function LoadedInfo({ info }: { info: string | null }) {
+  if (!info) return null;
+
+  return (
+    <div
+      class="mt-3 whitespace-pre-line rounded-lg border border-accent-light bg-accent-bg px-4 py-3 text-[0.875rem] leading-normal text-text-secondary"
+      aria-live="polite"
+    >
+      {info}
+    </div>
+  );
+}
+
+function HelpButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      class="fixed bottom-5 left-5 z-900 flex h-10 w-10 cursor-pointer items-center justify-center rounded-full border-[1.5px] border-border-strong bg-surface text-base font-bold text-text-secondary shadow-[0_2px_8px_rgba(0,0,0,0.12)] transition-[background,color,transform] duration-150 hover:scale-[1.08] hover:border-[var(--color-primary-500)] hover:bg-[var(--color-primary-50)] hover:text-[var(--color-primary-700)]"
+      aria-label={t("help.label")}
+      onClick={onClick}
+    >
+      ?
+    </button>
   );
 }

--- a/src/components/aggregation/ChartContent.tsx
+++ b/src/components/aggregation/ChartContent.tsx
@@ -39,8 +39,6 @@ export function ChartContent({ saChartType, maChartType }: ChartContentProps) {
   );
 }
 
-// ─── Individual chart card ──────────────────────────────────
-
 interface ChartCardProps {
   res: AggResult;
   gtChartType: ChartType;
@@ -90,8 +88,6 @@ function ChartCard({ res, gtChartType }: ChartCardProps) {
     </ResultCard>
   );
 }
-
-// ─── Chart builders (pure logic, unchanged) ─────────────────
 
 function buildGtChart(
   canvas: HTMLCanvasElement,

--- a/src/components/aggregation/CrossTable.tsx
+++ b/src/components/aggregation/CrossTable.tsx
@@ -7,6 +7,20 @@ import type { PctDirection } from "./Toolbar";
 import { Th, Td } from "./TableCells";
 import { useAggregation } from "./AggregationContext";
 
+interface CrossTableProps {
+  res: AggResult;
+  pv: ReturnType<typeof pivot>;
+  pctDir: PctDirection;
+}
+
+export function CrossTable({ res, pv, pctDir }: CrossTableProps) {
+  const data = useCrossTableData(res, pv);
+  if (pctDir === "horizontal") {
+    return <TransposedCrossTable data={data} res={res} />;
+  }
+  return <VerticalCrossTable data={data} res={res} />;
+}
+
 type SubInfo = { label: string; n: number };
 type CrossGroup = { crossCol: QuestionDef; subs: SubInfo[] };
 
@@ -52,8 +66,6 @@ const TH_BASE =
 const TD_BASE = "py-3 px-4 border-b border-row-border leading-[1.2]";
 const MONO = "text-right tabular-nums font-mono";
 
-// ─── Common data preparation ────────────────────────────────
-
 interface CrossTableData {
   mains: string[];
   gtSub: SubInfo;
@@ -76,8 +88,6 @@ function useCrossTableData(res: AggResult, pv: ReturnType<typeof pivot>): CrossT
 
   return { mains, gtSub, crossGroups, questionLabel, lookup, weightCol };
 }
-
-// ─── Vertical % Table ───────────────────────────────────────
 
 function VerticalCrossTable({ data, res }: { data: CrossTableData; res: AggResult }) {
   const { layoutMeta, crossCols } = useAggregation();
@@ -156,8 +166,6 @@ function VerticalCrossTable({ data, res }: { data: CrossTableData; res: AggResul
     </table>
   );
 }
-
-// ─── Transposed (Horizontal %) Table ────────────────────────
 
 function TransposedSubRow({
   sub,
@@ -257,20 +265,4 @@ function TransposedCrossTable({ data, res }: { data: CrossTableData; res: AggRes
       </tbody>
     </table>
   );
-}
-
-// ─── Public API ─────────────────────────────────────────────
-
-interface CrossTableProps {
-  res: AggResult;
-  pv: ReturnType<typeof pivot>;
-  pctDir: PctDirection;
-}
-
-export function CrossTable({ res, pv, pctDir }: CrossTableProps) {
-  const data = useCrossTableData(res, pv);
-  if (pctDir === "horizontal") {
-    return <TransposedCrossTable data={data} res={res} />;
-  }
-  return <VerticalCrossTable data={data} res={res} />;
 }

--- a/src/components/aggregation/Toolbar.tsx
+++ b/src/components/aggregation/Toolbar.tsx
@@ -70,31 +70,6 @@ interface ViewOptsProps {
   >;
 }
 
-function ChartTypeSelect({
-  label,
-  value,
-  onChange,
-}: {
-  label: string;
-  value: ChartType;
-  onChange: (type: ChartType) => void;
-}) {
-  return (
-    <label>
-      {label}{" "}
-      <select
-        class="cursor-pointer rounded-sm border border-border bg-surface px-2 py-1 text-[0.8125rem] text-text"
-        value={value}
-        onChange={(e) => onChange((e.target as HTMLSelectElement).value as ChartType)}
-      >
-        <option value="bar-h">{t("chart.barH")}</option>
-        <option value="bar-v">{t("chart.barV")}</option>
-        <option value="obi">{t("chart.obi")}</option>
-      </select>
-    </label>
-  );
-}
-
 export function ViewOpts({
   currentViewMode,
   currentPctDirection,
@@ -146,5 +121,32 @@ export function ViewOpts({
         </ToggleGroup>
       )}
     </div>
+  );
+}
+
+// ─── Internal ───────────────────────────────────────────────
+
+function ChartTypeSelect({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: ChartType;
+  onChange: (type: ChartType) => void;
+}) {
+  return (
+    <label>
+      {label}{" "}
+      <select
+        class="cursor-pointer rounded-sm border border-border bg-surface px-2 py-1 text-[0.8125rem] text-text"
+        value={value}
+        onChange={(e) => onChange((e.target as HTMLSelectElement).value as ChartType)}
+      >
+        <option value="bar-h">{t("chart.barH")}</option>
+        <option value="bar-v">{t("chart.barV")}</option>
+        <option value="obi">{t("chart.obi")}</option>
+      </select>
+    </label>
   );
 }

--- a/src/components/header/SettingsModal.tsx
+++ b/src/components/header/SettingsModal.tsx
@@ -1,23 +1,8 @@
 import { useEffect, useRef, useState } from "preact/hooks";
 import { t, getLocale, setLocale, onLocaleChange } from "../../lib/i18n";
 
-const THEME_KEY = "aggy-theme";
-const AI_KEY = "aggy-ai-comment";
-
-type Theme = "light" | "dark" | "system";
-
 export function isAICommentEnabled(): boolean {
   return localStorage.getItem(AI_KEY) !== "off";
-}
-
-function setAIComment(on: boolean): void {
-  localStorage.setItem(AI_KEY, on ? "on" : "off");
-}
-
-function getStoredTheme(): Theme {
-  const v = localStorage.getItem(THEME_KEY);
-  if (v === "dark" || v === "light" || v === "system") return v;
-  return "system";
 }
 
 export function applyTheme(theme: Theme): void {
@@ -35,6 +20,104 @@ export function applyTheme(theme: Theme): void {
   } else {
     delete document.documentElement.dataset.theme;
   }
+}
+
+export function SettingsRoot() {
+  const [open, setOpen] = useState(false);
+  const [aiAvailable, setAiAvailable] = useState(false);
+  const [, setTick] = useState(0);
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  // System theme change listener
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => {
+      if (getStoredTheme() === "system") applyTheme("system");
+    };
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  // Re-render on locale change
+  useEffect(() => {
+    onLocaleChange(() => setTick((n) => n + 1));
+  }, []);
+
+  // Close on outside click or Escape
+  useEffect(() => {
+    if (!open) return;
+    const onClickOutside = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("click", onClickOutside);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("click", onClickOutside);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const handleToggle = async (e: MouseEvent) => {
+    e.stopPropagation();
+    if (open) {
+      setOpen(false);
+    } else {
+      // Check AI availability once
+      if (typeof LanguageModel !== "undefined" && (await LanguageModel.availability()) !== "no") {
+        setAiAvailable(true);
+      }
+      setOpen(true);
+    }
+  };
+
+  const rerender = () => setTick((n) => n + 1);
+
+  return (
+    <div class="relative" ref={wrapRef}>
+      <button
+        id="settings-btn"
+        class="cursor-pointer rounded-lg border border-border bg-transparent px-3 py-2 text-base leading-none text-text transition-[background,border-color] duration-150 hover:border-border-strong hover:bg-surface2"
+        data-i18n="header.settings"
+        data-i18n-attr="aria-label"
+        aria-label={t("header.settings")}
+        onClick={handleToggle}
+      >
+        ⚙
+      </button>
+      {open && (
+        <div class="absolute top-[calc(100%+8px)] right-0 z-100 w-[300px] rounded-xl border border-border bg-surface p-4 shadow-lg">
+          <SettingsPanel showAI={aiAvailable} onRerender={rerender} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Apply stored theme on app startup (call once in App useEffect) */
+export function initTheme(): void {
+  applyTheme(getStoredTheme());
+}
+
+// ─── Internal ───────────────────────────────────────────────
+
+const THEME_KEY = "aggy-theme";
+const AI_KEY = "aggy-ai-comment";
+
+type Theme = "light" | "dark" | "system";
+
+function setAIComment(on: boolean): void {
+  localStorage.setItem(AI_KEY, on ? "on" : "off");
+}
+
+function getStoredTheme(): Theme {
+  const v = localStorage.getItem(THEME_KEY);
+  if (v === "dark" || v === "light" || v === "system") return v;
+  return "system";
 }
 
 function SegmentControl({
@@ -128,85 +211,4 @@ function SettingsPanel({ showAI, onRerender }: { showAI: boolean; onRerender: ()
       )}
     </>
   );
-}
-
-export function SettingsRoot() {
-  const [open, setOpen] = useState(false);
-  const [aiAvailable, setAiAvailable] = useState(false);
-  const [, setTick] = useState(0);
-  const wrapRef = useRef<HTMLDivElement>(null);
-
-  // System theme change listener
-  useEffect(() => {
-    const mq = window.matchMedia("(prefers-color-scheme: dark)");
-    const handler = () => {
-      if (getStoredTheme() === "system") applyTheme("system");
-    };
-    mq.addEventListener("change", handler);
-    return () => mq.removeEventListener("change", handler);
-  }, []);
-
-  // Re-render on locale change
-  useEffect(() => {
-    onLocaleChange(() => setTick((n) => n + 1));
-  }, []);
-
-  // Close on outside click or Escape
-  useEffect(() => {
-    if (!open) return;
-    const onClickOutside = (e: MouseEvent) => {
-      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
-    };
-    document.addEventListener("click", onClickOutside);
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("click", onClickOutside);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [open]);
-
-  const handleToggle = async (e: MouseEvent) => {
-    e.stopPropagation();
-    if (open) {
-      setOpen(false);
-    } else {
-      // Check AI availability once
-      if (typeof LanguageModel !== "undefined" && (await LanguageModel.availability()) !== "no") {
-        setAiAvailable(true);
-      }
-      setOpen(true);
-    }
-  };
-
-  const rerender = () => setTick((n) => n + 1);
-
-  return (
-    <div class="relative" ref={wrapRef}>
-      <button
-        id="settings-btn"
-        class="cursor-pointer rounded-lg border border-border bg-transparent px-3 py-2 text-base leading-none text-text transition-[background,border-color] duration-150 hover:border-border-strong hover:bg-surface2"
-        data-i18n="header.settings"
-        data-i18n-attr="aria-label"
-        aria-label={t("header.settings")}
-        onClick={handleToggle}
-      >
-        ⚙
-      </button>
-      {open && (
-        <div class="absolute top-[calc(100%+8px)] right-0 z-100 w-[300px] rounded-xl border border-border bg-surface p-4 shadow-lg">
-          <SettingsPanel showAI={aiAvailable} onRerender={rerender} />
-        </div>
-      )}
-    </div>
-  );
-}
-
-/** Apply stored theme on app startup (call once in App useEffect) */
-export function initTheme(): void {
-  applyTheme(getStoredTheme());
 }

--- a/src/components/header/WasmStatus.tsx
+++ b/src/components/header/WasmStatus.tsx
@@ -1,16 +1,6 @@
 import { useState } from "preact/hooks";
 import { t } from "../../lib/i18n";
 
-type DotStatus = "loading" | "ready" | "error";
-
-const STATUS_CLASSES: Record<DotStatus, string> = {
-  loading: "bg-[var(--color-warning-700)] animate-[pulse_1s_infinite]",
-  ready: "bg-[var(--color-success-700)]",
-  error: "bg-danger",
-};
-
-let rerender: ((s: DotStatus, label?: string) => void) | null = null;
-
 export function setWasmStatus(s: DotStatus, label?: string): void {
   rerender?.(s, label);
 }
@@ -38,3 +28,15 @@ export default function WasmStatus() {
     </div>
   );
 }
+
+// ─── Internal ───────────────────────────────────────────────
+
+type DotStatus = "loading" | "ready" | "error";
+
+const STATUS_CLASSES: Record<DotStatus, string> = {
+  loading: "bg-[var(--color-warning-700)] animate-[pulse_1s_infinite]",
+  ready: "bg-[var(--color-success-700)]",
+  error: "bg-danger",
+};
+
+let rerender: ((s: DotStatus, label?: string) => void) | null = null;

--- a/src/components/import/GettingStarted.tsx
+++ b/src/components/import/GettingStarted.tsx
@@ -1,6 +1,55 @@
 import { useEffect, useState } from "preact/hooks";
 import { t, onLocaleChange } from "../../lib/i18n";
 
+export function GettingStartedModal({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const [, setTick] = useState(0);
+
+  // Re-render on locale change
+  useEffect(() => {
+    onLocaleChange(() => setTick((n) => n + 1));
+  }, []);
+
+  // Escape key to close
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  // Lock body scroll
+  useEffect(() => {
+    if (open) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      class="fixed inset-0 z-[1000] flex items-center justify-center bg-black/50 p-4 animate-[fadeIn_0.2s_ease]"
+      role="dialog"
+      aria-modal={true}
+      aria-labelledby="gs-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <GettingStartedContent onClose={onClose} />
+    </div>
+  );
+}
+
+// ─── Internal ───────────────────────────────────────────────
+
 function GettingStartedContent({ onClose }: { onClose: () => void }) {
   return (
     <div
@@ -70,53 +119,6 @@ function GettingStartedContent({ onClose }: { onClose: () => void }) {
           {t("gs.ok")}
         </button>
       </div>
-    </div>
-  );
-}
-
-export function GettingStartedModal({ open, onClose }: { open: boolean; onClose: () => void }) {
-  const [, setTick] = useState(0);
-
-  // Re-render on locale change
-  useEffect(() => {
-    onLocaleChange(() => setTick((n) => n + 1));
-  }, []);
-
-  // Escape key to close
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [open, onClose]);
-
-  // Lock body scroll
-  useEffect(() => {
-    if (open) {
-      document.body.style.overflow = "hidden";
-    } else {
-      document.body.style.overflow = "";
-    }
-    return () => {
-      document.body.style.overflow = "";
-    };
-  }, [open]);
-
-  if (!open) return null;
-
-  return (
-    <div
-      class="fixed inset-0 z-[1000] flex items-center justify-center bg-black/50 p-4 animate-[fadeIn_0.2s_ease]"
-      role="dialog"
-      aria-modal={true}
-      aria-labelledby="gs-title"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
-      }}
-    >
-      <GettingStartedContent onClose={onClose} />
     </div>
   );
 }

--- a/src/components/import/SavedFiles.tsx
+++ b/src/components/import/SavedFiles.tsx
@@ -8,10 +8,6 @@ export interface SavedEntry {
   timestamp: number;
 }
 
-// Global refresh trigger for imperative callers (e.g. after OPFS save)
-type Listener = () => void;
-const listeners = new Set<Listener>();
-
 /** Trigger refresh from outside Preact (e.g. after saving to OPFS) */
 export function triggerSavedFilesRefresh(): void {
   for (const fn of listeners) fn();
@@ -96,3 +92,8 @@ export function SavedFilesList({
     </>
   );
 }
+
+// ─── Internal ───────────────────────────────────────────────
+
+type Listener = () => void;
+const listeners = new Set<Listener>();

--- a/src/lib/agg/download.ts
+++ b/src/lib/agg/download.ts
@@ -4,6 +4,25 @@ import type { LayoutMeta } from "../layout";
 import { NA_VALUE } from "./sqlHelpers";
 import { pivot } from "./pivot";
 
+export function downloadAllCSV(
+  results: AggResult[],
+  _weightCol: string,
+  layoutMeta?: LayoutMeta,
+): void {
+  const hasCross = results.some((r) => {
+    const { subs } = pivot(r.cells);
+    return subs.length > 1;
+  });
+
+  if (hasCross) {
+    downloadCrossCSV(results, layoutMeta);
+  } else {
+    downloadGtCSV(results);
+  }
+}
+
+// ─── Internal ───────────────────────────────────────────────
+
 /** Resolve cross sub value to label */
 function resolveSubLabel(subLabel: string, meta?: LayoutMeta): string {
   if (subLabel === NA_VALUE) return "無回答";
@@ -25,23 +44,6 @@ function resolveSubLabel(subLabel: string, meta?: LayoutMeta): string {
 /** Resolve option label for CSV export */
 function resolveMainLabel(main: string): string {
   return main === NA_VALUE ? "無回答" : main;
-}
-
-export function downloadAllCSV(
-  results: AggResult[],
-  _weightCol: string,
-  layoutMeta?: LayoutMeta,
-): void {
-  const hasCross = results.some((r) => {
-    const { subs } = pivot(r.cells);
-    return subs.length > 1;
-  });
-
-  if (hasCross) {
-    downloadCrossCSV(results, layoutMeta);
-  } else {
-    downloadGtCSV(results);
-  }
 }
 
 function downloadGtCSV(results: AggResult[]): void {

--- a/src/lib/aiComment.ts
+++ b/src/lib/aiComment.ts
@@ -29,7 +29,45 @@ declare global {
   var LanguageModel: LanguageModelStatic | undefined;
 }
 
-// --- Prompt Payload ---
+export function buildPromptPayload(
+  results: AggResult[],
+  weightCol: string,
+  layoutMeta?: LayoutMeta,
+): string {
+  for (const topN of [5, 3, 2]) {
+    const text = summarizeResults(results, weightCol, layoutMeta, topN);
+    if (text.length <= MAX_PAYLOAD_CHARS) return text;
+  }
+  return summarizeResults(results.slice(0, 20), weightCol, layoutMeta, 2);
+}
+
+export async function generateComment(
+  results: AggResult[],
+  weightCol: string,
+  layoutMeta?: LayoutMeta,
+): Promise<string | null> {
+  try {
+    if (results.length === 0) return null;
+
+    const locale = getLocale();
+    const payload = buildPromptPayload(results, weightCol, layoutMeta);
+    const session = await LanguageModel!.create({
+      systemPrompt: t("ai.systemPrompt"),
+      expectedInputs: [{ type: "text", languages: [locale] }],
+      expectedOutputs: [{ type: "text", languages: [locale] }],
+    });
+
+    try {
+      return await session.prompt(payload);
+    } finally {
+      session.destroy();
+    }
+  } catch {
+    return null;
+  }
+}
+
+// ─── Internal ───────────────────────────────────────────────
 
 const MAX_PAYLOAD_CHARS = 3500;
 
@@ -77,44 +115,4 @@ function summarizeResults(
   lines.push("");
   lines.push(t("ai.userPrompt"));
   return lines.join("\n");
-}
-
-export function buildPromptPayload(
-  results: AggResult[],
-  weightCol: string,
-  layoutMeta?: LayoutMeta,
-): string {
-  for (const topN of [5, 3, 2]) {
-    const text = summarizeResults(results, weightCol, layoutMeta, topN);
-    if (text.length <= MAX_PAYLOAD_CHARS) return text;
-  }
-  return summarizeResults(results.slice(0, 20), weightCol, layoutMeta, 2);
-}
-
-// --- Comment Generation ---
-
-export async function generateComment(
-  results: AggResult[],
-  weightCol: string,
-  layoutMeta?: LayoutMeta,
-): Promise<string | null> {
-  try {
-    if (results.length === 0) return null;
-
-    const locale = getLocale();
-    const payload = buildPromptPayload(results, weightCol, layoutMeta);
-    const session = await LanguageModel!.create({
-      systemPrompt: t("ai.systemPrompt"),
-      expectedInputs: [{ type: "text", languages: [locale] }],
-      expectedOutputs: [{ type: "text", languages: [locale] }],
-    });
-
-    try {
-      return await session.prompt(payload);
-    } finally {
-      session.destroy();
-    }
-  } catch {
-    return null;
-  }
 }

--- a/src/lib/duckdbBridge.ts
+++ b/src/lib/duckdbBridge.ts
@@ -2,19 +2,6 @@ import * as duckdb from "@duckdb/duckdb-wasm";
 import { aggregate, type Query, type AggResult } from "./agg/aggregate";
 import { setWasmStatus } from "../components/header/WasmStatus";
 
-const DUCKDB_CDN = "https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.33.1-dev18.0/dist";
-
-type DuckStatus = "loading" | "ready" | "error";
-
-let db: duckdb.AsyncDuckDB | null = null;
-let conn: duckdb.AsyncDuckDBConnection | null = null;
-let status: DuckStatus = "loading";
-let initPromise: Promise<void> | null = null;
-
-function updateStatusUI(s: DuckStatus, label?: string): void {
-  setWasmStatus(s, label);
-}
-
 export async function initDuckDB(): Promise<void> {
   if (initPromise) return initPromise;
 
@@ -55,12 +42,6 @@ export async function initDuckDB(): Promise<void> {
   return initPromise;
 }
 
-async function getConnection(): Promise<duckdb.AsyncDuckDBConnection> {
-  if (!db || status !== "ready") throw new Error("DuckDB is not ready");
-  if (!conn) conn = await db.connect();
-  return conn;
-}
-
 /** Register CSV text in DuckDB and return headers and row count */
 export async function loadCSV(csvText: string): Promise<{ headers: string[]; rowCount: number }> {
   await initDuckDB();
@@ -87,4 +68,25 @@ export async function loadCSV(csvText: string): Promise<{ headers: string[]; row
 export async function runDuckDBAggregation(query: Query): Promise<AggResult[]> {
   const c = await getConnection();
   return aggregate(c, query);
+}
+
+// ─── Internal ───────────────────────────────────────────────
+
+const DUCKDB_CDN = "https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.33.1-dev18.0/dist";
+
+type DuckStatus = "loading" | "ready" | "error";
+
+let db: duckdb.AsyncDuckDB | null = null;
+let conn: duckdb.AsyncDuckDBConnection | null = null;
+let status: DuckStatus = "loading";
+let initPromise: Promise<void> | null = null;
+
+function updateStatusUI(s: DuckStatus, label?: string): void {
+  setWasmStatus(s, label);
+}
+
+async function getConnection(): Promise<duckdb.AsyncDuckDBConnection> {
+  if (!db || status !== "ready") throw new Error("DuckDB is not ready");
+  if (!conn) conn = await db.connect();
+  return conn;
 }

--- a/src/lib/opfs.ts
+++ b/src/lib/opfs.ts
@@ -5,11 +5,6 @@ export interface SavedEntry {
   timestamp: number;
 }
 
-async function getAggyDir(): Promise<FileSystemDirectoryHandle> {
-  const root = await navigator.storage.getDirectory();
-  return root.getDirectoryHandle("aggy-data", { create: true });
-}
-
 export async function saveData(
   csvName: string,
   csvText: string,
@@ -83,4 +78,11 @@ export async function loadSaved(
 export async function deleteSaved(folderId: string): Promise<void> {
   const dir = await getAggyDir();
   await dir.removeEntry(folderId, { recursive: true });
+}
+
+// ─── Internal ───────────────────────────────────────────────
+
+async function getAggyDir(): Promise<FileSystemDirectoryHandle> {
+  const root = await navigator.storage.getDirectory();
+  return root.getDirectoryHandle("aggy-data", { create: true });
 }


### PR DESCRIPTION
## Summary
- 全ファイルで `imports → exports (Public API) → internal implementation` の順序に統一
- 対象: 12コンポーネント + 4 libファイル（計14ファイル）
- CLAUDE.md に file ordering 規約を追記

## Test plan
- [x] `pnpm check` (fmt, lint, tsc) パス
- [x] `pnpm test` (88 tests) パス
- [ ] `pnpm dev` で画面動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)