### PR TITLE
refactor: LayoutMeta → LabelMap にリネームし colTypes を除去

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,10 +15,10 @@ pnpm dev           # Vite dev server (COOP/COEP headers for SharedArrayBuffer)
 pnpm build         # tsc + vite build
 pnpm check         # fmt:check + lint + tsc --noEmit (CI validation)
 pnpm test          # vitest run
-pnpm lint          # oxlint
-pnpm lint:fix      # oxlint --fix
-pnpm fmt           # oxfmt (format)
-pnpm fmt:check     # oxfmt --check
+pnpm lint          # oxlint src/ scripts/ vite.config.ts
+pnpm lint:fix      # oxlint --fix src/ scripts/ vite.config.ts
+pnpm fmt           # oxfmt src/ scripts/ vite.config.ts index.html
+pnpm fmt:check     # oxfmt --check src/ scripts/ vite.config.ts index.html
 pnpm bench         # aggregate() benchmark (all patterns)
 pnpm bench rows    # single pattern (rows / cols / both)
 pnpm bench:gen     # generate benchmark data
@@ -28,12 +28,12 @@ pnpm bench:gen     # generate benchmark data
 
 ### Data Flow
 
-1. User uploads CSV → `Dropzone.tsx` → `duckdbBridge.loadCSV()` (registers as DuckDB view)
-2. User uploads JSON layout → `Dropzone.tsx` → `layout.parseLayout()` + `buildLayoutMeta()`
+1. User uploads CSV → `ImportScreen` → `duckdbBridge.loadCSV()` (registers as DuckDB table)
+2. User uploads JSON layout → `ImportScreen` → `layout.parseLayout()` + `buildLabelMap()`
 3. Both loaded → `ImportScreen` calls `onComplete` → `AggregationScreen` builds `QuestionDef[]`
 4. User clicks run → `aggregate()` executes SQL queries → returns `AggResult[]` (flat `Cell[]` arrays)
-5. `ResultView` / `GtTable` / `CrossTable` call `pivot()` to convert `Cell[]` → grid, then render tables
-6. CSV download: `download.downloadAllCSV()` re-pivots and outputs BOM-prefixed UTF-8 CSV
+5. `TableContent` / `ChartContent` call `pivot()` to convert `Cell[]` → grid, then pass to `GtTable` / `CrossTable` as props
+6. Export: `export.executeExport()` re-pivots and outputs files (CSV is BOM-prefixed UTF-8)
 
 ### Module Responsibilities
 
@@ -41,7 +41,7 @@ pnpm bench:gen     # generate benchmark data
 - **`src/lib/`** — Pure logic (aggregation SQL, DuckDB bridge, layout parsing, pivot, CSV export)
 - `agg/aggregate.ts` — Entry point; `gtAggregator.ts` / `crossAggregator.ts` build and run SQL for SA/MA GT and cross-tab (SA×SA, SA×MA, MA×SA, MA×MA)
 - `duckdbBridge.ts` — DuckDB Wasm lifecycle (init, CSV load, query execution). Module-level singleton state
-- `pivot.ts` — Converts flat `Cell[]` into `{ mains, subs, lookup }` grid structure using `\0`-separated composite keys in Maps
+- `pivot.ts` — Converts flat `Cell[]` into `{ mains: string[], subs: { label, n }[], lookup: Map }` grid structure using `\0`-separated composite keys
 
 ### Key Types
 
