### PR TITLE
docs: layout JSONのJSON Schemaを追加 + EXCLUDE/column削除

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ type QuestionDef = SAQuestion | MAQuestion;  // Tagged union
 interface Cell { main: string; sub: string; n: number; count: number; pct: number; }
 ```
 
-`LayoutMeta` maps column names to labels, value labels, and column types (`"sa"|"ma:PREFIX"|"id"|"weight"|"exclude"`).
+`LayoutMeta` maps column names to labels, value labels, and column types (`"sa"|"ma:PREFIX"|"id"|"weight"`).
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm run dev
 - **SA**: 単一回答（1列）
 - **MA**: 複数回答（0/1フラグ列、`key_code` の命名規則）
 - **WEIGHT**: ウェイト列（ウェイトバック集計に使用）
-- **ID / EXCLUDE**: 集計除外列
+- **ID**: 識別列（集計対象外）
 
 ## AI分析コメント（Chrome Built-in AI）
 

--- a/public/schemas/layout.schema.json
+++ b/public/schemas/layout.schema.json
@@ -19,10 +19,6 @@
         "label": {
           "type": "string",
           "description": "選択肢の表示ラベル"
-        },
-        "column": {
-          "type": "string",
-          "description": "MA列の明示的なCSV列名。省略時は {key}_{code} が使われる"
         }
       },
       "required": ["code", "label"],

--- a/public/schemas/layout.schema.json
+++ b/public/schemas/layout.schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://aggy.app/schemas/layout.schema.json",
+  "title": "Aggy Layout",
+  "description": "アンケートローデータのレイアウト定義。CSV列の種別（SA/MA/ID/WEIGHT/EXCLUDE）と選択肢ラベルを指定する。",
+  "type": "array",
+  "items": {
+    "$ref": "#/definitions/LayoutEntry"
+  },
+  "definitions": {
+    "LayoutItem": {
+      "type": "object",
+      "description": "選択肢の定義",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "選択肢コード（SAの場合はCSV値、MAの場合は列名サフィックス）"
+        },
+        "label": {
+          "type": "string",
+          "description": "選択肢の表示ラベル"
+        },
+        "column": {
+          "type": "string",
+          "description": "MA列の明示的なCSV列名。省略時は {key}_{code} が使われる"
+        }
+      },
+      "required": ["code", "label"],
+      "additionalProperties": false
+    },
+    "LayoutEntry": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "CSV列名（SA/ID/WEIGHT/EXCLUDE）またはMA列の接頭辞"
+        },
+        "label": {
+          "type": "string",
+          "description": "設問の表示ラベル"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["SA", "MA", "ID", "WEIGHT", "EXCLUDE"],
+          "description": "列の種別"
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LayoutItem"
+          },
+          "minItems": 1,
+          "description": "選択肢リスト（SA/MAで使用）"
+        }
+      },
+      "required": ["key", "type"],
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": { "type": { "const": "SA" } }
+          },
+          "then": {
+            "required": ["key", "type", "items"]
+          }
+        },
+        {
+          "if": {
+            "properties": { "type": { "const": "MA" } }
+          },
+          "then": {
+            "required": ["key", "type", "items"]
+          }
+        },
+        {
+          "if": {
+            "properties": { "type": { "enum": ["ID", "WEIGHT", "EXCLUDE"] } }
+          },
+          "then": {
+            "properties": {
+              "items": false
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/public/schemas/layout.schema.json
+++ b/public/schemas/layout.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://aggy.app/schemas/layout.schema.json",
   "title": "Aggy Layout",
-  "description": "アンケートローデータのレイアウト定義。CSV列の種別（SA/MA/ID/WEIGHT/EXCLUDE）と選択肢ラベルを指定する。",
+  "description": "アンケートローデータのレイアウト定義。CSV列の種別（SA/MA/ID/WEIGHT）と選択肢ラベルを指定する。",
   "type": "array",
   "items": {
     "$ref": "#/definitions/LayoutEntry"
@@ -33,7 +33,7 @@
       "properties": {
         "key": {
           "type": "string",
-          "description": "CSV列名（SA/ID/WEIGHT/EXCLUDE）またはMA列の接頭辞"
+          "description": "CSV列名（SA/ID/WEIGHT）またはMA列の接頭辞"
         },
         "label": {
           "type": "string",
@@ -41,7 +41,7 @@
         },
         "type": {
           "type": "string",
-          "enum": ["SA", "MA", "ID", "WEIGHT", "EXCLUDE"],
+          "enum": ["SA", "MA", "ID", "WEIGHT"],
           "description": "列の種別"
         },
         "items": {
@@ -74,7 +74,7 @@
         },
         {
           "if": {
-            "properties": { "type": { "enum": ["ID", "WEIGHT", "EXCLUDE"] } }
+            "properties": { "type": { "enum": ["ID", "WEIGHT"] } }
           },
           "then": {
             "properties": {

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -3,7 +3,6 @@ import type { QuestionDef } from "./agg/aggregate";
 export interface LayoutItem {
   code: string;
   label: string;
-  column?: string; // Explicit column name (defaults to `{key}_{code}`)
 }
 
 export type LayoutColType = "SA" | "MA" | "ID" | "WEIGHT";
@@ -105,7 +104,7 @@ export function buildLayoutMeta(layout: Layout): LayoutMeta {
       case "MA":
         if (items) {
           for (const item of items) {
-            const colName = item.column ?? `${key}_${item.code}`;
+            const colName = `${key}_${item.code}`;
             colTypes[colName] = `ma:${key}`;
             // MA columns are 1/0 flags; store item.label as display label for "1"
             valueLabels[colName] = { "1": item.label };

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -6,7 +6,7 @@ export interface LayoutItem {
   column?: string; // Explicit column name (defaults to `{key}_{code}`)
 }
 
-export type LayoutColType = "SA" | "MA" | "ID" | "WEIGHT" | "EXCLUDE";
+export type LayoutColType = "SA" | "MA" | "ID" | "WEIGHT";
 
 export interface LayoutEntry {
   key: string;
@@ -91,9 +91,6 @@ export function buildLayoutMeta(layout: Layout): LayoutMeta {
         break;
       case "WEIGHT":
         colTypes[key] = "weight";
-        break;
-      case "EXCLUDE":
-        colTypes[key] = "exclude";
         break;
       case "SA":
         colTypes[key] = "sa";


### PR DESCRIPTION
## Summary
- Layout JSONのJSON Schema (`public/schemas/layout.schema.json`) を新規作成
- `EXCLUDE` typeのサポートを削除（除外したい列はlayout/rawdataに含めない運用）
- `LayoutItem.column` プロパティを削除（MA列名は `{key}_{code}` 固定）

## Test plan
- [x] `pnpm check` 通過
- [x] サンプルファイルがスキーマバリデーション通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)