### PR TITLE
feat: チャートのカラーパレット選択機能を追加

### DIFF
--- a/src/components/aggregation/ChartContent.tsx
+++ b/src/components/aggregation/ChartContent.tsx
@@ -4,7 +4,7 @@ import { useRef, useEffect } from "preact/hooks";
 import type { AggResult, QuestionDef } from "../../lib/agg/aggregate";
 import type { LayoutMeta } from "../../lib/layout";
 import { pivot } from "../../lib/agg/pivot";
-import { Chart, getSeriesColor, getThemeColors } from "../../lib/chartConfig";
+import { Chart, getSeriesColor, getThemeColors, type PaletteId } from "../../lib/chartConfig";
 import { resolveValueLabel, resolveSubLabel } from "../../lib/labels";
 import { useAggregation } from "./AggregationContext";
 import { ResultCard } from "./ResultCard";
@@ -16,9 +16,10 @@ export type ChartType = "bar-h" | "bar-v" | "obi";
 interface ChartContentProps {
   saChartType: ChartType;
   maChartType: ChartType;
+  paletteId: PaletteId;
 }
 
-export function ChartContent({ saChartType, maChartType }: ChartContentProps) {
+export function ChartContent({ saChartType, maChartType, paletteId }: ChartContentProps) {
   const { results, hasCross } = useAggregation();
   return (
     <div
@@ -33,6 +34,7 @@ export function ChartContent({ saChartType, maChartType }: ChartContentProps) {
           key={res.question}
           res={res}
           gtChartType={res.type === "SA" ? saChartType : maChartType}
+          paletteId={paletteId}
         />
       ))}
     </div>
@@ -42,9 +44,10 @@ export function ChartContent({ saChartType, maChartType }: ChartContentProps) {
 interface ChartCardProps {
   res: AggResult;
   gtChartType: ChartType;
+  paletteId: PaletteId;
 }
 
-function ChartCard({ res, gtChartType }: ChartCardProps) {
+function ChartCard({ res, gtChartType, paletteId }: ChartCardProps) {
   const { layoutMeta, crossCols } = useAggregation();
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const chartRef = useRef<Chart | null>(null);
@@ -69,16 +72,17 @@ function ChartCard({ res, gtChartType }: ChartCardProps) {
         theme,
         layoutMeta,
         crossCols,
+        paletteId,
       );
     } else {
-      chartRef.current = buildGtChart(canvas, pv, gtChartType, res, theme, layoutMeta);
+      chartRef.current = buildGtChart(canvas, pv, gtChartType, res, theme, layoutMeta, paletteId);
     }
 
     return () => {
       chartRef.current?.destroy();
       chartRef.current = null;
     };
-  }, [res, gtChartType, layoutMeta, crossCols]);
+  }, [res, gtChartType, layoutMeta, crossCols, paletteId]);
 
   return (
     <ResultCard res={res}>
@@ -96,18 +100,19 @@ function buildGtChart(
   res: AggResult,
   theme: ReturnType<typeof getThemeColors>,
   layoutMeta: LayoutMeta,
+  paletteId: PaletteId,
 ): Chart {
   const { mains, lookup } = pv;
   const labels = mains.map((m) => resolveValueLabel(res.type, res.question, m, layoutMeta));
   const data = mains.map((m) => lookup.get(`${m}\0GT`)?.pct ?? 0);
-  const colors = mains.map((_, i) => getSeriesColor(i));
+  const colors = mains.map((_, i) => getSeriesColor(i, paletteId));
 
   // Stacked bar: each option as a segment in one horizontal bar
   if (chartType === "obi") {
     const datasets = mains.map((m, i) => ({
       label: resolveValueLabel(res.type, res.question, m, layoutMeta),
       data: [lookup.get(`${m}\0GT`)?.pct ?? 0],
-      backgroundColor: getSeriesColor(i),
+      backgroundColor: getSeriesColor(i, paletteId),
       maxBarThickness: 48,
     }));
 
@@ -189,6 +194,7 @@ function buildCrossChart(
   theme: ReturnType<typeof getThemeColors>,
   layoutMeta: LayoutMeta,
   crossCols: QuestionDef[],
+  paletteId: PaletteId,
 ): Chart {
   const { mains, subs, lookup } = pv;
   const crossSubs = subs.filter((s) => s.label !== "GT");
@@ -202,7 +208,7 @@ function buildCrossChart(
         const cell = lookup.get(`${m}\0${sub.label}`);
         return cell?.pct ?? 0;
       }),
-      backgroundColor: getSeriesColor(i),
+      backgroundColor: getSeriesColor(i, paletteId),
       maxBarThickness: 48,
     }));
 
@@ -244,7 +250,7 @@ function buildCrossChart(
       const cell = lookup.get(`${m}\0${sub.label}`);
       return cell?.pct ?? 0;
     }),
-    backgroundColor: getSeriesColor(i),
+    backgroundColor: getSeriesColor(i, paletteId),
     borderRadius: 3,
     maxBarThickness: 40,
   }));

