### PR TITLE
refactor: クロス集計時にGTテーブルとクロステーブルを分離表示

### DIFF
--- a/src/components/aggregation/ChartContent.tsx
+++ b/src/components/aggregation/ChartContent.tsx
@@ -29,68 +29,99 @@ export function ChartContent({ saChartType, maChartType, paletteId }: ChartConte
           : "grid grid-cols-[repeat(auto-fill,minmax(400px,1fr))] gap-6"
       }
     >
-      {results.map((res) => (
-        <ChartCard
-          key={res.question}
-          res={res}
-          gtChartType={res.type === "SA" ? saChartType : maChartType}
-          paletteId={paletteId}
-        />
-      ))}
+      {results.map((res) => {
+        const chartType = res.type === "SA" ? saChartType : maChartType;
+
+        if (!hasCross) {
+          return <GtChartCard key={res.question} res={res} chartType={chartType} paletteId={paletteId} />;
+        }
+
+        return (
+          <ResultCard key={res.question} res={res}>
+            <div class="flex items-end gap-4 pl-4">
+              <div class="shrink-0 p-4 h-80">
+                <GtChartCanvas res={res} chartType={chartType} paletteId={paletteId} />
+              </div>
+              <div class="min-w-0 flex-1 p-4 h-[400px]">
+                <CrossChartCanvas res={res} chartType={chartType} paletteId={paletteId} />
+              </div>
+            </div>
+          </ResultCard>
+        );
+      })}
     </div>
   );
 }
 
-interface ChartCardProps {
+interface ChartCanvasProps {
   res: AggResult;
-  gtChartType: ChartType;
+  chartType: ChartType;
   paletteId: PaletteId;
 }
 
-function ChartCard({ res, gtChartType, paletteId }: ChartCardProps) {
-  const { layoutMeta, crossCols } = useAggregation();
+function GtChartCard({ res, chartType, paletteId }: ChartCanvasProps) {
+  return (
+    <ResultCard res={res}>
+      <div class="p-4 h-80">
+        <GtChartCanvas res={res} chartType={chartType} paletteId={paletteId} />
+      </div>
+    </ResultCard>
+  );
+}
+
+function GtChartCanvas({ res, chartType, paletteId }: ChartCanvasProps) {
+  const { layoutMeta } = useAggregation();
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const chartRef = useRef<Chart | null>(null);
 
-  const pv = pivot(res.cells);
-  const isCross = pv.subs.length > 1;
+  const gtCells = res.cells.filter((c) => c.sub === "GT");
+  const pv = pivot(gtCells);
 
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
-
-    // Destroy previous chart if any
     chartRef.current?.destroy();
-
     const theme = getThemeColors();
-    if (isCross) {
-      chartRef.current = buildCrossChart(
-        canvas,
-        pv,
-        gtChartType,
-        res,
-        theme,
-        layoutMeta,
-        crossCols,
-        paletteId,
-      );
-    } else {
-      chartRef.current = buildGtChart(canvas, pv, gtChartType, res, theme, layoutMeta, paletteId);
-    }
-
+    chartRef.current = buildGtChart(canvas, pv, chartType, res, theme, layoutMeta, paletteId);
     return () => {
       chartRef.current?.destroy();
       chartRef.current = null;
     };
-  }, [res, gtChartType, layoutMeta, crossCols, paletteId]);
+  }, [res, chartType, layoutMeta, paletteId]);
 
