### PR TITLE
refactor: Cell から n/pct を除去し pivot で pct を算出

### DIFF
--- a/src/components/aggregation/ChartContent.tsx
+++ b/src/components/aggregation/ChartContent.tsx
@@ -52,7 +52,7 @@ function ChartCard({ res, gtChartType, paletteId }: ChartCardProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const chartRef = useRef<Chart | null>(null);
 
-  const pv = pivot(res.cells);
+  const pv = pivot(res.cells, res.nBySubLabel);
   const isCross = pv.subs.length > 1;
 
   useEffect(() => {

--- a/src/components/aggregation/CrossTable.tsx
+++ b/src/components/aggregation/CrossTable.tsx
@@ -1,6 +1,6 @@
-import type { AggResult, Cell, QuestionDef } from "../../lib/agg/aggregate";
+import type { AggResult, QuestionDef } from "../../lib/agg/aggregate";
 import { questionKey, parseCrossSub } from "../../lib/agg/aggregate";
-import type { pivot } from "../../lib/agg/pivot";
+import type { pivot, PivotCell } from "../../lib/agg/pivot";
 import { resolveQuestionLabel, resolveValueLabel, resolveSubLabel } from "../../lib/labels";
 import { t } from "../../lib/i18n";
 import type { PctDirection } from "./Toolbar";
@@ -70,7 +70,7 @@ interface CrossTableData {
   gtSub: SubInfo;
   crossGroups: CrossGroup[];
   questionLabel: string;
-  lookup: Map<string, Cell>;
+  lookup: Map<string, PivotCell>;
   weightCol: string;
 }
 
@@ -173,7 +173,7 @@ function TransposedSubRow({
 }: {
   sub: SubInfo;
   mains: string[];
-  lookup: Map<string, Cell>;
+  lookup: Map<string, PivotCell>;
 }) {
   const { labelMap, weightCol } = useAggregation();
   return (

--- a/src/components/aggregation/ResultCard.tsx
+++ b/src/components/aggregation/ResultCard.tsx
@@ -12,7 +12,7 @@ interface ResultCardProps {
 export function ResultCard({ res, extraClass, children }: ResultCardProps) {
   const { labelMap, weightCol } = useAggregation();
 
-  const gtN = res.cells.find((c) => c.sub === "GT")!.n;
+  const gtN = res.nBySubLabel["GT"] ?? 0;
   const nLabel = weightCol ? `n=${gtN.toFixed(1)}` : `n=${gtN.toLocaleString()}`;
 
   const questionLabel = resolveQuestionLabel(res.question, labelMap);

--- a/src/components/aggregation/TableContent.tsx
+++ b/src/components/aggregation/TableContent.tsx
@@ -11,8 +11,13 @@ interface TableContentProps {
 
 export function TableContent({ pctDirection }: TableContentProps) {
   const { results, hasCross } = useAggregation();
-  const allGtCells = results.flatMap((r) => r.cells.filter((c) => c.sub === "GT"));
-  const maxPct = Math.max(...allGtCells.map((c) => c.pct), 0);
+  const maxPct = Math.max(
+    ...results.flatMap((r) => {
+      const n = r.nBySubLabel["GT"] ?? 0;
+      return n > 0 ? r.cells.filter((c) => c.sub === "GT").map((c) => (c.count / n) * 100) : [];
+    }),
+    0,
+  );
 
   return (
     <div
@@ -23,7 +28,7 @@ export function TableContent({ pctDirection }: TableContentProps) {
       }
     >
       {results.map((res) => {
-        const pv = pivot(res.cells);
+        const pv = pivot(res.cells, res.nBySubLabel);
         const isCross = pv.subs.length > 1;
 
         return (

--- a/src/lib/agg/aggregate.ts
+++ b/src/lib/agg/aggregate.ts
@@ -6,16 +6,23 @@ import { CrossAggregator, fetchCrossHeaders } from "./crossAggregator";
 
 export interface Cell {
   main: string; // Option label (aggregation target value)
-  sub: string; // "GT" or cross-tab axis value or MA column name
-  n: number; // Denominator for this sub
+  sub: string; // "GT" or cross-tab axis value
   count: number;
-  pct: number;
 }
 
+/** Aggregation result per question */
 export interface AggResult {
   question: string;
   type: "SA" | "MA";
   cells: Cell[];
+  /** Denominator (n) per sub label: e.g. { "GT": 100, "q1\x011": 40 } */
+  nBySubLabel: Record<string, number>;
+}
+
+/** Aggregator return type (cells + n map) */
+export interface AggCells {
+  cells: Cell[];
+  nBySubLabel: Record<string, number>;
 }
 
 export type QuestionDef = SAQuestion | MAQuestion;
@@ -79,13 +86,29 @@ export async function aggregate(
   const results: AggResult[] = [];
   for (const q of payload.questions) {
     if (q.type === "SA") {
-      const gtCells = await gt.aggregateSA(q.column);
-      const crossCells = await Promise.all(crossAggregators.map((ca) => ca.aggregateSA(q.column)));
-      results.push({ question: q.column, type: "SA", cells: [...gtCells, ...crossCells.flat()] });
+      const gtResult = await gt.aggregateSA(q.column);
+      const crossResults = await Promise.all(
+        crossAggregators.map((ca) => ca.aggregateSA(q.column)),
+      );
+      const cells = [...gtResult.cells, ...crossResults.flatMap((r) => r.cells)];
+      const nBySubLabel = Object.assign(
+        {},
+        gtResult.nBySubLabel,
+        ...crossResults.map((r) => r.nBySubLabel),
+      );
+      results.push({ question: q.column, type: "SA", cells, nBySubLabel });
     } else {
-      const gtCells = await gt.aggregateMA(q.columns);
-      const crossCells = await Promise.all(crossAggregators.map((ca) => ca.aggregateMA(q.columns)));
-      results.push({ question: q.prefix, type: "MA", cells: [...gtCells, ...crossCells.flat()] });
+      const gtResult = await gt.aggregateMA(q.columns);
+      const crossResults = await Promise.all(
+        crossAggregators.map((ca) => ca.aggregateMA(q.columns)),
+      );
+      const cells = [...gtResult.cells, ...crossResults.flatMap((r) => r.cells)];
+      const nBySubLabel = Object.assign(
+        {},
+        gtResult.nBySubLabel,
+        ...crossResults.map((r) => r.nBySubLabel),
+      );
+      results.push({ question: q.prefix, type: "MA", cells, nBySubLabel });
     }
   }
 

--- a/src/lib/agg/crossAggregator.ts
+++ b/src/lib/agg/crossAggregator.ts
@@ -1,7 +1,7 @@
 /** Cross-tabulation aggregation — one cross axis at a time */
 
 import type * as duckdb from "@duckdb/duckdb-wasm";
-import type { Cell, QuestionDef, SAQuestion, MAQuestion } from "./aggregate";
+import type { AggCells, QuestionDef, SAQuestion, MAQuestion } from "./aggregate";
 import { crossSub } from "./aggregate";
 import {
   esc,
@@ -74,7 +74,7 @@ export class CrossAggregator {
   }
 
   /** Cross-tabulate an SA main question against this cross axis */
-  async aggregateSA(col: string): Promise<Cell[]> {
+  async aggregateSA(col: string): Promise<AggCells> {
     if (this.crossQ.type === "SA") {
       return this.saSA(col, this.crossQ);
     }
@@ -82,7 +82,7 @@ export class CrossAggregator {
   }
 
   /** Cross-tabulate an MA main question against this cross axis */
-  async aggregateMA(cols: string[]): Promise<Cell[]> {
+  async aggregateMA(cols: string[]): Promise<AggCells> {
     if (this.crossQ.type === "SA") {
       return this.maSA(cols, this.crossQ);
     }
@@ -91,7 +91,7 @@ export class CrossAggregator {
 
   // ── SA main × SA cross ──
 
-  private async saSA(col: string, crossQ: SAQuestion): Promise<Cell[]> {
+  private async saSA(col: string, crossQ: SAQuestion): Promise<AggCells> {
     const crossCol = crossQ.column;
     const { headers, crossValues } = this.crossHeader;
 
@@ -104,21 +104,26 @@ export class CrossAggregator {
     `;
 
     const result = await this.conn.query(sql);
-    const cells: Cell[] = [];
+    const cells: AggCells["cells"] = [];
     for (const r of result.toArray()) {
       const mv = String(r.mv);
       const sv = String(r.sv);
       const idx = crossValues.indexOf(sv);
       if (idx >= 0) {
-        cells.push(mkCell(mv, crossSub(crossCol, sv), headers[idx].n, Number(r.cnt)));
+        cells.push(mkCell(mv, crossSub(crossCol, sv), Number(r.cnt)));
       }
     }
-    return cells;
+
+    const nBySubLabel: Record<string, number> = {};
+    for (let i = 0; i < headers.length; i++) {
+      nBySubLabel[crossSub(crossCol, crossValues[i])] = headers[i].n;
+    }
+    return { cells, nBySubLabel };
   }
 
   // ── SA main × MA cross ──
 
-  private async saMA(col: string, crossQ: MAQuestion): Promise<Cell[]> {
+  private async saMA(col: string, crossQ: MAQuestion): Promise<AggCells> {
     const { headers } = this.crossHeader;
 
     const selectClauses = crossQ.columns.map(
@@ -135,26 +140,24 @@ export class CrossAggregator {
     `;
 
     const result = await this.conn.query(sql);
-    const cells: Cell[] = [];
+    const cells: AggCells["cells"] = [];
     for (const r of result.toArray()) {
       const mv = String(r.mv);
       for (let i = 0; i < crossQ.columns.length; i++) {
-        cells.push(
-          mkCell(
-            mv,
-            crossSub(crossQ.prefix, crossQ.codes[i]),
-            headers[i].n,
-            Number(r[`c${i}`] ?? 0),
-          ),
-        );
+        cells.push(mkCell(mv, crossSub(crossQ.prefix, crossQ.codes[i]), Number(r[`c${i}`] ?? 0)));
       }
     }
-    return cells;
+
+    const nBySubLabel: Record<string, number> = {};
+    for (let i = 0; i < headers.length; i++) {
+      nBySubLabel[crossSub(crossQ.prefix, crossQ.codes[i])] = headers[i].n;
+    }
+    return { cells, nBySubLabel };
   }
 
   // ── MA main × SA cross ──
 
-  private async maSA(maCols: string[], crossQ: SAQuestion): Promise<Cell[]> {
+  private async maSA(maCols: string[], crossQ: SAQuestion): Promise<AggCells> {
     const crossCol = crossQ.column;
     const { headers, crossValues } = this.crossHeader;
 
@@ -185,39 +188,31 @@ export class CrossAggregator {
       naMap.set(String(r.cv), Number(r.na_cnt ?? 0));
     }
 
-    const cells: Cell[] = [];
+    const cells: AggCells["cells"] = [];
     for (let maIdx = 0; maIdx < maCols.length; maIdx++) {
       for (let i = 0; i < crossValues.length; i++) {
         const counts = rowMap.get(crossValues[i]);
-        cells.push(
-          mkCell(
-            maCols[maIdx],
-            crossSub(crossCol, crossValues[i]),
-            headers[i].n,
-            counts?.[maIdx] ?? 0,
-          ),
-        );
+        cells.push(mkCell(maCols[maIdx], crossSub(crossCol, crossValues[i]), counts?.[maIdx] ?? 0));
       }
     }
 
     // No-answer cross cells
     for (let i = 0; i < crossValues.length; i++) {
       cells.push(
-        mkCell(
-          NA_VALUE,
-          crossSub(crossCol, crossValues[i]),
-          headers[i].n,
-          naMap.get(crossValues[i]) ?? 0,
-        ),
+        mkCell(NA_VALUE, crossSub(crossCol, crossValues[i]), naMap.get(crossValues[i]) ?? 0),
       );
     }
 
-    return cells;
+    const nBySubLabel: Record<string, number> = {};
+    for (let i = 0; i < headers.length; i++) {
+      nBySubLabel[crossSub(crossCol, crossValues[i])] = headers[i].n;
+    }
+    return { cells, nBySubLabel };
   }
 
   // ── MA main × MA cross ──
 
-  private async maMA(rowMaCols: string[], crossQ: MAQuestion): Promise<Cell[]> {
+  private async maMA(rowMaCols: string[], crossQ: MAQuestion): Promise<AggCells> {
     const { headers } = this.crossHeader;
 
     const selectClauses: string[] = [];
@@ -241,14 +236,13 @@ export class CrossAggregator {
     const result = await this.conn.query(sql);
     const row = result.toArray()[0];
 
-    const cells: Cell[] = [];
+    const cells: AggCells["cells"] = [];
     for (let r = 0; r < rowMaCols.length; r++) {
       for (let c = 0; c < crossQ.columns.length; c++) {
         cells.push(
           mkCell(
             rowMaCols[r],
             crossSub(crossQ.prefix, crossQ.codes[c]),
-            headers[c].n,
             Number(row[`r${r}c${c}`] ?? 0),
           ),
         );
@@ -258,15 +252,14 @@ export class CrossAggregator {
     // No-answer cross cells
     for (let c = 0; c < crossQ.columns.length; c++) {
       cells.push(
-        mkCell(
-          NA_VALUE,
-          crossSub(crossQ.prefix, crossQ.codes[c]),
-          headers[c].n,
-          Number(row[`na_c${c}`] ?? 0),
-        ),
+        mkCell(NA_VALUE, crossSub(crossQ.prefix, crossQ.codes[c]), Number(row[`na_c${c}`] ?? 0)),
       );
     }
 
-    return cells;
+    const nBySubLabel: Record<string, number> = {};
+    for (let c = 0; c < headers.length; c++) {
+      nBySubLabel[crossSub(crossQ.prefix, crossQ.codes[c])] = headers[c].n;
+    }
+    return { cells, nBySubLabel };
   }
 }

--- a/src/lib/agg/gtAggregator.ts
+++ b/src/lib/agg/gtAggregator.ts
@@ -1,7 +1,7 @@
 /** GT (Grand Total) aggregation — SA and MA */
 
 import type * as duckdb from "@duckdb/duckdb-wasm";
-import type { Cell } from "./aggregate";
+import type { AggCells } from "./aggregate";
 import {
   esc,
   weightExpr,
@@ -19,7 +19,7 @@ export class GtAggregator {
     private weightCol: string,
   ) {}
 
-  async aggregateSA(col: string): Promise<Cell[]> {
+  async aggregateSA(col: string): Promise<AggCells> {
     const sql = `
       SELECT "${esc(col)}" AS mv, ${weightExpr(this.weightCol)} AS cnt
       FROM survey
@@ -31,10 +31,11 @@ export class GtAggregator {
     const rows = result.toArray();
 
     const questionN = rows.reduce((sum, r) => sum + Number(r.cnt), 0);
-    return rows.map((r) => mkCell(String(r.mv), "GT", questionN, Number(r.cnt)));
+    const cells = rows.map((r) => mkCell(String(r.mv), "GT", Number(r.cnt)));
+    return { cells, nBySubLabel: { GT: questionN } };
   }
 
-  async aggregateMA(cols: string[]): Promise<Cell[]> {
+  async aggregateMA(cols: string[]): Promise<AggCells> {
     const selectClauses = cols.map((col, i) => {
       return `${maWeightedCountExpr(col, this.weightCol)} AS c${i}`;
     });
@@ -56,13 +57,11 @@ export class GtAggregator {
     const row = result.toArray()[0];
 
     const questionN = Number(row.question_n ?? 0);
-    const cells: Cell[] = cols.map((col, i) =>
-      mkCell(col, "GT", questionN, Number(row[`c${i}`] ?? 0)),
-    );
+    const cells = cols.map((col, i) => mkCell(col, "GT", Number(row[`c${i}`] ?? 0)));
 
     // No-answer row
-    cells.push(mkCell(NA_VALUE, "GT", questionN, Number(row.na_cnt ?? 0)));
+    cells.push(mkCell(NA_VALUE, "GT", Number(row.na_cnt ?? 0)));
 
-    return cells;
+    return { cells, nBySubLabel: { GT: questionN } };
   }
 }

--- a/src/lib/agg/pivot.ts
+++ b/src/lib/agg/pivot.ts
@@ -1,15 +1,26 @@
 import type { Cell } from "./aggregate";
 
-/** Convert flat cells array into a grid structure */
-export function pivot(cells: Cell[]): {
+export interface PivotCell {
+  count: number;
+  pct: number;
+}
+
+/** Convert flat cells array into a grid structure with pct computed from nBySubLabel */
+export function pivot(
+  cells: Cell[],
+  nBySubLabel: Record<string, number>,
+): {
   mains: string[];
   subs: { label: string; n: number }[];
-  lookup: Map<string, Cell>;
+  lookup: Map<string, PivotCell>;
 } {
   const mains = [...new Set(cells.map((c) => c.main))];
-  const subMap = new Map<string, number>();
-  for (const c of cells) subMap.set(c.sub, c.n);
-  const subs = [...subMap.entries()].map(([label, n]) => ({ label, n }));
-  const lookup = new Map(cells.map((c) => [`${c.main}\0${c.sub}`, c]));
+  const subOrder = [...new Set(cells.map((c) => c.sub))];
+  const subs = subOrder.map((label) => ({ label, n: nBySubLabel[label] ?? 0 }));
+  const lookup = new Map<string, PivotCell>();
+  for (const c of cells) {
+    const n = nBySubLabel[c.sub] ?? 0;
+    lookup.set(`${c.main}\0${c.sub}`, { count: c.count, pct: n > 0 ? (c.count / n) * 100 : 0 });
+  }
   return { mains, subs, lookup };
 }

--- a/src/lib/agg/sqlHelpers.ts
+++ b/src/lib/agg/sqlHelpers.ts
@@ -31,8 +31,8 @@ export function maNoneSelectedCondition(cols: string[]): string {
   return cols.map((c) => `"${esc(c)}" != 1`).join(" AND ");
 }
 
-export function mkCell(main: string, sub: string, n: number, count: number): Cell {
-  return { main, sub, n, count, pct: n > 0 ? (count / n) * 100 : 0 };
+export function mkCell(main: string, sub: string, count: number): Cell {
+  return { main, sub, count };
 }
 
 /** No-answer marker */

--- a/src/lib/aiComment.ts
+++ b/src/lib/aiComment.ts
@@ -2,6 +2,7 @@
 
 import type { AggResult } from "./agg/aggregate";
 import type { LabelMap } from "./layout";
+import { pivot } from "./agg/pivot";
 import { resolveQuestionLabel, resolveValueLabel } from "./labels";
 import { getLocale, t } from "./i18n";
 
@@ -84,14 +85,17 @@ function summarizeResults(
   }
 
   for (const res of results) {
-    const gtCells = res.cells.filter((c) => c.sub === "GT");
-    if (gtCells.length === 0) continue;
+    const pv = pivot(res.cells, res.nBySubLabel);
+    const gtN = res.nBySubLabel["GT"] ?? 0;
+    if (pv.mains.length === 0) continue;
 
-    const n = gtCells[0].n;
     const qLabel = resolveQuestionLabel(res.question, labelMap);
-    lines.push(`${res.question}: ${qLabel} (${res.type}, n=${n})`);
+    lines.push(`${res.question}: ${qLabel} (${res.type}, n=${gtN})`);
 
-    const sorted = [...gtCells].sort((a, b) => b.pct - a.pct);
+    const withPct = pv.mains
+      .map((m) => ({ main: m, pct: pv.lookup.get(`${m}\0GT`)?.pct ?? 0 }))
+      .filter((e) => pv.lookup.has(`${e.main}\0GT`));
+    const sorted = [...withPct].sort((a, b) => b.pct - a.pct);
     const top = sorted.slice(0, topN);
     const items = top.map((c) => {
       const label = resolveValueLabel(res.type, res.question, c.main, labelMap);

--- a/src/lib/export/export.ts
+++ b/src/lib/export/export.ts
@@ -22,7 +22,7 @@ export async function executeExport(
   weightCol: string,
   labelMap: LabelMap,
 ): Promise<boolean> {
-  const hasCross = results.some((r) => pivot(r.cells).subs.length > 1);
+  const hasCross = results.some((r) => pivot(r.cells, r.nBySubLabel).subs.length > 1);
 
   switch (action) {
     case "download-csv": {

--- a/src/lib/export/exportGrid.ts
+++ b/src/lib/export/exportGrid.ts
@@ -13,7 +13,7 @@ export interface ExportGrid {
 }
 
 export function buildExportGrids(results: AggResult[], labelMap: LabelMap): ExportGrid[] {
-  const hasCross = results.some((r) => pivot(r.cells).subs.length > 1);
+  const hasCross = results.some((r) => pivot(r.cells, r.nBySubLabel).subs.length > 1);
   if (hasCross) {
     return buildCrossGrids(results, labelMap);
   }
@@ -27,8 +27,8 @@ export function resolveMainLabel(main: string): string {
 }
 
 function buildGtGrid(res: AggResult): ExportGrid {
-  const { mains, lookup } = pivot(res.cells);
-  const gtSub = pivot(res.cells).subs.find((s) => s.label === "GT")!;
+  const { mains, subs, lookup } = pivot(res.cells, res.nBySubLabel);
+  const gtSub = subs.find((s) => s.label === "GT")!;
   const headers = [
     [
       t("export.header.variable"),
@@ -56,10 +56,10 @@ function buildGtGrid(res: AggResult): ExportGrid {
 }
 
 function buildCrossGrids(results: AggResult[], labelMap: LabelMap): ExportGrid[] {
-  const firstResult = results.find((r) => pivot(r.cells).subs.length > 1);
+  const firstResult = results.find((r) => pivot(r.cells, r.nBySubLabel).subs.length > 1);
   if (!firstResult) return results.map((res) => buildGtGrid(res));
 
-  const firstPivot = pivot(firstResult.cells);
+  const firstPivot = pivot(firstResult.cells, firstResult.nBySubLabel);
   const crossSubs = firstPivot.subs.filter((s) => s.label !== "GT");
 
   const headerRow1 = [
@@ -79,7 +79,7 @@ function buildCrossGrids(results: AggResult[], labelMap: LabelMap): ExportGrid[]
   const sharedHeaders = [headerRow1, headerRow2];
 
   return results.map((res) => {
-    const { mains, subs, lookup } = pivot(res.cells);
+    const { mains, subs, lookup } = pivot(res.cells, res.nBySubLabel);
     const resCrossSubs = subs.filter((s) => s.label !== "GT");
     const gtSub = subs.find((s) => s.label === "GT")!;
     const rows: string[][] = [];

--- a/src/lib/export/formatters/json.ts
+++ b/src/lib/export/formatters/json.ts
@@ -26,7 +26,7 @@ interface JsonExport {
 
 export function formatJSON(results: AggResult[], weightCol: string, labelMap: LabelMap): string {
   const entries: JsonExportEntry[] = results.map((res) => {
-    const { mains, subs, lookup } = pivot(res.cells);
+    const { mains, subs, lookup } = pivot(res.cells, res.nBySubLabel);
     const gtSub = subs.find((s) => s.label === "GT")!;
     const crossSubs = subs.filter((s) => s.label !== "GT");
 

--- a/tests/aggregate.test.ts
+++ b/tests/aggregate.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { aggregate, type Query, type Cell, crossSub } from "../src/lib/agg/aggregate";
+import { pivot } from "../src/lib/agg/pivot";
 import { setupDuckDB, teardownDuckDB } from "./helpers/duckdb";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -62,11 +63,12 @@ describe("aggregate - 重みなし", () => {
       // q1=3: 行4,8 = 2件
       // q1=99(無回答): 行11,13 = 2件
       const n = 13;
+      expect(r.nBySubLabel["GT"]).toBe(n);
       const cell1 = findCell(r.cells, "1", "GT")!;
       expect(cell1).toBeDefined();
-      expect(cell1.n).toBe(n);
       expect(cell1.count).toBe(6);
-      expect(cell1.pct).toBeCloseTo((6 / n) * 100, 5);
+      const pv = pivot(r.cells, r.nBySubLabel);
+      expect(pv.lookup.get("1\0GT")!.pct).toBeCloseTo((6 / n) * 100, 5);
 
       const cell2 = findCell(r.cells, "2", "GT")!;
       expect(cell2.count).toBe(3);
@@ -103,9 +105,9 @@ describe("aggregate - 重みなし", () => {
       // 無回答(shown but none='1'): 行11(0,0,0),12(0,0,0) = 2件
       const n = 13;
 
+      expect(r.nBySubLabel["GT"]).toBe(n);
       const cellQ3_1 = findCell(r.cells, "q3_1", "GT")!;
       expect(cellQ3_1).toBeDefined();
-      expect(cellQ3_1.n).toBe(n);
       expect(cellQ3_1.count).toBe(7);
 
       const cellQ3_2 = findCell(r.cells, "q3_2", "GT")!;
@@ -138,7 +140,7 @@ describe("aggregate - 重みなし", () => {
       // q2=3: 行1,5,8 = 3件
       // q2=99(無回答): 行11 = 1件
       const gtN = 13;
-      expect(findCell(r.cells, "1", "GT")!.n).toBe(gtN);
+      expect(r.nBySubLabel["GT"]).toBe(gtN);
       expect(findCell(r.cells, "1", "GT")!.count).toBe(5);
       expect(findCell(r.cells, "2", "GT")!.count).toBe(4);
       expect(findCell(r.cells, "3", "GT")!.count).toBe(3);
@@ -250,8 +252,9 @@ describe("aggregate - 重み付き", () => {
       const cell1 = findCell(r.cells, "1", "GT")!;
       expect(cell1).toBeDefined();
       expect(cell1.count).toBeCloseTo(6.9, 1);
-      expect(cell1.n).toBeCloseTo(13.8, 1);
-      expect(cell1.pct).toBeCloseTo((6.9 / 13.8) * 100, 1);
+      expect(r.nBySubLabel["GT"]).toBeCloseTo(13.8, 1);
+      const pv = pivot(r.cells, r.nBySubLabel);
+      expect(pv.lookup.get("1\0GT")!.pct).toBeCloseTo((6.9 / 13.8) * 100, 1);
 
       const cell2 = findCell(r.cells, "2", "GT")!;
       expect(cell2.count).toBeCloseTo(3.3, 1);


### PR DESCRIPTION
## Summary
- `Cell` から `n`/`pct` プロパティを除去し `{ main, sub, count }` に簡素化
- `AggResult` に `nBySubLabel: Record<string, number>` を追加し、sub label ごとの母数(n)を保持
- `pivot()` が `nBySubLabel` を受け取り `PivotCell { count, pct }` を算出する形に変更
- 全消費側（テーブル/チャート/エクスポート/AI コメント/テスト）を新しい API に移行

## Test plan
- [x] `pnpm check` (tsc + lint + fmt) パス
- [x] `pnpm test` 全 311 テストパス
- [ ] `pnpm dev` で手動確認: GT/クロス集計 → テーブル/チャート/エクスポート

🤖 Generated with [Claude Code](https://claude.com/claude-code)