### PR TITLE
feat: aggregate()のベンチマーク基盤を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 .claude/
+bench/data/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,9 @@ pnpm lint          # oxlint
 pnpm lint:fix      # oxlint --fix
 pnpm fmt           # oxfmt (format)
 pnpm fmt:check     # oxfmt --check
+pnpm bench         # aggregate() benchmark (all patterns)
+pnpm bench rows    # single pattern (rows / cols / both)
+pnpm bench:gen     # generate benchmark data
 ```
 
 ## Architecture

--- a/bench/generate.ts
+++ b/bench/generate.ts
@@ -1,0 +1,169 @@
+/**
+ * Benchmark data generator — produces CSV + layout JSON for each pattern.
+ *
+ * Usage:
+ *   tsx bench/generate.ts            # generate all patterns
+ *   tsx bench/generate.ts rows       # generate a specific pattern
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Seeded PRNG (mulberry32) — deterministic across runs
+// ---------------------------------------------------------------------------
+
+function mulberry32(seed: number): () => number {
+  let s = seed | 0;
+  return () => {
+    s = (s + 0x6d2b79f5) | 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pattern definitions
+// ---------------------------------------------------------------------------
+
+export interface PatternDef {
+  name: string;
+  rows: number;
+  saCount: number;
+  maCount: number;
+  maSubCount: number;
+}
+
+export const PATTERNS: PatternDef[] = [
+  { name: "rows", rows: 10_000, saCount: 10, maCount: 10, maSubCount: 5 },
+  { name: "cols", rows: 1_000, saCount: 100, maCount: 100, maSubCount: 5 },
+  { name: "both", rows: 10_000, saCount: 100, maCount: 100, maSubCount: 5 },
+];
+
+// ---------------------------------------------------------------------------
+// CSV generation
+// ---------------------------------------------------------------------------
+
+function generateCSV(pattern: PatternDef, rand: () => number): string {
+  const { rows, saCount, maCount, maSubCount } = pattern;
+
+  // Build header
+  const headers: string[] = ["id", "weight"];
+  for (let i = 1; i <= saCount; i++) headers.push(`sa${i}`);
+  for (let i = 1; i <= maCount; i++) {
+    for (let j = 1; j <= maSubCount; j++) headers.push(`ma${i}_${j}`);
+  }
+
+  const lines: string[] = [headers.join(",")];
+
+  for (let r = 1; r <= rows; r++) {
+    const cells: string[] = [];
+    // id
+    cells.push(String(r));
+    // weight: 0.5 ~ 1.5
+    cells.push((0.5 + rand()).toFixed(2));
+    // SA columns
+    for (let i = 0; i < saCount; i++) {
+      if (rand() < 0.05) {
+        cells.push(""); // 5% missing
+      } else {
+        cells.push(String(Math.floor(rand() * 5) + 1));
+      }
+    }
+    // MA columns
+    for (let i = 0; i < maCount * maSubCount; i++) {
+      cells.push(rand() < 0.5 ? "1" : "0");
+    }
+    lines.push(cells.join(","));
+  }
+
+  return lines.join("\n") + "\n";
+}
+
+// ---------------------------------------------------------------------------
+// Layout JSON generation
+// ---------------------------------------------------------------------------
+
+interface LayoutEntry {
+  key: string;
+  type: string;
+  label?: string;
+  items?: { code: string; label: string }[];
+}
+
+function generateLayout(pattern: PatternDef): LayoutEntry[] {
+  const { saCount, maCount, maSubCount } = pattern;
+  const layout: LayoutEntry[] = [
+    { key: "id", type: "ID" },
+    { key: "weight", type: "WEIGHT" },
+  ];
+
+  for (let i = 1; i <= saCount; i++) {
+    layout.push({
+      key: `sa${i}`,
+      label: `SA設問${i}`,
+      type: "SA",
+      items: Array.from({ length: 5 }, (_, j) => ({
+        code: String(j + 1),
+        label: `選択肢${j + 1}`,
+      })),
+    });
+  }
+
+  for (let i = 1; i <= maCount; i++) {
+    layout.push({
+      key: `ma${i}`,
+      label: `MA設問${i}`,
+      type: "MA",
+      items: Array.from({ length: maSubCount }, (_, j) => ({
+        code: String(j + 1),
+        label: `項目${j + 1}`,
+      })),
+    });
+  }
+
+  return layout;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+export function generate(patternNames?: string[]): void {
+  const dataDir = resolve(import.meta.dirname!, "data");
+  mkdirSync(dataDir, { recursive: true });
+
+  const targets = patternNames
+    ? PATTERNS.filter((p) => patternNames.includes(p.name))
+    : PATTERNS;
+
+  if (targets.length === 0) {
+    console.error(`Unknown pattern(s): ${patternNames?.join(", ")}`);
+    console.error(`Available: ${PATTERNS.map((p) => p.name).join(", ")}`);
+    process.exit(1);
+  }
+
+  for (const pattern of targets) {
+    const seed = 42;
+    const rand = mulberry32(seed);
+
+    console.log(
+      `Generating ${pattern.name}: ${pattern.rows.toLocaleString()} rows × ${pattern.saCount + pattern.maCount * pattern.maSubCount + 2} cols`,
+    );
+
+    const csv = generateCSV(pattern, rand);
+    writeFileSync(resolve(dataDir, `${pattern.name}.csv`), csv);
+
+    const layout = generateLayout(pattern);
+    writeFileSync(resolve(dataDir, `${pattern.name}_layout.json`), JSON.stringify(layout, null, 2));
+  }
+
+  console.log("Done.");
+}
+
+// CLI entry point
+if (process.argv[1]?.endsWith("generate.ts") || process.argv[1]?.endsWith("generate")) {
+  const args = process.argv.slice(2);
+  generate(args.length > 0 ? args : undefined);
+}

--- a/bench/run.ts
+++ b/bench/run.ts
@@ -1,0 +1,206 @@
+/**
+ * Benchmark runner — measures aggregate() execution time for each data pattern.
+ *
+ * Usage:
+ *   tsx bench/run.ts              # run all patterns
+ *   tsx bench/run.ts rows         # run a specific pattern
+ */
+
+import { createRequire } from "node:module";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { performance } from "node:perf_hooks";
+
+import { aggregate } from "../src/lib/agg/aggregate";
+import type { Query, QuestionDef } from "../src/lib/agg/aggregate";
+import { parseLayout, buildLayoutMeta, buildQuestionDefs } from "../src/lib/layout";
+import { generate, PATTERNS, type PatternDef } from "./generate";
+
+// ---------------------------------------------------------------------------
+// DuckDB setup (same approach as tests/helpers/duckdb.ts)
+// ---------------------------------------------------------------------------
+
+const require = createRequire(import.meta.url);
+const DUCKDB_DIST = resolve(require.resolve("@duckdb/duckdb-wasm"), "..");
+
+const { createDuckDB, NODE_RUNTIME, ConsoleLogger } = require(
+  resolve(DUCKDB_DIST, "duckdb-node-blocking.cjs"),
+);
+
+let db: any;
+let conn: any;
+
+async function initDuckDB(): Promise<void> {
+  const logger = new ConsoleLogger();
+  const bundles = {
+    mvp: { mainModule: resolve(DUCKDB_DIST, "duckdb-mvp.wasm") },
+    eh: { mainModule: resolve(DUCKDB_DIST, "duckdb-eh.wasm") },
+  };
+  db = await createDuckDB(bundles, logger, NODE_RUNTIME);
+  await db.instantiate();
+  conn = await db.connect();
+}
+
+async function loadCSVIntoDuckDB(csvText: string): Promise<void> {
+  await db.registerFileText("survey.csv", csvText);
+  await conn.query(
+    `CREATE OR REPLACE VIEW survey AS SELECT * FROM read_csv('survey.csv', all_varchar=true)`,
+  );
+}
+
+async function closeDuckDB(): Promise<void> {
+  if (conn) await conn.close();
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark logic
+// ---------------------------------------------------------------------------
+
+const RUNS = 3;
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+interface BenchResult {
+  pattern: string;
+  rows: number;
+  cols: number;
+  cross: string;
+  medianMs: number;
+  allMs: number[];
+}
+
+async function benchPattern(
+  pattern: PatternDef,
+  questions: QuestionDef[],
+  crossCols: QuestionDef[],
+  crossLabel: string,
+): Promise<BenchResult> {
+  const query: Query = {
+    questions,
+    weight_col: "weight",
+    cross_cols: crossCols,
+  };
+
+  const totalCols = pattern.saCount + pattern.maCount * pattern.maSubCount + 2;
+  const times: number[] = [];
+
+  for (let i = 0; i < RUNS; i++) {
+    const start = performance.now();
+    await aggregate(conn, query);
+    const elapsed = performance.now() - start;
+    times.push(elapsed);
+  }
+
+  return {
+    pattern: pattern.name,
+    rows: pattern.rows,
+    cols: totalCols,
+    cross: crossLabel,
+    medianMs: median(times),
+    allMs: times,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const targets = args.length > 0
+    ? PATTERNS.filter((p) => args.includes(p.name))
+    : PATTERNS;
+
+  if (targets.length === 0) {
+    console.error(`Unknown pattern(s): ${args.join(", ")}`);
+    console.error(`Available: ${PATTERNS.map((p) => p.name).join(", ")}`);
+    process.exit(1);
+  }
+
+  // Ensure data exists
+  const dataDir = resolve(import.meta.dirname!, "data");
+  const missing = targets.filter(
+    (p) => !existsSync(resolve(dataDir, `${p.name}.csv`)),
+  );
+  if (missing.length > 0) {
+    console.log(`Generating missing data: ${missing.map((p) => p.name).join(", ")}`);
+    generate(missing.map((p) => p.name));
+  }
+
+  // Init DuckDB
+  console.log("Initializing DuckDB...");
+  await initDuckDB();
+
+  const results: BenchResult[] = [];
+
+  for (const pattern of targets) {
+    console.log(`\nBenchmarking: ${pattern.name}`);
+
+    // Load CSV
+    const csvText = readFileSync(resolve(dataDir, `${pattern.name}.csv`), "utf-8");
+    await loadCSVIntoDuckDB(csvText);
+
+    // Parse layout → build questions
+    const layoutText = readFileSync(resolve(dataDir, `${pattern.name}_layout.json`), "utf-8");
+    const layout = parseLayout(layoutText);
+    const meta = buildLayoutMeta(layout);
+
+    // Extract headers from CSV first line
+    const headers = csvText.slice(0, csvText.indexOf("\n")).split(",");
+    const questions = buildQuestionDefs(headers, meta.colTypes);
+
+    // Pick 2 SA questions for cross-tab
+    const saQuestions = questions.filter((q): q is Extract<QuestionDef, { type: "SA" }> => q.type === "SA");
+    const crossCols = saQuestions.slice(0, 2);
+
+    // Run: no cross
+    results.push(await benchPattern(pattern, questions, [], "none"));
+
+    // Run: SA×2 cross
+    results.push(await benchPattern(pattern, questions, crossCols, `SA×2`));
+  }
+
+  await closeDuckDB();
+
+  // Print results
+  console.log("\n" + "=".repeat(80));
+  console.log("BENCHMARK RESULTS (aggregate() execution time)");
+  console.log("=".repeat(80));
+  console.log(
+    padEnd("Pattern", 10) +
+    padEnd("Rows", 10) +
+    padEnd("Cols", 8) +
+    padEnd("Cross", 8) +
+    padEnd("Runs", 6) +
+    padEnd("Median", 14) +
+    "All (ms)",
+  );
+  console.log("-".repeat(80));
+
+  for (const r of results) {
+    console.log(
+      padEnd(r.pattern, 10) +
+      padEnd(r.rows.toLocaleString(), 10) +
+      padEnd(String(r.cols), 8) +
+      padEnd(r.cross, 8) +
+      padEnd(String(RUNS), 6) +
+      padEnd(r.medianMs.toFixed(1) + " ms", 14) +
+      r.allMs.map((t) => t.toFixed(1)).join(", "),
+    );
+  }
+
+  console.log("=".repeat(80));
+}
+
+function padEnd(s: string, len: number): string {
+  return s.padEnd(len);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "fmt:check": "oxfmt --check src/ scripts/ vite.config.ts index.html",
     "test": "vitest run",
     "test:watch": "vitest",
-    "check": "pnpm run fmt:check && pnpm run lint && tsc --noEmit"
+    "check": "pnpm run fmt:check && pnpm run lint && tsc --noEmit",
+    "bench:gen": "tsx bench/generate.ts",
+    "bench": "tsx bench/run.ts"
   },
   "dependencies": {
     "@duckdb/duckdb-wasm": "^1.33.1-dev18.0",


### PR DESCRIPTION
## Summary
- `bench/generate.ts`: シード付きPRNGによる決定論的テストデータ生成（CSV + layout JSON）
- `bench/run.ts`: DuckDB node-blocking APIを使ったaggregate()の実行時間計測（パターン別×クロス有無）
- `pnpm bench` / `pnpm bench:gen` スクリプト追加
- 生成データ（`bench/data/`）は`.gitignore`で除外

## Benchmark結果（参考値）
```
Pattern   Rows      Cols    Cross   Runs  Median        All (ms)
rows      10,000    62      none    3     1255.4 ms     1293.4, 1255.4, 1251.4
rows      10,000    62      SA×2    3     3883.8 ms     3937.7, 3883.8, 3883.5
```

## Test plan
- [ ] `pnpm bench:gen` でデータ生成を確認
- [ ] `pnpm bench rows` で単一パターン実行を確認
- [ ] `pnpm bench` で全パターン実行を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)