@@ -50,7 +50,7 @@ type QuestionDef = SAQuestion | MAQuestion;  // Tagged union
 interface Cell { main: string; sub: string; n: number; count: number; pct: number; }
 ```
 
-`LayoutMeta` maps column names to labels, value labels, and column types (`"sa"|"ma:PREFIX"|"weight"`).
+`LabelMap` maps question labels (`questionLabels: Record<string, string>`) and value labels (`valueLabels: Record<string, Record<string, string>>`).
 
 ## Conventions
 

--- a/bench/run.ts
+++ b/bench/run.ts
@@ -13,7 +13,7 @@ import { performance } from "node:perf_hooks";
 
 import { aggregate } from "../src/lib/agg/aggregate";
 import type { Query, QuestionDef } from "../src/lib/agg/aggregate";
-import { parseLayout, buildLayoutMeta, buildQuestionDefs } from "../src/lib/layout";
+import { parseLayout, buildQuestionDefs } from "../src/lib/layout";
 import { generate, PATTERNS, type PatternDef } from "./generate";
 
 // ---------------------------------------------------------------------------
@@ -141,11 +141,10 @@ async function main(): Promise<void> {
     // Parse layout → build questions
     const layoutText = readFileSync(resolve(dataDir, `${pattern.name}_layout.json`), "utf-8");
     const layout = parseLayout(layoutText);
-    const meta = buildLayoutMeta(layout);
 
     // Extract headers from CSV first line
     const headers = csvText.slice(0, csvText.indexOf("\n")).split(",");
-    const questions = buildQuestionDefs(headers, meta.colTypes);
+    const questions = buildQuestionDefs(headers, layout);
 
     // Pick 2 questions for cross-tab (prefer SA; fall back to MA for MA-only patterns)
     const saQuestions = questions.filter(

--- a/src/components/AggregationScreen.tsx
+++ b/src/components/AggregationScreen.tsx
@@ -3,7 +3,7 @@ import CrossConfig from "./aggregation/CrossConfig";
 import ResultView from "./aggregation/ResultView";
 import { AggregationContext, type AggregationContextValue } from "./aggregation/AggregationContext";
 import { runDuckDBAggregation } from "../lib/duckdbBridge";
-import { buildQuestionDefs } from "../lib/layout";
+import { buildQuestionDefs, findWeightColumn, countLayoutColumns } from "../lib/layout";
 import { questionKey } from "../lib/agg/aggregate";
 import { t } from "../lib/i18n";
 import { ToggleButton, ToggleGroup } from "./shared/ToggleButton";
@@ -15,9 +15,9 @@ interface AggregationScreenProps {
 }
 
 export default function AggregationScreen({ csv, layout }: AggregationScreenProps) {
-  const questions = buildQuestionDefs(csv.headers, layout.meta.colTypes);
-  const questionLabels = layout.meta.questionLabels;
-  const weightCol = Object.entries(layout.meta.colTypes).find(([, t]) => t === "weight")?.[0] ?? "";
+  const questions = buildQuestionDefs(csv.headers, layout.layout);
+  const questionLabels = layout.labelMap.questionLabels;
+  const weightCol = findWeightColumn(layout.layout);
 
   const [crossSelected, setCrossSelected] = useState<Record<string, boolean>>(() => {
     const sel: Record<string, boolean> = {};
@@ -51,7 +51,7 @@ export default function AggregationScreen({ csv, layout }: AggregationScreenProp
       setAggCtx({
         results,
         weightCol: wCol,
-        layoutMeta: layout.meta,
+        labelMap: layout.labelMap,
         crossCols,
         hasCross: crossCols.length > 0,
       });
@@ -83,7 +83,7 @@ export default function AggregationScreen({ csv, layout }: AggregationScreenProp
               }}
               layout={{
                 fileName: layout.fileName,
-                colCount: Object.keys(layout.meta.colTypes).length,
+                colCount: countLayoutColumns(layout.layout),
               }}
             />
           </div>

--- a/src/components/ImportScreen.tsx
+++ b/src/components/ImportScreen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useState } from "preact/hooks";
-import { parseLayout, buildLayoutMeta } from "../lib/layout";
+import { parseLayout, buildLabelMap } from "../lib/layout";
 import { loadCSV } from "../lib/duckdbBridge";
 import { saveData, loadSaved } from "../lib/opfs";
 import { t } from "../lib/i18n";
@@ -150,9 +150,9 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
   const handleLayoutFile = useCallback(async (file: File) => {
     try {
       const text = await file.text();
-      const layout = parseLayout(text);
-      const meta = buildLayoutMeta(layout);
-      layoutRef.current = { json: text, fileName: file.name, meta };
+      const parsed = parseLayout(text);
+      const labelMap = buildLabelMap(parsed);
+      layoutRef.current = { json: text, fileName: file.name, layout: parsed, labelMap };
       loadedFromSavedRef.current = false;
       setLayoutFileName(file.name);
       updateLoadedInfo();
@@ -165,8 +165,8 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
   const handleLoadFromSaved = useCallback(async (folderId: string) => {
     try {
       const { csvText, csvName, layoutJson, layoutName } = await loadSaved(folderId);
-      const layout = parseLayout(layoutJson);
-      const meta = buildLayoutMeta(layout);
+      const parsed = parseLayout(layoutJson);
+      const labelMap = buildLabelMap(parsed);
       const result = await loadCSV(csvText);
 
       csvRef.current = {
@@ -175,7 +175,7 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
         headers: result.headers,
         rowCount: result.rowCount,
       };
-      layoutRef.current = { json: layoutJson, fileName: layoutName, meta };
+      layoutRef.current = { json: layoutJson, fileName: layoutName, layout: parsed, labelMap };
 
       loadedFromSavedRef.current = true;
       setCsvFileName(csvName);

--- a/src/components/aggregation/AIBubble.tsx
+++ b/src/components/aggregation/AIBubble.tsx
@@ -5,7 +5,7 @@ import { isAICommentEnabled } from "../header/SettingsModal";
 import { useAggregation } from "./AggregationContext";
 
 export function AIBubble() {
-  const { results, weightCol, layoutMeta } = useAggregation();
+  const { results, weightCol, labelMap } = useAggregation();
   const [comment, setComment] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [visible, setVisible] = useState(true);
@@ -19,7 +19,7 @@ export function AIBubble() {
     setLoading(true);
     setComment(null);
     setVisible(true);
-    generateComment(results, weightCol, layoutMeta).then((c) => {
+    generateComment(results, weightCol, labelMap).then((c) => {
       if (cancelled) return;
       if (c) {
         setComment(c);
@@ -31,7 +31,7 @@ export function AIBubble() {
     return () => {
       cancelled = true;
     };
-  }, [results, weightCol, layoutMeta]);
+  }, [results, weightCol, labelMap]);
 
   if (!visible) return null;
 

--- a/src/components/aggregation/AggregationContext.ts
+++ b/src/components/aggregation/AggregationContext.ts
@@ -1,11 +1,11 @@
 import { createContext } from "preact";
 import { useContext } from "preact/hooks";
-import type { LayoutMeta } from "../../lib/layout";
+import type { LabelMap } from "../../lib/layout";
 import type { AggResult, QuestionDef } from "../../lib/agg/aggregate";
 
 export interface AggregationContextValue {
   results: AggResult[];
-  layoutMeta: LayoutMeta;
+  labelMap: LabelMap;
   weightCol: string;
   crossCols: QuestionDef[];
   hasCross: boolean;

--- a/src/components/aggregation/ChartContent.tsx
+++ b/src/components/aggregation/ChartContent.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useEffect } from "preact/hooks";
 import type { AggResult, QuestionDef } from "../../lib/agg/aggregate";
-import type { LayoutMeta } from "../../lib/layout";
+import type { LabelMap } from "../../lib/layout";
 import { pivot } from "../../lib/agg/pivot";
 import { Chart, getSeriesColor, getThemeColors, type PaletteId } from "../../lib/chartConfig";
 import { resolveValueLabel, resolveSubLabel } from "../../lib/labels";
@@ -48,7 +48,7 @@ interface ChartCardProps {
 }
 
 function ChartCard({ res, gtChartType, paletteId }: ChartCardProps) {
-  const { layoutMeta, crossCols } = useAggregation();
+  const { labelMap, crossCols } = useAggregation();
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const chartRef = useRef<Chart | null>(null);
 
@@ -70,19 +70,19 @@ function ChartCard({ res, gtChartType, paletteId }: ChartCardProps) {
         gtChartType,
         res,
         theme,
-        layoutMeta,
+        labelMap,
         crossCols,
         paletteId,
       );
     } else {
-      chartRef.current = buildGtChart(canvas, pv, gtChartType, res, theme, layoutMeta, paletteId);
+      chartRef.current = buildGtChart(canvas, pv, gtChartType, res, theme, labelMap, paletteId);
     }
 
     return () => {
       chartRef.current?.destroy();
       chartRef.current = null;
     };
-  }, [res, gtChartType, layoutMeta, crossCols, paletteId]);
+  }, [res, gtChartType, labelMap, crossCols, paletteId]);
 
   return (
     <ResultCard res={res}>
@@ -99,18 +99,18 @@ function buildGtChart(
   chartType: ChartType,
   res: AggResult,
   theme: ReturnType<typeof getThemeColors>,
-  layoutMeta: LayoutMeta,
+  labelMap: LabelMap,
   paletteId: PaletteId,
 ): Chart {
   const { mains, lookup } = pv;
-  const labels = mains.map((m) => resolveValueLabel(res.type, res.question, m, layoutMeta));
+  const labels = mains.map((m) => resolveValueLabel(res.type, res.question, m, labelMap));
   const data = mains.map((m) => lookup.get(`${m}\0GT`)?.pct ?? 0);
   const colors = mains.map((_, i) => getSeriesColor(i, paletteId));
 
   // Stacked bar: each option as a segment in one horizontal bar
   if (chartType === "obi") {
     const datasets = mains.map((m, i) => ({
-      label: resolveValueLabel(res.type, res.question, m, layoutMeta),
+      label: resolveValueLabel(res.type, res.question, m, labelMap),
       data: [lookup.get(`${m}\0GT`)?.pct ?? 0],
       backgroundColor: getSeriesColor(i, paletteId),
       maxBarThickness: 48,
@@ -192,7 +192,7 @@ function buildCrossChart(
   gtChartType: ChartType,
   res: AggResult,
   theme: ReturnType<typeof getThemeColors>,
-  layoutMeta: LayoutMeta,
+  labelMap: LabelMap,
   crossCols: QuestionDef[],
   paletteId: PaletteId,
 ): Chart {
@@ -201,9 +201,9 @@ function buildCrossChart(
 
   // Stacked bar: one bar per cross value
   if (gtChartType === "obi") {
-    const subLabels = crossSubs.map((s) => resolveSubLabel(s.label, layoutMeta, crossCols));
+    const subLabels = crossSubs.map((s) => resolveSubLabel(s.label, labelMap, crossCols));
     const datasets = mains.map((m, i) => ({
-      label: resolveValueLabel(res.type, res.question, m, layoutMeta),
+      label: resolveValueLabel(res.type, res.question, m, labelMap),
       data: crossSubs.map((sub) => {
         const cell = lookup.get(`${m}\0${sub.label}`);
         return cell?.pct ?? 0;
@@ -242,10 +242,10 @@ function buildCrossChart(
 
   // Clustered bar chart (direction matches GT selection)
   const isHorizontal = gtChartType === "bar-h";
-  const labels = mains.map((m) => resolveValueLabel(res.type, res.question, m, layoutMeta));
+  const labels = mains.map((m) => resolveValueLabel(res.type, res.question, m, labelMap));
 
   const datasets = crossSubs.map((sub, i) => ({
-    label: resolveSubLabel(sub.label, layoutMeta, crossCols),
+    label: resolveSubLabel(sub.label, labelMap, crossCols),
     data: mains.map((m) => {
       const cell = lookup.get(`${m}\0${sub.label}`);
       return cell?.pct ?? 0;

--- a/src/components/aggregation/CrossTable.tsx
+++ b/src/components/aggregation/CrossTable.tsx
@@ -75,10 +75,10 @@ interface CrossTableData {
 }
 
 function useCrossTableData(res: AggResult, pv: ReturnType<typeof pivot>): CrossTableData {
-  const { layoutMeta, weightCol, crossCols } = useAggregation();
+  const { labelMap, weightCol, crossCols } = useAggregation();
   const { mains, subs, lookup } = pv;
   const gtSub = subs.find((s) => s.label === "GT")!;
-  const questionLabel = resolveQuestionLabel(res.question, layoutMeta);
+  const questionLabel = resolveQuestionLabel(res.question, labelMap);
   const crossGroups = groupSubsByCrossAxis(
     subs.filter((s) => s.label !== "GT"),
     crossCols,
@@ -89,7 +89,7 @@ function useCrossTableData(res: AggResult, pv: ReturnType<typeof pivot>): CrossT
 }
 
 function VerticalCrossTable({ data, res }: { data: CrossTableData; res: AggResult }) {
-  const { layoutMeta, crossCols } = useAggregation();
+  const { labelMap, crossCols } = useAggregation();
   const { mains, gtSub, crossGroups, questionLabel, lookup, weightCol } = data;
   const hasMultipleAxes = crossGroups.length > 1;
 
@@ -110,7 +110,7 @@ function VerticalCrossTable({ data, res }: { data: CrossTableData; res: AggResul
               colSpan={group.subs.length}
               class={`${TH_BASE} text-center bg-cross-bg border-l border-border text-accent2 ${hasMultipleAxes ? "border-l-2 border-l-border-strong" : ""}`}
             >
-              {resolveQuestionLabel(crossColKey(group.crossCol), layoutMeta)}
+              {resolveQuestionLabel(crossColKey(group.crossCol), labelMap)}
             </th>
           ))}
         </tr>
@@ -123,7 +123,7 @@ function VerticalCrossTable({ data, res }: { data: CrossTableData; res: AggResul
                 key={sub.label}
                 class={`${TH_BASE} text-right text-xs whitespace-nowrap border-l border-row-border bg-surface2 ${hasMultipleAxes && si === 0 && gi > 0 ? "border-l-2 border-l-border-strong" : ""}`}
               >
-                {resolveSubLabel(sub.label, layoutMeta, crossCols)}
+                {resolveSubLabel(sub.label, labelMap, crossCols)}
                 <br />
                 <span class="text-muted text-xs font-normal">n={formatN(sub.n, weightCol)}</span>
               </th>
@@ -136,7 +136,7 @@ function VerticalCrossTable({ data, res }: { data: CrossTableData; res: AggResul
           const gtCell = lookup.get(`${main}\0GT`)!;
           return (
             <tr key={main}>
-              <Td>{resolveValueLabel(res.type, res.question, main, layoutMeta)}</Td>
+              <Td>{resolveValueLabel(res.type, res.question, main, labelMap)}</Td>
               <Td right mono>
                 {res.type === "SA" && !weightCol
                   ? gtCell.count.toLocaleString()
@@ -175,13 +175,13 @@ function TransposedSubRow({
   mains: string[];
   lookup: Map<string, Cell>;
 }) {
-  const { layoutMeta, weightCol, crossCols } = useAggregation();
+  const { labelMap, weightCol, crossCols } = useAggregation();
   return (
     <tr>
       <td
         class={`${TD_BASE} text-left text-xs font-bold whitespace-nowrap border-r-2 border-r-border-strong text-accent2`}
       >
-        {resolveSubLabel(sub.label, layoutMeta, crossCols)}
+        {resolveSubLabel(sub.label, labelMap, crossCols)}
         <br />
         <span class="text-muted text-xs font-normal">n={formatN(sub.n, weightCol)}</span>
       </td>
@@ -198,7 +198,7 @@ function TransposedSubRow({
 }
 
 function TransposedCrossTable({ data, res }: { data: CrossTableData; res: AggResult }) {
-  const { layoutMeta } = useAggregation();
+  const { labelMap } = useAggregation();
   const { mains, gtSub, crossGroups, questionLabel, lookup, weightCol } = data;
 
   return (
@@ -208,7 +208,7 @@ function TransposedCrossTable({ data, res }: { data: CrossTableData; res: AggRes
         <tr>
           <th class="py-3 px-4" />
           {mains.map((main) => {
-            const label = resolveValueLabel(res.type, res.question, main, layoutMeta);
+            const label = resolveValueLabel(res.type, res.question, main, labelMap);
             const gtCell = lookup.get(`${main}\0GT`);
             return (
               <th
@@ -253,7 +253,7 @@ function TransposedCrossTable({ data, res }: { data: CrossTableData; res: AggRes
                 colSpan={mains.length + 1}
                 class="py-3 px-4 bg-cross-bg text-accent2 font-bold text-xs tracking-wide border-b-2 border-border-strong border-t-2 border-t-border-strong"
               >
-                {resolveQuestionLabel(crossColKey(group.crossCol), layoutMeta)}
+                {resolveQuestionLabel(crossColKey(group.crossCol), labelMap)}
               </td>
             </tr>
             {group.subs.map((sub) => (

--- a/src/components/aggregation/GtTable.tsx
+++ b/src/components/aggregation/GtTable.tsx
@@ -12,9 +12,9 @@ interface GtTableProps {
 }
 
 export function GtTable({ res, pv, maxPct }: GtTableProps) {
-  const { layoutMeta, weightCol } = useAggregation();
+  const { labelMap, weightCol } = useAggregation();
   const { mains, lookup } = pv;
-  const questionLabel = resolveQuestionLabel(res.question, layoutMeta);
+  const questionLabel = resolveQuestionLabel(res.question, labelMap);
 
   return (
     <table class="w-full border-collapse text-sm tabular-nums">
@@ -32,7 +32,7 @@ export function GtTable({ res, pv, maxPct }: GtTableProps) {
       <tbody class="[&_tr:hover_td]:bg-row-hover [&_tr:last-child_td]:border-b-0">
         {mains.map((main) => {
           const cell = lookup.get(`${main}\0GT`)!;
-          const label = resolveValueLabel(res.type, res.question, main, layoutMeta);
+          const label = resolveValueLabel(res.type, res.question, main, labelMap);
           const countStr =
             res.type === "SA" && !weightCol ? cell.count.toLocaleString() : cell.count.toFixed(1);
           const barWidth = ((cell.pct / Math.max(maxPct, 1)) * 72).toFixed(1);

--- a/src/components/aggregation/ResultCard.tsx
+++ b/src/components/aggregation/ResultCard.tsx
@@ -10,12 +10,12 @@ interface ResultCardProps {
 }
 
 export function ResultCard({ res, extraClass, children }: ResultCardProps) {
-  const { layoutMeta, weightCol } = useAggregation();
+  const { labelMap, weightCol } = useAggregation();
 
   const gtN = res.cells.find((c) => c.sub === "GT")!.n;
   const nLabel = weightCol ? `n=${gtN.toFixed(1)}` : `n=${gtN.toLocaleString()}`;
 
-  const questionLabel = resolveQuestionLabel(res.question, layoutMeta);
+  const questionLabel = resolveQuestionLabel(res.question, labelMap);
   const hasLabel = questionLabel !== res.question;
 
   return (

--- a/src/components/aggregation/Toolbar.tsx
+++ b/src/components/aggregation/Toolbar.tsx
@@ -23,7 +23,7 @@ interface ToolbarProps {
 }
 
 export function Toolbar({ currentViewMode, callbacks }: ToolbarProps) {
-  const { results, weightCol, layoutMeta } = useAggregation();
+  const { results, weightCol, labelMap } = useAggregation();
   const weightText = weightCol
     ? t("result.weight.applied", { col: weightCol })
     : t("result.weight.none");
@@ -52,7 +52,7 @@ export function Toolbar({ currentViewMode, callbacks }: ToolbarProps) {
       </ToggleGroup>
 
       <ExportMenu
-        onExport={(action: ExportAction) => executeExport(action, results, weightCol, layoutMeta)}
+        onExport={(action: ExportAction) => executeExport(action, results, weightCol, labelMap)}
       />
     </div>
   );

--- a/src/lib/aiComment.ts
+++ b/src/lib/aiComment.ts
@@ -1,7 +1,7 @@
 /** AI analysis comment generation via Chrome Built-in AI (Prompt API) */
 
 import type { AggResult } from "./agg/aggregate";
-import type { LayoutMeta } from "./layout";
+import type { LabelMap } from "./layout";
 import { getLocale, t } from "./i18n";
 
 // Chrome Prompt API type declarations
@@ -32,25 +32,25 @@ declare global {
 export function buildPromptPayload(
   results: AggResult[],
   weightCol: string,
-  layoutMeta?: LayoutMeta,
+  labelMap: LabelMap,
 ): string {
   for (const topN of [5, 3, 2]) {
-    const text = summarizeResults(results, weightCol, layoutMeta, topN);
+    const text = summarizeResults(results, weightCol, labelMap, topN);
     if (text.length <= MAX_PAYLOAD_CHARS) return text;
   }
-  return summarizeResults(results.slice(0, 20), weightCol, layoutMeta, 2);
+  return summarizeResults(results.slice(0, 20), weightCol, labelMap, 2);
 }
 
 export async function generateComment(
   results: AggResult[],
   weightCol: string,
-  layoutMeta?: LayoutMeta,
+  labelMap: LabelMap,
 ): Promise<string | null> {
   try {
     if (results.length === 0) return null;
 
     const locale = getLocale();
-    const payload = buildPromptPayload(results, weightCol, layoutMeta);
+    const payload = buildPromptPayload(results, weightCol, labelMap);
     const session = await LanguageModel!.create({
       systemPrompt: t("ai.systemPrompt"),
       expectedInputs: [{ type: "text", languages: [locale] }],
@@ -71,20 +71,19 @@ export async function generateComment(
 
 const MAX_PAYLOAD_CHARS = 3500;
 
-function resolveQLabel(col: string, meta?: LayoutMeta): string {
-  return meta?.questionLabels[col] ?? col;
+function resolveQLabel(col: string, labelMap: LabelMap): string {
+  return labelMap.questionLabels[col] ?? col;
 }
 
-function resolveVLabel(type: "SA" | "MA", col: string, code: string, meta?: LayoutMeta): string {
-  if (!meta) return code;
-  if (type === "SA") return meta.valueLabels[col]?.[code] ?? code;
-  return meta.valueLabels[code]?.["1"] ?? code;
+function resolveVLabel(type: "SA" | "MA", col: string, code: string, labelMap: LabelMap): string {
+  if (type === "SA") return labelMap.valueLabels[col]?.[code] ?? code;
+  return labelMap.valueLabels[code]?.["1"] ?? code;
 }
 
 function summarizeResults(
   results: AggResult[],
   weightCol: string,
-  layoutMeta: LayoutMeta | undefined,
+  labelMap: LabelMap,
   topN: number,
 ): string {
   const lines: string[] = [];
@@ -97,13 +96,13 @@ function summarizeResults(
     if (gtCells.length === 0) continue;
 
     const n = gtCells[0].n;
-    const qLabel = resolveQLabel(res.question, layoutMeta);
+    const qLabel = resolveQLabel(res.question, labelMap);
     lines.push(`${res.question}: ${qLabel} (${res.type}, n=${n})`);
 
     const sorted = [...gtCells].sort((a, b) => b.pct - a.pct);
     const top = sorted.slice(0, topN);
     const items = top.map((c) => {
-      const label = resolveVLabel(res.type, res.question, c.main, layoutMeta);
+      const label = resolveVLabel(res.type, res.question, c.main, labelMap);
       return `${label}: ${c.pct.toFixed(1)}%`;
     });
 

--- a/src/lib/export/export.ts
+++ b/src/lib/export/export.ts
@@ -1,5 +1,5 @@
 import type { AggResult } from "../agg/aggregate";
-import type { LayoutMeta } from "../layout";
+import type { LabelMap } from "../layout";
 import { buildExportGrids } from "./exportGrid";
 import { pivot } from "../agg/pivot";
 import { downloadCSV } from "./formatters/csv";
@@ -20,40 +20,40 @@ export async function executeExport(
   action: ExportAction,
   results: AggResult[],
   weightCol: string,
-  layoutMeta?: LayoutMeta,
+  labelMap: LabelMap,
 ): Promise<boolean> {
   const hasCross = results.some((r) => pivot(r.cells).subs.length > 1);
 
   switch (action) {
     case "download-csv": {
-      const grids = buildExportGrids(results, layoutMeta);
+      const grids = buildExportGrids(results, labelMap);
       downloadCSV(grids, hasCross);
       return true;
     }
     case "download-markdown": {
-      const grids = buildExportGrids(results, layoutMeta);
+      const grids = buildExportGrids(results, labelMap);
       downloadMarkdown(grids, hasCross);
       return true;
     }
     case "download-json": {
-      downloadJSON(results, weightCol, layoutMeta, hasCross);
+      downloadJSON(results, weightCol, labelMap, hasCross);
       return true;
     }
     case "copy-tsv": {
-      const grids = buildExportGrids(results, layoutMeta);
+      const grids = buildExportGrids(results, labelMap);
       const tsv = formatTSV(grids);
       const html = formatHTML(grids);
       await copyToClipboard({ "text/plain": tsv, "text/html": html });
       return true;
     }
     case "copy-markdown": {
-      const grids = buildExportGrids(results, layoutMeta);
+      const grids = buildExportGrids(results, labelMap);
       const md = formatMarkdown(grids);
       await copyToClipboard({ "text/plain": md });
       return true;
     }
     case "copy-json": {
-      const json = formatJSON(results, weightCol, layoutMeta);
+      const json = formatJSON(results, weightCol, labelMap);
       await copyToClipboard({ "text/plain": json });
       return true;
     }

--- a/src/lib/export/exportGrid.ts
+++ b/src/lib/export/exportGrid.ts
@@ -1,6 +1,6 @@
 import type { AggResult } from "../agg/aggregate";
 import { parseCrossSub } from "../agg/aggregate";
-import type { LayoutMeta } from "../layout";
+import type { LabelMap } from "../layout";
 import { NA_VALUE } from "../agg/sqlHelpers";
 import { pivot } from "../agg/pivot";
 import { t } from "../i18n";
@@ -12,10 +12,10 @@ export interface ExportGrid {
   rows: string[][];
 }
 
-export function buildExportGrids(results: AggResult[], layoutMeta?: LayoutMeta): ExportGrid[] {
+export function buildExportGrids(results: AggResult[], labelMap: LabelMap): ExportGrid[] {
   const hasCross = results.some((r) => pivot(r.cells).subs.length > 1);
   if (hasCross) {
-    return buildCrossGrids(results, layoutMeta);
+    return buildCrossGrids(results, labelMap);
   }
   return results.map((res) => buildGtGrid(res));
 }
@@ -26,21 +26,19 @@ export function resolveMainLabel(main: string): string {
   return main === NA_VALUE ? t("export.na") : main;
 }
 
-export function resolveSubLabel(subLabel: string, meta?: LayoutMeta): string {
+export function resolveSubLabel(subLabel: string, labelMap: LabelMap): string {
   if (subLabel === NA_VALUE) return t("export.na");
 
   const parsed = parseCrossSub(subLabel);
   if (parsed) {
     const { axisKey, rawValue } = parsed;
     if (rawValue === NA_VALUE) return t("export.na");
-    if (!meta) return rawValue;
-    const maLabel = meta.valueLabels[rawValue]?.["1"];
+    const maLabel = labelMap.valueLabels[rawValue]?.["1"];
     if (maLabel) return maLabel;
-    return meta.valueLabels[axisKey]?.[rawValue] ?? rawValue;
+    return labelMap.valueLabels[axisKey]?.[rawValue] ?? rawValue;
   }
 
-  if (!meta) return subLabel;
-  return meta.valueLabels[subLabel]?.["1"] ?? subLabel;
+  return labelMap.valueLabels[subLabel]?.["1"] ?? subLabel;
 }
 
 function buildGtGrid(res: AggResult): ExportGrid {
@@ -72,7 +70,7 @@ function buildGtGrid(res: AggResult): ExportGrid {
   return { question: res.question, type: res.type, headers, rows };
 }
 
-function buildCrossGrids(results: AggResult[], layoutMeta?: LayoutMeta): ExportGrid[] {
+function buildCrossGrids(results: AggResult[], labelMap: LabelMap): ExportGrid[] {
   const firstResult = results.find((r) => pivot(r.cells).subs.length > 1);
   if (!firstResult) return results.map((res) => buildGtGrid(res));
 
@@ -89,7 +87,7 @@ function buildCrossGrids(results: AggResult[], layoutMeta?: LayoutMeta): ExportG
   const headerRow2 = ["", "", "", "", ""];
   for (const sub of crossSubs) {
     headerRow1.push("");
-    headerRow2.push(`${resolveSubLabel(sub.label, layoutMeta)}(n=${sub.n.toFixed(1)})`);
+    headerRow2.push(`${resolveSubLabel(sub.label, labelMap)}(n=${sub.n.toFixed(1)})`);
   }
   const sharedHeaders = [headerRow1, headerRow2];
 

--- a/src/lib/export/formatters/json.ts
+++ b/src/lib/export/formatters/json.ts
@@ -1,5 +1,5 @@
 import type { AggResult } from "../../agg/aggregate";
-import type { LayoutMeta } from "../../layout";
+import type { LabelMap } from "../../layout";
 import { pivot } from "../../agg/pivot";
 import { resolveMainLabel, resolveSubLabel } from "../exportGrid";
 import { downloadFile, today } from "../export";
@@ -23,11 +23,7 @@ interface JsonExport {
   results: JsonExportEntry[];
 }
 
-export function formatJSON(
-  results: AggResult[],
-  weightCol: string,
-  layoutMeta?: LayoutMeta,
-): string {
+export function formatJSON(results: AggResult[], weightCol: string, labelMap: LabelMap): string {
   const entries: JsonExportEntry[] = results.map((res) => {
     const { mains, subs, lookup } = pivot(res.cells);
     const gtSub = subs.find((s) => s.label === "GT")!;
@@ -45,7 +41,7 @@ export function formatJSON(
         opt.cross = {};
         for (const sub of crossSubs) {
           const cell = lookup.get(`${main}\0${sub.label}`);
-          const label = resolveSubLabel(sub.label, layoutMeta);
+          const label = resolveSubLabel(sub.label, labelMap);
           if (cell) {
             opt.cross[label] = { count: cell.count, pct: cell.pct };
           }
@@ -68,10 +64,10 @@ export function formatJSON(
 export function downloadJSON(
   results: AggResult[],
   weightCol: string,
-  layoutMeta?: LayoutMeta,
+  labelMap: LabelMap,
   hasCross?: boolean,
 ): void {
-  const json = formatJSON(results, weightCol, layoutMeta);
+  const json = formatJSON(results, weightCol, labelMap);
   const prefix = hasCross ? "cross_result" : "gt_result";
   downloadFile(json, `${prefix}_${today()}.json`, "application/json;charset=utf-8;");
 }

--- a/src/lib/labels.ts
+++ b/src/lib/labels.ts
@@ -2,12 +2,12 @@
 
 import type { QuestionDef } from "./agg/aggregate";
 import { parseCrossSub } from "./agg/aggregate";
-import type { LayoutMeta } from "./layout";
+import type { LabelMap } from "./layout";
 import { NA_VALUE } from "./agg/sqlHelpers";
 
 /** Resolve question label; falls back to column name */
-export function resolveQuestionLabel(col: string, meta?: LayoutMeta): string {
-  return meta?.questionLabels[col] ?? col;
+export function resolveQuestionLabel(col: string, labelMap: LabelMap): string {
+  return labelMap.questionLabels[col] ?? col;
 }
 
 /** Resolve option label (SA: valueLabels[col][code], MA: valueLabels[colName]["1"]) */
@@ -15,21 +15,20 @@ export function resolveValueLabel(
   type: "SA" | "MA",
   col: string,
   rowLabel: string,
-  meta?: LayoutMeta,
+  labelMap: LabelMap,
 ): string {
   if (rowLabel === NA_VALUE) return "無回答";
-  if (!meta) return rowLabel;
   if (type === "SA") {
-    return meta.valueLabels[col]?.[rowLabel] ?? rowLabel;
+    return labelMap.valueLabels[col]?.[rowLabel] ?? rowLabel;
   } else {
-    return meta.valueLabels[rowLabel]?.["1"] ?? rowLabel;
+    return labelMap.valueLabels[rowLabel]?.["1"] ?? rowLabel;
   }
 }
 
 /** Resolve cross-axis header label (sub values are prefixed as "axisKey\x01rawValue") */
 export function resolveSubLabel(
   subLabel: string,
-  meta?: LayoutMeta,
+  labelMap: LabelMap,
   _crossCols?: QuestionDef[],
 ): string {
   if (subLabel === NA_VALUE) return "無回答";
@@ -38,17 +37,15 @@ export function resolveSubLabel(
   if (parsed) {
     const { axisKey, rawValue } = parsed;
     if (rawValue === NA_VALUE) return "無回答";
-    if (!meta) return rawValue;
     // MA axis: rawValue is column name → valueLabels[rawValue]["1"]
-    const maLabel = meta.valueLabels[rawValue]?.["1"];
+    const maLabel = labelMap.valueLabels[rawValue]?.["1"];
     if (maLabel) return maLabel;
     // SA axis: rawValue is value code → valueLabels[axisKey][rawValue]
-    return meta.valueLabels[axisKey]?.[rawValue] ?? rawValue;
+    return labelMap.valueLabels[axisKey]?.[rawValue] ?? rawValue;
   }
 
   // No prefix (backwards compatibility)
-  if (!meta) return subLabel;
-  const maLabel = meta.valueLabels[subLabel]?.["1"];
+  const maLabel = labelMap.valueLabels[subLabel]?.["1"];
   if (maLabel) return maLabel;
   return subLabel;
 }

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -16,13 +16,11 @@ export interface LayoutEntry {
 
 export type Layout = LayoutEntry[];
 
-export interface LayoutMeta {
+export interface LabelMap {
   /** Question labels: CSV column name (or MA group name) → display name */
   questionLabels: Record<string, string>;
   /** Value labels: SA → { colName: { code: label } }, MA → { colName: { "1": itemLabel } } */
   valueLabels: Record<string, Record<string, string>>;
-  /** Column types: { colName → type string } */
-  colTypes: Record<string, string>;
 }
 
 export function parseLayout(jsonText: string): Layout {
@@ -50,15 +48,24 @@ export function parseLayout(jsonText: string): Layout {
   return parsed as Layout;
 }
 
-/** Build QuestionDef[] from headers and colTypes */
-export function buildQuestionDefs(
-  headers: string[],
-  colTypes: Record<string, string>,
-): QuestionDef[] {
+/** Build QuestionDef[] from CSV headers and layout definition */
+export function buildQuestionDefs(headers: string[], layout: Layout): QuestionDef[] {
+  // Build a column→type lookup from layout
+  const colTypes = new Map<string, string>();
+  for (const entry of layout) {
+    if (entry.type === "SA") {
+      colTypes.set(entry.key, "sa");
+    } else if (entry.type === "MA" && entry.items) {
+      for (const item of entry.items) {
+        colTypes.set(`${entry.key}_${item.code}`, `ma:${entry.key}`);
+      }
+    }
+  }
+
   const questions: QuestionDef[] = [];
   const maAccum: Record<string, string[]> = {};
   for (const col of headers) {
-    const t = colTypes[col];
+    const t = colTypes.get(col);
     if (!t) continue;
     if (t === "sa") {
       questions.push({ type: "SA", column: col });
@@ -72,10 +79,19 @@ export function buildQuestionDefs(
   return questions;
 }
 
-export function buildLayoutMeta(layout: Layout): LayoutMeta {
+/** Find weight column name from layout, or empty string if none */
+export function findWeightColumn(layout: Layout): string {
+  return layout.find((e) => e.type === "WEIGHT")?.key ?? "";
+}
+
+/** Count total layout-defined columns (SA: 1 each, MA: items count, WEIGHT: 1) */
+export function countLayoutColumns(layout: Layout): number {
+  return layout.reduce((acc, e) => acc + (e.type === "MA" ? (e.items?.length ?? 0) : 1), 0);
+}
+
+export function buildLabelMap(layout: Layout): LabelMap {
   const questionLabels: Record<string, string> = {};
   const valueLabels: Record<string, Record<string, string>> = {};
-  const colTypes: Record<string, string> = {};
 
   for (const entry of layout) {
     const { key, label, type, items } = entry;
@@ -85,11 +101,7 @@ export function buildLayoutMeta(layout: Layout): LayoutMeta {
     }
 
     switch (type) {
-      case "WEIGHT":
-        colTypes[key] = "weight";
-        break;
       case "SA":
-        colTypes[key] = "sa";
         if (items) {
           const map: Record<string, string> = {};
           for (const item of items) {
@@ -102,8 +114,6 @@ export function buildLayoutMeta(layout: Layout): LayoutMeta {
         if (items) {
           for (const item of items) {
             const colName = `${key}_${item.code}`;
-            colTypes[colName] = `ma:${key}`;
-            // MA columns are 1/0 flags; store item.label as display label for "1"
             valueLabels[colName] = { "1": item.label };
           }
         }
@@ -111,5 +121,5 @@ export function buildLayoutMeta(layout: Layout): LayoutMeta {
     }
   }
 
-  return { questionLabels, valueLabels, colTypes };
+  return { questionLabels, valueLabels };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-import type { LayoutMeta } from "./layout";
+import type { LabelMap, Layout } from "./layout";
 
 export type CsvData = { text: string; fileName: string; headers: string[]; rowCount: number };
-export type LayoutData = { json: string; fileName: string; meta: LayoutMeta };
+export type LayoutData = { json: string; fileName: string; layout: Layout; labelMap: LabelMap };

--- a/tests/export.test.ts
+++ b/tests/export.test.ts
@@ -6,6 +6,9 @@ import { formatCSV } from "../src/lib/export/formatters/csv";
 import { formatTSV, formatHTML } from "../src/lib/export/formatters/tsv";
 import { formatMarkdown } from "../src/lib/export/formatters/markdown";
 import { formatJSON } from "../src/lib/export/formatters/json";
+import type { LabelMap } from "../src/lib/layout";
+
+const EMPTY_LABEL_MAP: LabelMap = { questionLabels: {}, valueLabels: {} };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let conn: any;
@@ -41,7 +44,7 @@ afterAll(async () => {
 
 describe("buildExportGrids", () => {
   it("GT結果から正しいグリッド構造を生成する", () => {
-    const grids = buildExportGrids(gtResults);
+    const grids = buildExportGrids(gtResults, EMPTY_LABEL_MAP);
     expect(grids).toHaveLength(2);
 
     const grid = grids[0];
@@ -56,7 +59,7 @@ describe("buildExportGrids", () => {
   });
 
   it("クロス結果からヘッダー2行のグリッドを生成する", () => {
-    const grids = buildExportGrids(crossResults);
+    const grids = buildExportGrids(crossResults, EMPTY_LABEL_MAP);
     expect(grids).toHaveLength(1);
 
     const grid = grids[0];
@@ -71,7 +74,7 @@ describe("buildExportGrids", () => {
 
 describe("formatCSV", () => {
   it("カンマ区切りで正しく出力される", () => {
-    const grids = buildExportGrids(gtResults);
+    const grids = buildExportGrids(gtResults, EMPTY_LABEL_MAP);
     const csv = formatCSV(grids);
     const lines = csv.split("\r\n");
 
@@ -98,7 +101,7 @@ describe("formatCSV", () => {
 
 describe("formatTSV", () => {
   it("タブ区切りで出力される", () => {
-    const grids = buildExportGrids(gtResults);
+    const grids = buildExportGrids(gtResults, EMPTY_LABEL_MAP);
     const tsv = formatTSV(grids);
     const lines = tsv.split("\n");
 
@@ -111,7 +114,7 @@ describe("formatTSV", () => {
 
 describe("formatHTML", () => {
   it("テーブルタグを含むHTMLを生成する", () => {
-    const grids = buildExportGrids(gtResults);
+    const grids = buildExportGrids(gtResults, EMPTY_LABEL_MAP);
     const html = formatHTML(grids);
 
     expect(html).toContain("<table>");
@@ -137,7 +140,7 @@ describe("formatHTML", () => {
 
 describe("formatMarkdown", () => {
   it("パイプ区切りのテーブルを生成する", () => {
-    const grids = buildExportGrids(gtResults);
+    const grids = buildExportGrids(gtResults, EMPTY_LABEL_MAP);
     const md = formatMarkdown(grids);
 
     expect(md).toContain("### q1 (SA)");
@@ -146,7 +149,7 @@ describe("formatMarkdown", () => {
   });
 
   it("クロス結果でもMarkdownテーブルを生成する", () => {
-    const grids = buildExportGrids(crossResults);
+    const grids = buildExportGrids(crossResults, EMPTY_LABEL_MAP);
     const md = formatMarkdown(grids);
 
     expect(md).toContain("### q2 (SA)");
@@ -158,7 +161,7 @@ describe("formatMarkdown", () => {
 
 describe("formatJSON", () => {
   it("パース可能なJSONを出力する", () => {
-    const json = formatJSON(gtResults, "");
+    const json = formatJSON(gtResults, "", EMPTY_LABEL_MAP);
     const parsed = JSON.parse(json);
 
     expect(parsed.weightColumn).toBeNull();
@@ -171,14 +174,14 @@ describe("formatJSON", () => {
   });
 
   it("weightCol指定時にweightColumnが含まれる", () => {
-    const json = formatJSON(gtResults, "weight");
+    const json = formatJSON(gtResults, "weight", EMPTY_LABEL_MAP);
     const parsed = JSON.parse(json);
 
     expect(parsed.weightColumn).toBe("weight");
   });
 
   it("各optionにcount/pctが数値で含まれる", () => {
-    const json = formatJSON(gtResults, "");
+    const json = formatJSON(gtResults, "", EMPTY_LABEL_MAP);
     const parsed = JSON.parse(json);
     const opt = parsed.results[0].options[0];
 
@@ -188,7 +191,7 @@ describe("formatJSON", () => {
   });
 
   it("クロス結果でcrossフィールドが含まれる", () => {
-    const json = formatJSON(crossResults, "");
+    const json = formatJSON(crossResults, "", EMPTY_LABEL_MAP);
     const parsed = JSON.parse(json);
     const opt = parsed.results[0].options[0];
 


### PR DESCRIPTION
## Summary
- `LayoutMeta` を `LabelMap` にリネームし、`colTypes` フィールドを除去。純粋なラベル解決辞書に責務を限定
- `buildQuestionDefs` が `Layout` を直接受け取るように変更し、`colTypes` への中間依存を除去
- `findWeightColumn` / `countLayoutColumns` ヘルパーを追加
- 全ラベル解決関数（labels.ts, export系, aiComment.ts）で不要な `optional (?)` を除去し必須引数に変更

## Test plan
- [x] `pnpm check` (fmt:check + lint + tsc --noEmit) パス
- [x] `pnpm test` (248テスト全パス)
- [x] `pnpm build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)