### PR TITLE
fix: 履歴から読み込んだデータが重複保存される問題を修正

### DIFF
--- a/src/components/ImportScreen.tsx
+++ b/src/components/ImportScreen.tsx
@@ -92,6 +92,7 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
 
   const csvRef = useRef<CsvData | null>(null);
   const layoutRef = useRef<LayoutData | null>(null);
+  const loadedFromSavedRef = useRef(false);
 
   const { entries, deleteEntry } = useSavedFiles();
 
@@ -137,6 +138,7 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
         headers: result.headers,
         rowCount: result.rowCount,
       };
+      loadedFromSavedRef.current = false;
       setCsvFileName(file.name);
       updateLoadedInfo();
       checkBothLoaded();
@@ -151,6 +153,7 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
       const layout = parseLayout(text);
       const meta = buildLayoutMeta(layout);
       layoutRef.current = { json: text, fileName: file.name, meta };
+      loadedFromSavedRef.current = false;
       setLayoutFileName(file.name);
       updateLoadedInfo();
       checkBothLoaded();
@@ -174,6 +177,7 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
       };
       layoutRef.current = { json: layoutJson, fileName: layoutName, meta };
 
+      loadedFromSavedRef.current = true;
       setCsvFileName(csvName);
       setLayoutFileName(layoutName);
       updateLoadedInfo();
@@ -185,7 +189,7 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
 
   function handleProceed(): void {
     if (csvRef.current && layoutRef.current) {
-      saveToOPFS();
+      if (!loadedFromSavedRef.current) saveToOPFS();
       onComplete(csvRef.current, layoutRef.current);
     }
   }


### PR DESCRIPTION
## Summary
- 履歴から選択して集計画面に遷移する際、`saveToOPFS()` が常に呼ばれ同じデータが新規エントリとして重複保存されていた
- `loadedFromSavedRef` フラグで履歴由来のデータを追跡し、その場合は保存をスキップ
- 新規ファイルアップロード時にはフラグをリセットするため、履歴選択後に別ファイルをアップロードした場合は正しく保存される

## Test plan
- [ ] 新規ファイルをアップロードして集計画面に遷移 → 履歴に1件追加されること
- [ ] 履歴から選択して集計画面に遷移 → 履歴に重複エントリが追加されないこと
- [ ] 履歴から選択後、別ファイルをアップロードして遷移 → 新規として保存されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)