### PR TITLE
fix: OPFS保存タイミングをファイル選択時から集計画面遷移時に変更

### DIFF
--- a/src/components/ImportScreen.tsx
+++ b/src/components/ImportScreen.tsx
@@ -115,7 +115,7 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
     updateLoadedInfo();
   }
 
-  async function trySaveToOPFS(): Promise<void> {
+  async function saveToOPFS(): Promise<void> {
     const csv = csvRef.current;
     const layout = layoutRef.current;
     if (!csv || !layout) return;
@@ -185,7 +185,7 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
 
   function handleProceed(): void {
     if (csvRef.current && layoutRef.current) {
-      trySaveToOPFS();
+      saveToOPFS();
       onComplete(csvRef.current, layoutRef.current);
     }
   }

--- a/src/components/ImportScreen.tsx
+++ b/src/components/ImportScreen.tsx
@@ -140,7 +140,6 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
       setCsvFileName(file.name);
       updateLoadedInfo();
       checkBothLoaded();
-      trySaveToOPFS();
     } catch (e) {
       console.error("CSV load failed:", e);
     }
@@ -155,7 +154,6 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
       setLayoutFileName(file.name);
       updateLoadedInfo();
       checkBothLoaded();
-      trySaveToOPFS();
     } catch (e) {
       console.error("Layout load failed:", e);
     }
@@ -187,6 +185,7 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
 
   function handleProceed(): void {
     if (csvRef.current && layoutRef.current) {
+      trySaveToOPFS();
       onComplete(csvRef.current, layoutRef.current);
     }
   }


### PR DESCRIPTION
## Summary
- ファイル選択直後にOPFS履歴へ保存されていたのを、「集計画面へ進む」ボタン押下時に変更
- `trySaveToOPFS` を `saveToOPFS` にリネーム

## Test plan
- [ ] CSVとLayoutファイルを選択し、履歴に即座に追加されないことを確認
- [ ] 「集計画面へ進む」ボタン押下後、履歴に追加されることを確認
- [ ] 履歴からの読み込みが従来通り動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)