### PR TITLE
refactor: MA無回答ラベルをi18n対応に統一

### DIFF
--- a/src/lib/export/exportGrid.ts
+++ b/src/lib/export/exportGrid.ts
@@ -23,7 +23,7 @@ export function buildExportGrids(results: AggResult[], labelMap: LabelMap): Expo
 // ─── Internal ───────────────────────────────────────────────
 
 export function resolveMainLabel(main: string): string {
-  return main === NA_VALUE ? t("export.na") : main;
+  return main === NA_VALUE ? t("label.na") : main;
 }
 
 function buildGtGrid(res: AggResult): ExportGrid {
@@ -72,9 +72,7 @@ function buildCrossGrids(results: AggResult[], labelMap: LabelMap): ExportGrid[]
   const headerRow2 = ["", "", "", "", ""];
   for (const sub of crossSubs) {
     headerRow1.push("");
-    headerRow2.push(
-      `${resolveSubLabel(sub.label, labelMap, t("export.na"))}(n=${sub.n.toFixed(1)})`,
-    );
+    headerRow2.push(`${resolveSubLabel(sub.label, labelMap)}(n=${sub.n.toFixed(1)})`);
   }
   const sharedHeaders = [headerRow1, headerRow2];
 

--- a/src/lib/labels.ts
+++ b/src/lib/labels.ts
@@ -3,6 +3,7 @@
 import { parseCrossSub } from "./agg/aggregate";
 import type { LabelMap } from "./layout";
 import { NA_VALUE } from "./agg/sqlHelpers";
+import { t } from "./i18n";
 
 /** Resolve question label; falls back to column name */
 export function resolveQuestionLabel(col: string, labelMap: LabelMap): string {
@@ -16,19 +17,19 @@ export function resolveValueLabel(
   rowLabel: string,
   labelMap: LabelMap,
 ): string {
-  if (rowLabel === NA_VALUE) return "無回答";
+  if (rowLabel === NA_VALUE) return t("label.na");
   const code = type === "MA" ? (labelMap.colToCode[rowLabel] ?? rowLabel) : rowLabel;
   return labelMap.valueLabels[col]?.[code] ?? rowLabel;
 }
 
 /** Resolve cross-axis header label (sub values are prefixed as "axisKey\x01rawValue") */
-export function resolveSubLabel(subLabel: string, labelMap: LabelMap, naLabel = "無回答"): string {
-  if (subLabel === NA_VALUE) return naLabel;
+export function resolveSubLabel(subLabel: string, labelMap: LabelMap): string {
+  if (subLabel === NA_VALUE) return t("label.na");
 
   const parsed = parseCrossSub(subLabel);
   if (parsed) {
     const { axisKey, rawValue } = parsed;
-    if (rawValue === NA_VALUE) return naLabel;
+    if (rawValue === NA_VALUE) return t("label.na");
     return labelMap.valueLabels[axisKey]?.[rawValue] ?? rawValue;
   }
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -62,7 +62,7 @@ const en: Record<string, string> = {
   "export.header.pct": "%",
   "export.header.total.n": "Total_n",
   "export.header.total.pct": "Total_%",
-  "export.na": "No answer",
+  "label.na": "No answer",
 
   // Chart type
   "chart.barH": "Horizontal Bar",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -62,7 +62,7 @@ const ja: Record<string, string> = {
   "export.header.pct": "%",
   "export.header.total.n": "全体_n",
   "export.header.total.pct": "全体_%",
-  "export.na": "無回答",
+  "label.na": "無回答",
 
   // Chart type
   "chart.barH": "横棒",


### PR DESCRIPTION
## Summary
- ハードコードされた `"無回答"` と `resolveSubLabel` の `naLabel` パラメータを廃止
- i18n キーを `export.na` → `label.na` にリネームし、テーブル・チャート・エクスポート全箇所で `t("label.na")` を使用するよう統一
- 言語設定に応じて日本語「無回答」/ 英語 "No answer" が正しく表示されるように

## Test plan
- [x] `pnpm check` (fmt:check + lint + tsc --noEmit) パス
- [x] `pnpm test` 全21テストパス
- [ ] ブラウザで MA 設問の GT/クロス集計を実行し、テーブル・チャート・エクスポートで無回答ラベルが言語設定に応じて表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)