### PR TITLE
refactor: valueLabels を SA/MA 統一形式に変更

### DIFF
--- a/src/components/aggregation/ChartContent.tsx
+++ b/src/components/aggregation/ChartContent.tsx
@@ -201,7 +201,7 @@ function buildCrossChart(
 
   // Stacked bar: one bar per cross value
   if (gtChartType === "obi") {
-    const subLabels = crossSubs.map((s) => resolveSubLabel(s.label, labelMap, crossCols));
+    const subLabels = crossSubs.map((s) => resolveSubLabel(s.label, labelMap));
     const datasets = mains.map((m, i) => ({
       label: resolveValueLabel(res.type, res.question, m, labelMap),
       data: crossSubs.map((sub) => {
@@ -245,7 +245,7 @@ function buildCrossChart(
   const labels = mains.map((m) => resolveValueLabel(res.type, res.question, m, labelMap));
 
   const datasets = crossSubs.map((sub, i) => ({
-    label: resolveSubLabel(sub.label, labelMap, crossCols),
+    label: resolveSubLabel(sub.label, labelMap),
     data: mains.map((m) => {
       const cell = lookup.get(`${m}\0${sub.label}`);
       return cell?.pct ?? 0;

--- a/src/components/aggregation/CrossTable.tsx
+++ b/src/components/aggregation/CrossTable.tsx
@@ -89,7 +89,7 @@ function useCrossTableData(res: AggResult, pv: ReturnType<typeof pivot>): CrossT
 }
 
 function VerticalCrossTable({ data, res }: { data: CrossTableData; res: AggResult }) {
-  const { labelMap, crossCols } = useAggregation();
+  const { labelMap } = useAggregation();
   const { mains, gtSub, crossGroups, questionLabel, lookup, weightCol } = data;
   const hasMultipleAxes = crossGroups.length > 1;
 
@@ -123,7 +123,7 @@ function VerticalCrossTable({ data, res }: { data: CrossTableData; res: AggResul
                 key={sub.label}
                 class={`${TH_BASE} text-right text-xs whitespace-nowrap border-l border-row-border bg-surface2 ${hasMultipleAxes && si === 0 && gi > 0 ? "border-l-2 border-l-border-strong" : ""}`}
               >
-                {resolveSubLabel(sub.label, labelMap, crossCols)}
+                {resolveSubLabel(sub.label, labelMap)}
                 <br />
                 <span class="text-muted text-xs font-normal">n={formatN(sub.n, weightCol)}</span>
               </th>
@@ -175,13 +175,13 @@ function TransposedSubRow({
   mains: string[];
   lookup: Map<string, Cell>;
 }) {
-  const { labelMap, weightCol, crossCols } = useAggregation();
+  const { labelMap, weightCol } = useAggregation();
   return (
     <tr>
       <td
         class={`${TD_BASE} text-left text-xs font-bold whitespace-nowrap border-r-2 border-r-border-strong text-accent2`}
       >
-        {resolveSubLabel(sub.label, labelMap, crossCols)}
+        {resolveSubLabel(sub.label, labelMap)}
         <br />
         <span class="text-muted text-xs font-normal">n={formatN(sub.n, weightCol)}</span>
       </td>

--- a/src/lib/agg/aggregate.ts
+++ b/src/lib/agg/aggregate.ts
@@ -29,6 +29,7 @@ export interface MAQuestion {
   type: "MA";
   prefix: string;
   columns: string[];
+  codes: string[];
 }
 
 export function questionKey(q: QuestionDef): string {

--- a/src/lib/agg/crossAggregator.ts
+++ b/src/lib/agg/crossAggregator.ts
@@ -49,11 +49,11 @@ export async function fetchCrossHeaders(
       const sql = `SELECT ${selectClauses.join(", ")} FROM survey`;
       const result = await conn.query(sql);
       const row = result.toArray()[0];
-      const headers = crossQ.columns.map((col, i) => ({
-        label: col,
+      const headers = crossQ.columns.map((_, i) => ({
+        label: crossQ.codes[i],
         n: Number(row[`c${i}`] ?? 0),
       }));
-      cache.set(crossQ.prefix, { headers, crossValues: headers.map((h) => h.label) });
+      cache.set(crossQ.prefix, { headers, crossValues: crossQ.codes });
     }
   }
   return cache;
@@ -142,7 +142,7 @@ export class CrossAggregator {
         cells.push(
           mkCell(
             mv,
-            crossSub(crossQ.prefix, crossQ.columns[i]),
+            crossSub(crossQ.prefix, crossQ.codes[i]),
             headers[i].n,
             Number(r[`c${i}`] ?? 0),
           ),
@@ -247,7 +247,7 @@ export class CrossAggregator {
         cells.push(
           mkCell(
             rowMaCols[r],
-            crossSub(crossQ.prefix, crossQ.columns[c]),
+            crossSub(crossQ.prefix, crossQ.codes[c]),
             headers[c].n,
             Number(row[`r${r}c${c}`] ?? 0),
           ),
@@ -260,7 +260,7 @@ export class CrossAggregator {
       cells.push(
         mkCell(
           NA_VALUE,
-          crossSub(crossQ.prefix, crossQ.columns[c]),
+          crossSub(crossQ.prefix, crossQ.codes[c]),
           headers[c].n,
           Number(row[`na_c${c}`] ?? 0),
         ),

--- a/src/lib/aiComment.ts
+++ b/src/lib/aiComment.ts
@@ -2,6 +2,7 @@
 
 import type { AggResult } from "./agg/aggregate";
 import type { LabelMap } from "./layout";
+import { resolveQuestionLabel, resolveValueLabel } from "./labels";
 import { getLocale, t } from "./i18n";
 
 // Chrome Prompt API type declarations
@@ -71,15 +72,6 @@ export async function generateComment(
 
 const MAX_PAYLOAD_CHARS = 3500;
 
-function resolveQLabel(col: string, labelMap: LabelMap): string {
-  return labelMap.questionLabels[col] ?? col;
-}
-
-function resolveVLabel(type: "SA" | "MA", col: string, code: string, labelMap: LabelMap): string {
-  if (type === "SA") return labelMap.valueLabels[col]?.[code] ?? code;
-  return labelMap.valueLabels[code]?.["1"] ?? code;
-}
-
 function summarizeResults(
   results: AggResult[],
   weightCol: string,
@@ -96,13 +88,13 @@ function summarizeResults(
     if (gtCells.length === 0) continue;
 
     const n = gtCells[0].n;
-    const qLabel = resolveQLabel(res.question, labelMap);
+    const qLabel = resolveQuestionLabel(res.question, labelMap);
     lines.push(`${res.question}: ${qLabel} (${res.type}, n=${n})`);
 
     const sorted = [...gtCells].sort((a, b) => b.pct - a.pct);
     const top = sorted.slice(0, topN);
     const items = top.map((c) => {
-      const label = resolveVLabel(res.type, res.question, c.main, labelMap);
+      const label = resolveValueLabel(res.type, res.question, c.main, labelMap);
       return `${label}: ${c.pct.toFixed(1)}%`;
     });
 

--- a/src/lib/export/exportGrid.ts
+++ b/src/lib/export/exportGrid.ts
@@ -1,8 +1,8 @@
 import type { AggResult } from "../agg/aggregate";
-import { parseCrossSub } from "../agg/aggregate";
 import type { LabelMap } from "../layout";
 import { NA_VALUE } from "../agg/sqlHelpers";
 import { pivot } from "../agg/pivot";
+import { resolveSubLabel } from "../labels";
 import { t } from "../i18n";
 
 export interface ExportGrid {
@@ -24,21 +24,6 @@ export function buildExportGrids(results: AggResult[], labelMap: LabelMap): Expo
 
 export function resolveMainLabel(main: string): string {
   return main === NA_VALUE ? t("export.na") : main;
-}
-
-export function resolveSubLabel(subLabel: string, labelMap: LabelMap): string {
-  if (subLabel === NA_VALUE) return t("export.na");
-
-  const parsed = parseCrossSub(subLabel);
-  if (parsed) {
-    const { axisKey, rawValue } = parsed;
-    if (rawValue === NA_VALUE) return t("export.na");
-    const maLabel = labelMap.valueLabels[rawValue]?.["1"];
-    if (maLabel) return maLabel;
-    return labelMap.valueLabels[axisKey]?.[rawValue] ?? rawValue;
-  }
-
-  return labelMap.valueLabels[subLabel]?.["1"] ?? subLabel;
 }
 
 function buildGtGrid(res: AggResult): ExportGrid {
@@ -87,7 +72,9 @@ function buildCrossGrids(results: AggResult[], labelMap: LabelMap): ExportGrid[]
   const headerRow2 = ["", "", "", "", ""];
   for (const sub of crossSubs) {
     headerRow1.push("");
-    headerRow2.push(`${resolveSubLabel(sub.label, labelMap)}(n=${sub.n.toFixed(1)})`);
+    headerRow2.push(
+      `${resolveSubLabel(sub.label, labelMap, t("export.na"))}(n=${sub.n.toFixed(1)})`,
+    );
   }
   const sharedHeaders = [headerRow1, headerRow2];
 

--- a/src/lib/export/formatters/json.ts
+++ b/src/lib/export/formatters/json.ts
@@ -1,7 +1,8 @@
 import type { AggResult } from "../../agg/aggregate";
 import type { LabelMap } from "../../layout";
 import { pivot } from "../../agg/pivot";
-import { resolveMainLabel, resolveSubLabel } from "../exportGrid";
+import { resolveMainLabel } from "../exportGrid";
+import { resolveSubLabel } from "../../labels";
 import { downloadFile, today } from "../export";
 
 interface JsonOption {

--- a/src/lib/labels.ts
+++ b/src/lib/labels.ts
@@ -1,6 +1,5 @@
-/** Label resolution utility (shared by table / chart components) */
+/** Label resolution utility (shared by table / chart / export) */
 
-import type { QuestionDef } from "./agg/aggregate";
 import { parseCrossSub } from "./agg/aggregate";
 import type { LabelMap } from "./layout";
 import { NA_VALUE } from "./agg/sqlHelpers";
@@ -10,7 +9,7 @@ export function resolveQuestionLabel(col: string, labelMap: LabelMap): string {
   return labelMap.questionLabels[col] ?? col;
 }
 
-/** Resolve option label (SA: valueLabels[col][code], MA: valueLabels[colName]["1"]) */
+/** Resolve option label: unified valueLabels[col][code] for both SA and MA */
 export function resolveValueLabel(
   type: "SA" | "MA",
   col: string,
@@ -18,34 +17,20 @@ export function resolveValueLabel(
   labelMap: LabelMap,
 ): string {
   if (rowLabel === NA_VALUE) return "無回答";
-  if (type === "SA") {
-    return labelMap.valueLabels[col]?.[rowLabel] ?? rowLabel;
-  } else {
-    return labelMap.valueLabels[rowLabel]?.["1"] ?? rowLabel;
-  }
+  const code = type === "MA" ? (labelMap.colToCode[rowLabel] ?? rowLabel) : rowLabel;
+  return labelMap.valueLabels[col]?.[code] ?? rowLabel;
 }
 
 /** Resolve cross-axis header label (sub values are prefixed as "axisKey\x01rawValue") */
-export function resolveSubLabel(
-  subLabel: string,
-  labelMap: LabelMap,
-  _crossCols?: QuestionDef[],
-): string {
-  if (subLabel === NA_VALUE) return "無回答";
+export function resolveSubLabel(subLabel: string, labelMap: LabelMap, naLabel = "無回答"): string {
+  if (subLabel === NA_VALUE) return naLabel;
 
   const parsed = parseCrossSub(subLabel);
   if (parsed) {
     const { axisKey, rawValue } = parsed;
-    if (rawValue === NA_VALUE) return "無回答";
-    // MA axis: rawValue is column name → valueLabels[rawValue]["1"]
-    const maLabel = labelMap.valueLabels[rawValue]?.["1"];
-    if (maLabel) return maLabel;
-    // SA axis: rawValue is value code → valueLabels[axisKey][rawValue]
+    if (rawValue === NA_VALUE) return naLabel;
     return labelMap.valueLabels[axisKey]?.[rawValue] ?? rawValue;
   }
 
-  // No prefix (backwards compatibility)
-  const maLabel = labelMap.valueLabels[subLabel]?.["1"];
-  if (maLabel) return maLabel;
   return subLabel;
 }

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -19,8 +19,10 @@ export type Layout = LayoutEntry[];
 export interface LabelMap {
   /** Question labels: CSV column name (or MA group name) → display name */
   questionLabels: Record<string, string>;
-  /** Value labels: SA → { colName: { code: label } }, MA → { colName: { "1": itemLabel } } */
+  /** Value labels: unified { questionKey: { code: label } } for both SA and MA */
   valueLabels: Record<string, Record<string, string>>;
+  /** MA column name → item code (e.g. { "q3_1": "1" }) */
+  colToCode: Record<string, string>;
 }
 
 export function parseLayout(jsonText: string): Layout {
@@ -57,24 +59,27 @@ export function buildQuestionDefs(headers: string[], layout: Layout): QuestionDe
       colTypes.set(entry.key, "sa");
     } else if (entry.type === "MA" && entry.items) {
       for (const item of entry.items) {
-        colTypes.set(`${entry.key}_${item.code}`, `ma:${entry.key}`);
+        colTypes.set(`${entry.key}_${item.code}`, `ma:${entry.key}:${item.code}`);
       }
     }
   }
 
   const questions: QuestionDef[] = [];
-  const maAccum: Record<string, string[]> = {};
+  const maAccum: Record<string, { columns: string[]; codes: string[] }> = {};
   for (const col of headers) {
     const t = colTypes.get(col);
     if (!t) continue;
     if (t === "sa") {
       questions.push({ type: "SA", column: col });
     } else if (t.startsWith("ma:")) {
-      (maAccum[t.slice(3)] ??= []).push(col);
+      const [, prefix, code] = t.split(":");
+      const acc = (maAccum[prefix] ??= { columns: [], codes: [] });
+      acc.columns.push(col);
+      acc.codes.push(code);
     }
   }
-  for (const [prefix, cols] of Object.entries(maAccum)) {
-    questions.push({ type: "MA", prefix, columns: cols });
+  for (const [prefix, { columns, codes }] of Object.entries(maAccum)) {
+    questions.push({ type: "MA", prefix, columns, codes });
   }
   return questions;
 }
@@ -92,6 +97,7 @@ export function countLayoutColumns(layout: Layout): number {
 export function buildLabelMap(layout: Layout): LabelMap {
   const questionLabels: Record<string, string> = {};
   const valueLabels: Record<string, Record<string, string>> = {};
+  const colToCode: Record<string, string> = {};
 
   for (const entry of layout) {
     const { key, label, type, items } = entry;
@@ -112,14 +118,16 @@ export function buildLabelMap(layout: Layout): LabelMap {
         break;
       case "MA":
         if (items) {
+          const map: Record<string, string> = {};
           for (const item of items) {
-            const colName = `${key}_${item.code}`;
-            valueLabels[colName] = { "1": item.label };
+            map[item.code] = item.label;
+            colToCode[`${key}_${item.code}`] = item.code;
           }
+          valueLabels[key] = map;
         }
         break;
     }
   }
 
-  return { questionLabels, valueLabels };
+  return { questionLabels, valueLabels, colToCode };
 }

--- a/tests/aggregate.test.ts
+++ b/tests/aggregate.test.ts
@@ -82,7 +82,7 @@ describe("aggregate - 重みなし", () => {
   describe("MA GT集計（クロスなし）", () => {
     it("q3 の GT 集計で各サブカラムの count と無回答が正しい", async () => {
       const query: Query = {
-        questions: [{ type: "MA", prefix: "q3", columns: ["q3_1", "q3_2", "q3_3"] }],
+        questions: [{ type: "MA", prefix: "q3", columns: ["q3_1", "q3_2", "q3_3"], codes: ["1", "2", "3"] }],
         weight_col: "",
         cross_cols: [],
       };
@@ -159,7 +159,7 @@ describe("aggregate - 重みなし", () => {
       const query: Query = {
         questions: [{ type: "SA", column: "q1" }],
         weight_col: "",
-        cross_cols: [{ type: "MA", prefix: "q3", columns: ["q3_1", "q3_2", "q3_3"] }],
+        cross_cols: [{ type: "MA", prefix: "q3", columns: ["q3_1", "q3_2", "q3_3"], codes: ["1", "2", "3"] }],
       };
 
       const results = await aggregate(conn, query);
@@ -172,7 +172,7 @@ describe("aggregate - 重みなし", () => {
       // q1有効: 行1-13 (行14=空除外) = 13行
       // q1=1 の行: 行1,3,5,7,10,12
       // q1=1 かつ q3_1='1': 行1,3 = 2件
-      const cell = findCell(r.cells, "1", crossSub("q3", "q3_1"));
+      const cell = findCell(r.cells, "1", crossSub("q3", "1"));
       expect(cell).toBeDefined();
       expect(cell!.count).toBe(2);
     });
@@ -181,7 +181,7 @@ describe("aggregate - 重みなし", () => {
   describe("MA × SA クロス集計", () => {
     it("q3 を q1 でクロスした結果が正しい", async () => {
       const query: Query = {
-        questions: [{ type: "MA", prefix: "q3", columns: ["q3_1", "q3_2", "q3_3"] }],
+        questions: [{ type: "MA", prefix: "q3", columns: ["q3_1", "q3_2", "q3_3"], codes: ["1", "2", "3"] }],
         weight_col: "",
         cross_cols: [{ type: "SA", column: "q1" }],
       };
@@ -207,9 +207,9 @@ describe("aggregate - 重みなし", () => {
   describe("MA × MA クロス集計", () => {
     it("q3 を自身でクロスした結果にセルが存在する", async () => {
       const query: Query = {
-        questions: [{ type: "MA", prefix: "q3", columns: ["q3_1", "q3_2", "q3_3"] }],
+        questions: [{ type: "MA", prefix: "q3", columns: ["q3_1", "q3_2", "q3_3"], codes: ["1", "2", "3"] }],
         weight_col: "",
-        cross_cols: [{ type: "MA", prefix: "q3", columns: ["q3_1", "q3_2", "q3_3"] }],
+        cross_cols: [{ type: "MA", prefix: "q3", columns: ["q3_1", "q3_2", "q3_3"], codes: ["1", "2", "3"] }],
       };
 
       const results = await aggregate(conn, query);
@@ -217,12 +217,12 @@ describe("aggregate - 重みなし", () => {
 
       const r = results[0];
       // q3_1='1' かつ q3_1='1': 行1,3,4,6,8,9,14 = 7件
-      const cell = findCell(r.cells, "q3_1", crossSub("q3", "q3_1"));
+      const cell = findCell(r.cells, "q3_1", crossSub("q3", "1"));
       expect(cell).toBeDefined();
       expect(cell!.count).toBe(7);
 
       // q3_1='1' かつ q3_2='1': 行3,9 = 2件
-      const cell12 = findCell(r.cells, "q3_1", crossSub("q3", "q3_2"));
+      const cell12 = findCell(r.cells, "q3_1", crossSub("q3", "2"));
       expect(cell12).toBeDefined();
       expect(cell12!.count).toBe(2);
     });
@@ -264,7 +264,7 @@ describe("aggregate - 重み付き", () => {
   describe("MA GT集計（重み付き）", () => {
     it("q3 の重み付き GT 集計で weighted count が正しい", async () => {
       const query: Query = {
-        questions: [{ type: "MA", prefix: "q3", columns: ["q3_1", "q3_2", "q3_3"] }],
+        questions: [{ type: "MA", prefix: "q3", columns: ["q3_1", "q3_2", "q3_3"], codes: ["1", "2", "3"] }],
         weight_col: "weight",
         cross_cols: [],
       };

--- a/tests/export.test.ts
+++ b/tests/export.test.ts
@@ -8,7 +8,7 @@ import { formatMarkdown } from "../src/lib/export/formatters/markdown";
 import { formatJSON } from "../src/lib/export/formatters/json";
 import type { LabelMap } from "../src/lib/layout";
 
-const EMPTY_LABEL_MAP: LabelMap = { questionLabels: {}, valueLabels: {} };
+const EMPTY_LABEL_MAP: LabelMap = { questionLabels: {}, valueLabels: {}, colToCode: {} };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let conn: any;
@@ -21,7 +21,7 @@ beforeAll(async () => {
   const gtQuery: Query = {
     questions: [
       { type: "SA", column: "q1" },
-      { type: "MA", prefix: "q3", columns: ["q3_1", "q3_2", "q3_3"] },
+      { type: "MA", prefix: "q3", columns: ["q3_1", "q3_2", "q3_3"], codes: ["1", "2", "3"] },
     ],
     weight_col: "",
     cross_cols: [],


### PR DESCRIPTION
## Summary

- `MAQuestion.codes` を追加し、選択肢コードを集計層で直接利用可能に
- `valueLabels` を SA/MA 統一形式 (`valueLabels[questionKey][code] = label`) に変更
- `LabelMap.colToCode` を追加し、MA カラム名→コード変換をサポート
- `crossSub` の MA rawValue をカラム名→コードに変更し、`resolveSubLabel` の SA/MA 分岐を解消
- `resolveSubLabel` の重複実装を解消（`exportGrid.ts` → `labels.ts` に一本化）
- `aiComment.ts` の重複ラベル解決関数を削除し `labels.ts` から import

## Test plan

- [x] `pnpm check` (tsc + lint + fmt) パス
- [x] `pnpm test` (290 テスト) パス
- [ ] 手動確認: CSV+JSON アップロード → GT/クロス集計 → テーブル/チャート/エクスポート

🤖 Generated with [Claude Code](https://claude.com/claude-code)