### PR TITLE
refactor: aggregationコンポーネントのTailwindクラス最適化

### DIFF
--- a/src/components/aggregation/AIBubble.tsx
+++ b/src/components/aggregation/AIBubble.tsx
@@ -43,7 +43,7 @@ export function AIBubble() {
         style="border-left:8px solid transparent;border-right:8px solid transparent;border-top:8px solid var(--surface)"
       />
       <button
-        class="absolute top-2 right-3 flex min-h-11 min-w-11 cursor-pointer items-center justify-center border-none bg-transparent p-1 text-lg leading-none text-muted hover:text-text"
+        class="absolute top-2 right-3 flex min-h-11 min-w-11 cursor-pointer items-center justify-center p-1 text-lg leading-none text-muted hover:text-text"
         aria-label={t("ai.close")}
         onClick={() => setVisible(false)}
       >
@@ -51,7 +51,7 @@ export function AIBubble() {
       </button>
       <div class="mb-3 text-sm font-bold text-accent2">{t("ai.header")}</div>
       <div
-        class={`whitespace-pre-wrap text-sm leading-[1.75] text-text${loading ? " text-muted animate-[pulse_1.2s_ease-in-out_infinite]" : ""}`}
+        class={`whitespace-pre-wrap text-sm leading-relaxed text-text${loading ? " text-muted animate-[pulse_1.2s_ease-in-out_infinite]" : ""}`}
       >
         {loading ? t("ai.loading") : comment}
       </div>

--- a/src/components/aggregation/CrossConfig.tsx
+++ b/src/components/aggregation/CrossConfig.tsx
@@ -24,11 +24,11 @@ export default function CrossConfig({
         return (
           <label
             key={key}
-            class="flex min-h-9 cursor-pointer items-center gap-3 rounded-sm px-3 py-2 text-[0.875rem] transition-[background] duration-100 hover:bg-surface2"
+            class="flex min-h-9 cursor-pointer items-center gap-3 rounded-sm px-3 py-2 text-sm transition-colors hover:bg-surface2"
           >
             <input
               type="checkbox"
-              class="h-[18px] w-[18px] cursor-pointer accent-accent"
+              class="size-[18px] cursor-pointer accent-accent"
               checked={crossSelected[key] ?? false}
               onChange={(e) => {
                 onToggle(key, (e.target as HTMLInputElement).checked);

--- a/src/components/aggregation/CrossTable.tsx
+++ b/src/components/aggregation/CrossTable.tsx
@@ -61,8 +61,7 @@ function crossColKey(col: QuestionDef): string {
   return col.type === "SA" ? col.column : col.prefix;
 }
 
-const TH_BASE =
-  "py-3 px-4 text-[0.8125rem] font-bold tracking-[0.04em] border-b-2 border-border-strong";
+const TH_BASE = "py-3 px-4 text-xs font-bold tracking-wide border-b-2 border-border-strong";
 const TD_BASE = "py-3 px-4 border-b border-row-border leading-[1.2]";
 const MONO = "text-right tabular-nums font-mono";
 
@@ -180,7 +179,7 @@ function TransposedSubRow({
   return (
     <tr>
       <td
-        class={`${TD_BASE} text-left text-[0.8125rem] font-bold whitespace-nowrap border-r-2 border-r-border-strong text-accent2`}
+        class={`${TD_BASE} text-left text-xs font-bold whitespace-nowrap border-r-2 border-r-border-strong text-accent2`}
       >
         {resolveSubLabel(sub.label, layoutMeta, crossCols)}
         <br />
@@ -230,7 +229,7 @@ function TransposedCrossTable({ data, res }: { data: CrossTableData; res: AggRes
         {/* GT row */}
         <tr class="[&_td]:border-b-2 [&_td]:border-border-strong">
           <td
-            class={`${TD_BASE} text-left text-[0.8125rem] font-bold whitespace-nowrap border-r-2 border-r-border-strong bg-gt-bg text-accent`}
+            class={`${TD_BASE} text-left text-xs font-bold whitespace-nowrap border-r-2 border-r-border-strong bg-gt-bg text-accent`}
           >
             {t("table.total")}
             <br />
@@ -252,7 +251,7 @@ function TransposedCrossTable({ data, res }: { data: CrossTableData; res: AggRes
             <tr key={`hdr-${crossColKey(group.crossCol)}`}>
               <td
                 colSpan={mains.length + 1}
-                class="py-3 px-4 bg-cross-bg text-accent2 font-bold text-[0.8125rem] tracking-[0.04em] border-b-2 border-border-strong border-t-2 border-t-border-strong"
+                class="py-3 px-4 bg-cross-bg text-accent2 font-bold text-xs tracking-wide border-b-2 border-border-strong border-t-2 border-t-border-strong"
               >
                 {resolveQuestionLabel(crossColKey(group.crossCol), layoutMeta)}
               </td>

--- a/src/components/aggregation/ExportMenu.tsx
+++ b/src/components/aggregation/ExportMenu.tsx
@@ -1,3 +1,4 @@
+import type { ComponentChildren } from "preact";
 import { useRef, useState, useEffect, useCallback } from "preact/hooks";
 import { t } from "../../lib/i18n";
 import type { ExportAction } from "../../lib/export/export";
@@ -51,7 +52,7 @@ export function ExportMenu({ onExport }: ExportMenuProps) {
   return (
     <div ref={ref} class="relative">
       <button
-        class="relative m-0 flex h-9 w-9 cursor-pointer items-center justify-center rounded-lg border border-border bg-transparent text-muted transition-colors duration-150 hover:border-accent hover:text-accent"
+        class="relative flex size-9 cursor-pointer items-center justify-center rounded-lg border border-border text-muted transition-colors hover:border-accent hover:text-accent"
         onClick={() => setOpen((v) => !v)}
         aria-label={t("export.label")}
         title={t("export.label")}
@@ -89,18 +90,14 @@ export function ExportMenu({ onExport }: ExportMenuProps) {
 
       {open && (
         <div class="absolute right-0 z-10 mt-1 min-w-48 rounded-lg border border-border bg-surface shadow-lg">
-          <div class="px-3 pt-2.5 pb-1 text-[0.6875rem] font-medium tracking-wide text-muted uppercase">
-            {t("export.section.copy")}
-          </div>
+          <SectionLabel>{t("export.section.copy")}</SectionLabel>
           <MenuItem label="TSV" onClick={() => handleAction("copy-tsv")} />
           <MenuItem label="Markdown" onClick={() => handleAction("copy-markdown")} />
           <MenuItem label="JSON" onClick={() => handleAction("copy-json")} />
 
           <div class="mx-3 my-1 border-t border-border" />
 
-          <div class="px-3 pt-1.5 pb-1 text-[0.6875rem] font-medium tracking-wide text-muted uppercase">
-            {t("export.section.download")}
-          </div>
+          <SectionLabel class="pt-1.5">{t("export.section.download")}</SectionLabel>
           <div class="pb-1.5">
             <MenuItem label="CSV" onClick={() => handleAction("download-csv")} />
             <MenuItem label="Markdown (.md)" onClick={() => handleAction("download-markdown")} />
@@ -114,10 +111,20 @@ export function ExportMenu({ onExport }: ExportMenuProps) {
 
 // ─── Internal ───────────────────────────────────────────────
 
+function SectionLabel({ class: cls, children }: { class?: string; children: ComponentChildren }) {
+  return (
+    <div
+      class={`px-3 pt-2.5 pb-1 text-[0.6875rem] font-medium tracking-wide text-muted uppercase${cls ? ` ${cls}` : ""}`}
+    >
+      {children}
+    </div>
+  );
+}
+
 function MenuItem({ label, onClick }: { label: string; onClick: () => void }) {
   return (
     <button
-      class="block w-full cursor-pointer border-none bg-transparent px-3 py-1.5 text-left text-[0.8125rem] text-text hover:bg-accent-bg"
+      class="block w-full cursor-pointer px-3 py-1.5 text-left text-xs text-text hover:bg-accent-bg"
       onClick={onClick}
     >
       {label}

--- a/src/components/aggregation/ResultCard.tsx
+++ b/src/components/aggregation/ResultCard.tsx
@@ -25,12 +25,12 @@ export function ResultCard({ res, extraClass, children }: ResultCardProps) {
       class={`overflow-hidden rounded-xl border border-border bg-surface shadow-sm${extraClass ? ` ${extraClass}` : ""}`}
     >
       <div class="flex items-baseline gap-3 border-b border-border p-4">
-        <div class="flex min-w-0 flex-col gap-[2px]">
-          <span class="text-[0.875rem] font-bold text-accent">{questionLabel}</span>
-          {hasLabel && <span class="text-xs tracking-[0.04em] text-muted">{res.question}</span>}
+        <div class="flex min-w-0 flex-col gap-0.5">
+          <span class="text-sm font-bold text-accent">{questionLabel}</span>
+          {hasLabel && <span class="text-xs tracking-wide text-muted">{res.question}</span>}
         </div>
-        <span class="text-xs tracking-[0.04em] text-muted">{res.type}</span>
-        <span class="ml-auto text-[0.8125rem] text-muted">{nLabel}</span>
+        <span class="text-xs tracking-wide text-muted">{res.type}</span>
+        <span class="ml-auto text-xs text-muted">{nLabel}</span>
       </div>
       {children}
     </div>

--- a/src/components/aggregation/TableCells.tsx
+++ b/src/components/aggregation/TableCells.tsx
@@ -7,7 +7,7 @@ interface ThProps extends JSX.HTMLAttributes<HTMLTableCellElement> {
 export function Th({ right, class: cls, children, ...props }: ThProps) {
   return (
     <th
-      class={`py-3 px-4 text-[0.8125rem] font-bold tracking-[0.04em] border-b-2 border-border-strong text-text-secondary bg-surface2 ${right ? "text-right" : "text-left"} ${cls ?? ""}`}
+      class={`py-3 px-4 text-xs font-bold tracking-wide border-b-2 border-border-strong text-text-secondary bg-surface2 ${right ? "text-right" : "text-left"} ${cls ?? ""}`}
       {...props}
     >
       {children}

--- a/src/components/aggregation/Toolbar.tsx
+++ b/src/components/aggregation/Toolbar.tsx
@@ -31,7 +31,7 @@ export function Toolbar({ currentViewMode, callbacks }: ToolbarProps) {
   return (
     <div class="mb-6 flex items-center gap-4">
       <h2 class="text-xl font-bold">{t("result.title.gt")}</h2>
-      <span class="text-[0.8125rem] text-muted">
+      <span class="text-xs text-muted">
         {t("result.meta", { count: results.length, weight: weightText })}
       </span>
 
@@ -86,7 +86,7 @@ export function ViewOpts({
   if (!showChart && !showPctToggle) return null;
 
   return (
-    <div class="mb-4 flex items-center justify-end gap-4 text-[0.8125rem] text-text-secondary">
+    <div class="mb-4 flex items-center justify-end gap-4 text-xs text-text-secondary">
       {showChart && (
         <>
           <ChartTypeSelect
@@ -148,7 +148,7 @@ function PaletteSelector({
             role="radio"
             aria-checked={isActive}
             aria-label={id}
-            class={`h-5 w-5 cursor-pointer rounded-full border-2 transition-shadow ${isActive ? "border-accent shadow-[0_0_0_1px_var(--accent)]" : "border-border hover:border-muted"}`}
+            class={`size-5 cursor-pointer rounded-full border-2 transition-shadow ${isActive ? "border-accent shadow-[0_0_0_1px_var(--accent)]" : "border-border hover:border-muted"}`}
             style={
               base
                 ? { backgroundColor: base }
@@ -178,7 +178,7 @@ function ChartTypeSelect({
     <label>
       {label}{" "}
       <select
-        class="cursor-pointer rounded-sm border border-border bg-surface px-2 py-1 text-[0.8125rem] text-text"
+        class="cursor-pointer rounded-sm border border-border bg-surface px-2 py-1 text-xs text-text"
         value={value}
         onChange={(e) => onChange((e.target as HTMLSelectElement).value as ChartType)}
       >


### PR DESCRIPTION
## Summary
- arbitrary values を標準 Tailwind クラスに置換 (`text-[0.8125rem]`→`text-xs`, `tracking-[0.04em]`→`tracking-wide` 等)
- TW4 preflight で不要な `border-none`, `bg-transparent`, `duration-150`, `m-0` を button から削除
- `h-* w-*` → `size-*` 統合、`gap-[2px]` → `gap-0.5` 置換
- ExportMenu の重複セクションラベルクラスを `SectionLabel` コンポーネントに抽出

## Test plan
- [ ] `pnpm check` (fmt:check + lint + tsc) パス確認済み
- [ ] ブラウザで GT テーブル・クロステーブルのフォントサイズ・文字間隔を目視確認
- [ ] ExportMenu のドロップダウン表示・ボタンホバーの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)