### PR TITLE
perf: 不要なORDER BY削除とResultCardのpivot重複除去

### DIFF
--- a/src/components/aggregation/ResultCard.tsx
+++ b/src/components/aggregation/ResultCard.tsx
@@ -1,6 +1,5 @@
 import type { ComponentChildren } from "preact";
 import type { AggResult } from "../../lib/agg/aggregate";
-import { pivot } from "../../lib/agg/pivot";
 import { resolveQuestionLabel } from "../../lib/labels";
 import { useAggregation } from "./AggregationContext";
 
@@ -13,9 +12,8 @@ interface ResultCardProps {
 export function ResultCard({ res, extraClass, children }: ResultCardProps) {
   const { layoutMeta, weightCol } = useAggregation();
 
-  const pv = pivot(res.cells);
-  const gtSub = pv.subs.find((s) => s.label === "GT")!;
-  const nLabel = weightCol ? `n=${gtSub.n.toFixed(1)}` : `n=${gtSub.n.toLocaleString()}`;
+  const gtN = res.cells.find((c) => c.sub === "GT")!.n;
+  const nLabel = weightCol ? `n=${gtN.toFixed(1)}` : `n=${gtN.toLocaleString()}`;
 
   const questionLabel = resolveQuestionLabel(res.question, layoutMeta);
   const hasLabel = questionLabel !== res.question;

--- a/src/lib/agg/crossAggregator.ts
+++ b/src/lib/agg/crossAggregator.ts
@@ -38,7 +38,6 @@ export async function fetchCrossHeaders(
         FROM survey
         WHERE "${esc(col)}" IS NOT NULL
         GROUP BY "${esc(col)}"
-        ORDER BY "${esc(col)}" NULLS LAST
       `;
       const result = await conn.query(sql);
       const headers = result.toArray().map((r) => ({ label: String(r.cv), n: Number(r.n) }));
@@ -102,7 +101,6 @@ export class CrossAggregator {
       WHERE "${esc(col)}" IS NOT NULL
         AND "${esc(crossCol)}" IS NOT NULL
       GROUP BY "${esc(col)}", "${esc(crossCol)}"
-      ORDER BY sv, mv NULLS LAST
     `;
 
     const result = await this.conn.query(sql);

--- a/src/lib/agg/gtAggregator.ts
+++ b/src/lib/agg/gtAggregator.ts
@@ -25,7 +25,6 @@ export class GtAggregator {
       FROM survey
       WHERE "${esc(col)}" IS NOT NULL
       GROUP BY "${esc(col)}"
-      ORDER BY "${esc(col)}" NULLS LAST
     `;
 
     const result = await this.conn.query(sql);


### PR DESCRIPTION
## Summary
- 集計SQLから不要な`ORDER BY`句を3箇所削除（表示順はレイアウトJSON側で制御されるため不要）
- `ResultCard`で`pivot()`を重複呼び出ししていたのを`cells.find()`に置換

## Test plan
- [x] `pnpm test` — 全21テスト通過
- [x] `pnpm build` — ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)