--- a/src/components/aggregation/ResultView.tsx
+++ b/src/components/aggregation/ResultView.tsx
@@ -3,12 +3,14 @@ import { Toolbar, ViewOpts, type PctDirection, type ViewMode } from "./Toolbar";
 import { ChartContent, type ChartType } from "./ChartContent";
 import { TableContent } from "./TableContent";
 import { AIBubble } from "./AIBubble";
+import type { PaletteId } from "../../lib/chartConfig";
 
 export default function ResultView() {
   const [viewMode, setViewMode] = useState<ViewMode>("table");
   const [saChartType, setSaChartType] = useState<ChartType>("bar-h");
   const [maChartType, setMaChartType] = useState<ChartType>("bar-h");
   const [pctDirection, setPctDirection] = useState<PctDirection>("vertical");
+  const [paletteId, setPaletteId] = useState<PaletteId>("default");
   const [, setThemeTick] = useState(0);
 
   // Re-render on theme change (needed for canvas-based charts)
@@ -28,6 +30,7 @@ export default function ResultView() {
     onSaChartTypeChange: setSaChartType,
     onMaChartTypeChange: setMaChartType,
     onPctDirectionChange: setPctDirection,
+    onPaletteChange: setPaletteId,
   };
 
   return (
@@ -38,10 +41,11 @@ export default function ResultView() {
         currentPctDirection={pctDirection}
         saChartType={saChartType}
         maChartType={maChartType}
+        paletteId={paletteId}
         callbacks={callbacks}
       />
       {viewMode === "chart" ? (
-        <ChartContent saChartType={saChartType} maChartType={maChartType} />
+        <ChartContent saChartType={saChartType} maChartType={maChartType} paletteId={paletteId} />
       ) : (
         <TableContent pctDirection={pctDirection} />
       )}

--- a/src/components/aggregation/Toolbar.tsx
+++ b/src/components/aggregation/Toolbar.tsx
@@ -1,5 +1,6 @@
 import { downloadAllCSV } from "../../lib/agg/download";
 import { t } from "../../lib/i18n";
+import { PALETTE_BASES, PALETTE_IDS, type PaletteId } from "../../lib/chartConfig";
 import type { ChartType } from "./ChartContent";
 import { ToggleButton, ToggleGroup } from "../shared/ToggleButton";
 import { useAggregation } from "./AggregationContext";
@@ -12,6 +13,7 @@ export interface ToolbarCallbacks {
   onSaChartTypeChange: (type: ChartType) => void;
   onMaChartTypeChange: (type: ChartType) => void;
   onPctDirectionChange: (dir: PctDirection) => void;
+  onPaletteChange: (id: PaletteId) => void;
 }
 
 interface ToolbarProps {
@@ -64,9 +66,10 @@ interface ViewOptsProps {
   currentPctDirection: PctDirection;
   saChartType: ChartType;
   maChartType: ChartType;
+  paletteId: PaletteId;
   callbacks: Pick<
     ToolbarCallbacks,
-    "onSaChartTypeChange" | "onMaChartTypeChange" | "onPctDirectionChange"
+    "onSaChartTypeChange" | "onMaChartTypeChange" | "onPctDirectionChange" | "onPaletteChange"
   >;
 }
 
@@ -75,6 +78,7 @@ export function ViewOpts({
   currentPctDirection,
   saChartType,
   maChartType,
+  paletteId,
   callbacks,
 }: ViewOptsProps) {
   const { hasCross } = useAggregation();
@@ -98,6 +102,7 @@ export function ViewOpts({
             value={maChartType}
             onChange={callbacks.onMaChartTypeChange}
           />
+          <PaletteSelector current={paletteId} onChange={callbacks.onPaletteChange} />
         </>
       )}
       {showPctToggle && (
@@ -125,6 +130,43 @@ export function ViewOpts({
 }
 
 // ─── Internal ───────────────────────────────────────────────
+
+function PaletteSelector({
+  current,
+  onChange,
+}: {
+  current: PaletteId;
+  onChange: (id: PaletteId) => void;
+}) {
+  return (
+    <div class="flex items-center gap-1.5" role="radiogroup" aria-label={t("chart.palette")}>
+      <span class="mr-0.5 text-muted">{t("chart.palette")}:</span>
+      {PALETTE_IDS.map((id) => {
+        const isActive = id === current;
+        const base = id === "default" ? undefined : PALETTE_BASES[id];
+        return (
+          <button
+            key={id}
+            type="button"
+            role="radio"
+            aria-checked={isActive}
+            aria-label={id}
+            class={`h-5 w-5 cursor-pointer rounded-full border-2 transition-shadow ${isActive ? "border-accent shadow-[0_0_0_1px_var(--accent)]" : "border-border hover:border-muted"}`}
+            style={
+              base
+                ? { backgroundColor: base }
+                : {
+                    background:
+                      "conic-gradient(#0064d4, #0097a7, #1b7d3a, #e06500, #c62828, #6a1b9a, #0064d4)",
+                  }
+            }
+            onClick={() => onChange(id)}
+          />
+        );
+      })}
+    </div>
+  );
+}
 
 function ChartTypeSelect({
   label,

--- a/src/lib/chartConfig.ts
+++ b/src/lib/chartConfig.ts
@@ -15,7 +15,7 @@ Chart.register(BarController, CategoryScale, LinearScale, BarElement, Tooltip, L
 export { Chart };
 
 /** Color palette for survey aggregation (light/dark compatible) */
-const PALETTE = [
+const DEFAULT_PALETTE = [
   "#0064d4",
   "#0097a7",
   "#e06500",
@@ -28,8 +28,84 @@ const PALETTE = [
   "#00695c",
 ];
 
-export function getSeriesColor(index: number): string {
-  return PALETTE[index % PALETTE.length];
+export type PaletteId = "default" | "blue" | "green" | "orange" | "red" | "purple";
+
+/** ColorBrewer sequential single-hue 9-step palettes (dark → light) */
+const COLORBREWER_PALETTES: Record<Exclude<PaletteId, "default">, string[]> = {
+  blue: [
+    "#08306b",
+    "#08519c",
+    "#2171b5",
+    "#4292c6",
+    "#6baed6",
+    "#9ecae1",
+    "#c6dbef",
+    "#deebf7",
+    "#f7fbff",
+  ],
+  green: [
+    "#00441b",
+    "#006d2c",
+    "#238b45",
+    "#41ab5d",
+    "#74c476",
+    "#a1d99b",
+    "#c7e9c0",
+    "#e5f5e0",
+    "#f7fcf5",
+  ],
+  orange: [
+    "#7f2704",
+    "#a63603",
+    "#d94801",
+    "#f16913",
+    "#fd8d3c",
+    "#fdae6b",
+    "#fdd0a2",
+    "#fee6ce",
+    "#fff5eb",
+  ],
+  red: [
+    "#67000d",
+    "#a50f15",
+    "#cb181d",
+    "#ef3b2c",
+    "#fb6a4a",
+    "#fc9272",
+    "#fcbba1",
+    "#fee0d2",
+    "#fff5f0",
+  ],
+  purple: [
+    "#3f007d",
+    "#54278f",
+    "#6a51a3",
+    "#807dba",
+    "#9e9ac8",
+    "#bcbddc",
+    "#dadaeb",
+    "#efedf5",
+    "#fcfbfd",
+  ],
+};
+
+/** Representative base color for each palette (used for UI swatch) */
+export const PALETTE_BASES: Record<Exclude<PaletteId, "default">, string> = {
+  blue: "#2171b5",
+  green: "#238b45",
+  orange: "#d94801",
+  red: "#cb181d",
+  purple: "#6a51a3",
+};
+
+export const PALETTE_IDS: PaletteId[] = ["default", "blue", "green", "orange", "red", "purple"];
+
+export function getSeriesColor(index: number, paletteId: PaletteId = "default"): string {
+  if (paletteId === "default") {
+    return DEFAULT_PALETTE[index % DEFAULT_PALETTE.length];
+  }
+  const palette = COLORBREWER_PALETTES[paletteId];
+  return palette[index % palette.length];
 }
 
 /** Get current theme colors from CSS variables */

--- a/src/lib/chartConfig.ts
+++ b/src/lib/chartConfig.ts
@@ -98,7 +98,7 @@ export const PALETTE_BASES: Record<Exclude<PaletteId, "default">, string> = {
   purple: "#6a51a3",
 };
 
-export const PALETTE_IDS: PaletteId[] = ["default", "blue", "green", "orange", "red", "purple"];
+export const PALETTE_IDS: PaletteId[] = ["default", "red", "orange", "green", "blue", "purple"];
 
 export function getSeriesColor(index: number, paletteId: PaletteId = "default"): string {
   if (paletteId === "default") {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -54,6 +54,7 @@ const en: Record<string, string> = {
   "chart.barH": "Horizontal Bar",
   "chart.barV": "Vertical Bar",
   "chart.obi": "Stacked",
+  "chart.palette": "Color",
 
   // Table headers
   "table.option": "Option",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -54,6 +54,7 @@ const ja: Record<string, string> = {
   "chart.barH": "横棒",
   "chart.barV": "縦棒",
   "chart.obi": "帯",
+  "chart.palette": "配色",
 
   // Table headers
   "table.option": "選択肢",


### PR DESCRIPTION
## Summary
- チャート表示時にカラーパレットを選択できるUIを追加
- デフォルト（複数色）+ ColorBrewerの単色グラデーション5種（赤・橙・緑・青・紫）の計6パレット
- 丸いカラーアイコンで直感的に切り替え可能（暖色→寒色の虹色順に配置）

## Test plan
- [ ] `pnpm dev` でチャート表示し、丸アイコンクリックでパレットが切り替わること
- [ ] GT集計・クロス集計の両方で反映されること
- [ ] デフォルト選択時は従来と同じ見た目であること
- [ ] 帯チャート・横棒・縦棒すべてで配色が適用されること
- [ ] `pnpm check` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)