-  return (
-    <ResultCard res={res}>
-      <div class={`p-4 ${isCross ? "h-[400px]" : "h-80"}`}>
-        <canvas ref={canvasRef} />
-      </div>
-    </ResultCard>
-  );
+  return <canvas ref={canvasRef} />;
+}
+
+function CrossChartCanvas({ res, chartType, paletteId }: ChartCanvasProps) {
+  const { layoutMeta, crossCols } = useAggregation();
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const chartRef = useRef<Chart | null>(null);
+
+  const crossCells = res.cells.filter((c) => c.sub !== "GT");
+  const pv = pivot(crossCells);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    chartRef.current?.destroy();
+    const theme = getThemeColors();
+    chartRef.current = buildCrossChart(
+      canvas,
+      pv,
+      chartType,
+      res,
+      theme,
+      layoutMeta,
+      crossCols,
+      paletteId,
+    );
+    return () => {
+      chartRef.current?.destroy();
+      chartRef.current = null;
+    };
+  }, [res, chartType, layoutMeta, crossCols, paletteId]);
+
+  return <canvas ref={canvasRef} />;
 }
 
 function buildGtChart(
@@ -197,7 +228,7 @@ function buildCrossChart(
   paletteId: PaletteId,
 ): Chart {
   const { mains, subs, lookup } = pv;
-  const crossSubs = subs.filter((s) => s.label !== "GT");
+  const crossSubs = subs;
 
   // Stacked bar: one bar per cross value
   if (gtChartType === "obi") {

--- a/src/components/aggregation/CrossTable.tsx
+++ b/src/components/aggregation/CrossTable.tsx
@@ -3,8 +3,8 @@ import { questionKey, parseCrossSub } from "../../lib/agg/aggregate";
 import type { pivot } from "../../lib/agg/pivot";
 import { resolveQuestionLabel, resolveValueLabel, resolveSubLabel } from "../../lib/labels";
 import { t } from "../../lib/i18n";
+import { Td } from "./TableCells";
 import type { PctDirection } from "./Toolbar";
-import { Th, Td } from "./TableCells";
 import { useAggregation } from "./AggregationContext";
 
 interface CrossTableProps {
@@ -68,7 +68,6 @@ const MONO = "text-right tabular-nums font-mono";
 
 interface CrossTableData {
   mains: string[];
-  gtSub: SubInfo;
   crossGroups: CrossGroup[];
   questionLabel: string;
   lookup: Map<string, Cell>;
@@ -78,20 +77,15 @@ interface CrossTableData {
 function useCrossTableData(res: AggResult, pv: ReturnType<typeof pivot>): CrossTableData {
   const { layoutMeta, weightCol, crossCols } = useAggregation();
   const { mains, subs, lookup } = pv;
-  const gtSub = subs.find((s) => s.label === "GT")!;
   const questionLabel = resolveQuestionLabel(res.question, layoutMeta);
-  const crossGroups = groupSubsByCrossAxis(
-    subs.filter((s) => s.label !== "GT"),
-    crossCols,
-    res.type,
-  );
+  const crossGroups = groupSubsByCrossAxis(subs, crossCols, res.type);
 
-  return { mains, gtSub, crossGroups, questionLabel, lookup, weightCol };
+  return { mains, crossGroups, questionLabel, lookup, weightCol };
 }
 
 function VerticalCrossTable({ data, res }: { data: CrossTableData; res: AggResult }) {
   const { layoutMeta, crossCols } = useAggregation();
-  const { mains, gtSub, crossGroups, questionLabel, lookup, weightCol } = data;
+  const { mains, crossGroups, questionLabel, lookup, weightCol } = data;
   const hasMultipleAxes = crossGroups.length > 1;
 
   return (
@@ -100,11 +94,6 @@ function VerticalCrossTable({ data, res }: { data: CrossTableData; res: AggResul
       <thead>
         <tr>
           <th rowSpan={2} class="py-3 px-4" />
-          <th colSpan={2} class={`${TH_BASE} text-center bg-gt-bg text-accent`}>
-            {t("table.total")}
-            <br />
-            <span class="text-muted text-xs font-normal">n={formatN(gtSub.n, weightCol)}</span>
-          </th>
           {crossGroups.map((group) => (
             <th
               key={crossColKey(group.crossCol)}
@@ -116,8 +105,6 @@ function VerticalCrossTable({ data, res }: { data: CrossTableData; res: AggResul
           ))}
         </tr>
         <tr>
-          <Th right>n</Th>
-          <Th right>%</Th>
           {crossGroups.map((group, gi) =>
             group.subs.map((sub, si) => (
               <th
@@ -134,18 +121,9 @@ function VerticalCrossTable({ data, res }: { data: CrossTableData; res: AggResul
       </thead>
       <tbody class="[&_tr:hover_td]:bg-row-hover [&_tr:last-child_td]:border-b-0">
         {mains.map((main) => {
-          const gtCell = lookup.get(`${main}\0GT`)!;
           return (
             <tr key={main}>
               <Td>{resolveValueLabel(res.type, res.question, main, layoutMeta)}</Td>
-              <Td right mono>
-                {res.type === "SA" && !weightCol
-                  ? gtCell.count.toLocaleString()
-                  : gtCell.count.toFixed(1)}
-              </Td>
-              <Td right mono class="text-muted">
-                {gtCell.pct.toFixed(1)}%
-              </Td>
               {crossGroups.map((group, gi) =>
                 group.subs.map((sub, si) => {
                   const cell = lookup.get(`${main}\0${sub.label}`);
@@ -200,7 +178,7 @@ function TransposedSubRow({
 
 function TransposedCrossTable({ data, res }: { data: CrossTableData; res: AggResult }) {
   const { layoutMeta } = useAggregation();
-  const { mains, gtSub, crossGroups, questionLabel, lookup, weightCol } = data;
+  const { mains, crossGroups, questionLabel, lookup } = data;
 
   return (
     <table class="w-full border-collapse text-sm tabular-nums min-w-[400px]">
@@ -210,42 +188,18 @@ function TransposedCrossTable({ data, res }: { data: CrossTableData; res: AggRes
           <th class="py-3 px-4" />
           {mains.map((main) => {
             const label = resolveValueLabel(res.type, res.question, main, layoutMeta);
-            const gtCell = lookup.get(`${main}\0GT`);
             return (
               <th
                 key={main}
                 class={`${TH_BASE} text-right text-xs whitespace-nowrap border-l border-row-border bg-surface2`}
               >
                 {label}
-                <br />
-                <span class="text-muted text-xs font-normal">
-                  n={formatN(gtCell?.count ?? 0, weightCol)}
-                </span>
               </th>
             );
           })}
         </tr>
       </thead>
       <tbody>
-        {/* GT row */}
-        <tr class="[&_td]:border-b-2 [&_td]:border-border-strong">
-          <td
-            class={`${TD_BASE} text-left text-[0.8125rem] font-bold whitespace-nowrap border-r-2 border-r-border-strong bg-gt-bg text-accent`}
-          >
-            {t("table.total")}
-            <br />
-            <span class="text-muted text-xs font-normal">n={formatN(gtSub.n, weightCol)}</span>
-          </td>
-          {mains.map((main) => {
-            const cell = lookup.get(`${main}\0GT`);
-            return (
-              <td key={main} class={`${TD_BASE} ${MONO} text-accent bg-gt-bg`}>
-                {cell ? cell.pct.toFixed(1) + "%" : "-"}
-              </td>
-            );
-          })}
-        </tr>
-
         {/* Cross sub rows */}
         {crossGroups.map((group) => (
           <>

--- a/src/components/aggregation/TableContent.tsx
+++ b/src/components/aggregation/TableContent.tsx
@@ -23,20 +23,30 @@ export function TableContent({ pctDirection }: TableContentProps) {
       }
     >
       {results.map((res) => {
-        const pv = pivot(res.cells);
-        const isCross = pv.subs.length > 1;
+        if (!hasCross) {
+          const pv = pivot(res.cells);
+          return (
+            <ResultCard key={res.question} res={res}>
+              <GtTable res={res} pv={pv} maxPct={maxPct} />
+            </ResultCard>
+          );
+        }
+
+        const gtCells = res.cells.filter((c) => c.sub === "GT");
+        const crossCells = res.cells.filter((c) => c.sub !== "GT");
+        const gtPv = pivot(gtCells);
+        const crossPv = pivot(crossCells);
 
         return (
-          <ResultCard
-            key={res.question}
-            res={res}
-            extraClass={isCross ? "overflow-x-auto" : undefined}
-          >
-            {isCross ? (
-              <CrossTable res={res} pv={pv} pctDir={pctDirection} />
-            ) : (
-              <GtTable res={res} pv={pv} maxPct={maxPct} />
-            )}
+          <ResultCard key={res.question} res={res} extraClass="overflow-x-auto">
+            <div class="flex items-end gap-4 pl-4">
+              <div class="shrink-0">
+                <GtTable res={res} pv={gtPv} maxPct={maxPct} />
+              </div>
+              <div class="min-w-0 overflow-x-auto">
+                <CrossTable res={res} pv={crossPv} pctDir={pctDirection} />
+              </div>
+            </div>
           </ResultCard>
         );
       })}


### PR DESCRIPTION
## Summary
- クロス集計結果の表示を、1つの統合テーブル/チャートからGTテーブル+クロステーブルの横並びレイアウトに変更
- CrossTableからGT列/行を除去し、GtTableで独立表示
- ChartContentも同様にGTチャートとクロスチャートを横並び表示
- aggregate.tsのデータ構造は変更なし（表示層のみの変更）

## Test plan
- [ ] `pnpm build` / `pnpm test` パス確認済み
- [ ] GTのみ集計 → 従来通りGtTableがカード形式で表示
- [ ] クロス集計 → GTテーブルとクロステーブルが横並び
- [ ] 横%切替 → クロステーブルのみ転置、GTテーブルは変わらない
- [ ] チャート表示 → GTチャートとクロスチャートが横並び
- [ ] CSV出力 → 従来通り動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)