### PR TITLE
refactor: SQL で pct/n を算出し Cell に持たせる

### DIFF
--- a/src/components/aggregation/ChartContent.tsx
+++ b/src/components/aggregation/ChartContent.tsx
@@ -52,7 +52,7 @@ function ChartCard({ res, gtChartType, paletteId }: ChartCardProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const chartRef = useRef<Chart | null>(null);
 
-  const pv = pivot(res.cells, res.nBySubLabel);
+  const pv = pivot(res.cells);
   const isCross = pv.subs.length > 1;
 
   useEffect(() => {

--- a/src/components/aggregation/CrossTable.tsx
+++ b/src/components/aggregation/CrossTable.tsx
@@ -1,6 +1,6 @@
-import type { AggResult, QuestionDef } from "../../lib/agg/aggregate";
+import type { AggResult, QuestionDef, Cell } from "../../lib/agg/aggregate";
 import { questionKey, parseCrossSub } from "../../lib/agg/aggregate";
-import type { pivot, PivotCell } from "../../lib/agg/pivot";
+import type { pivot } from "../../lib/agg/pivot";
 import { resolveQuestionLabel, resolveValueLabel, resolveSubLabel } from "../../lib/labels";
 import { t } from "../../lib/i18n";
 import type { PctDirection } from "./Toolbar";
@@ -70,7 +70,7 @@ interface CrossTableData {
   gtSub: SubInfo;
   crossGroups: CrossGroup[];
   questionLabel: string;
-  lookup: Map<string, PivotCell>;
+  lookup: Map<string, Cell>;
   weightCol: string;
 }
 
@@ -173,7 +173,7 @@ function TransposedSubRow({
 }: {
   sub: SubInfo;
   mains: string[];
-  lookup: Map<string, PivotCell>;
+  lookup: Map<string, Cell>;
 }) {
   const { labelMap, weightCol } = useAggregation();
   return (

--- a/src/components/aggregation/ResultCard.tsx
+++ b/src/components/aggregation/ResultCard.tsx
@@ -12,7 +12,7 @@ interface ResultCardProps {
 export function ResultCard({ res, extraClass, children }: ResultCardProps) {
   const { labelMap, weightCol } = useAggregation();
 
-  const gtN = res.nBySubLabel["GT"] ?? 0;
+  const gtN = res.cells.find((c) => c.sub === "GT")?.n ?? 0;
   const nLabel = weightCol ? `n=${gtN.toFixed(1)}` : `n=${gtN.toLocaleString()}`;
 
   const questionLabel = resolveQuestionLabel(res.question, labelMap);

--- a/src/components/aggregation/TableContent.tsx
+++ b/src/components/aggregation/TableContent.tsx
@@ -12,10 +12,7 @@ interface TableContentProps {
 export function TableContent({ pctDirection }: TableContentProps) {
   const { results, hasCross } = useAggregation();
   const maxPct = Math.max(
-    ...results.flatMap((r) => {
-      const n = r.nBySubLabel["GT"] ?? 0;
-      return n > 0 ? r.cells.filter((c) => c.sub === "GT").map((c) => (c.count / n) * 100) : [];
-    }),
+    ...results.flatMap((r) => r.cells.filter((c) => c.sub === "GT").map((c) => c.pct)),
     0,
   );
 
@@ -28,7 +25,7 @@ export function TableContent({ pctDirection }: TableContentProps) {
       }
     >
       {results.map((res) => {
-        const pv = pivot(res.cells, res.nBySubLabel);
+        const pv = pivot(res.cells);
         const isCross = pv.subs.length > 1;
 
         return (

--- a/src/lib/agg/aggregate.ts
+++ b/src/lib/agg/aggregate.ts
@@ -8,6 +8,8 @@ export interface Cell {
   main: string; // Option label (aggregation target value)
   sub: string; // "GT" or cross-tab axis value
   count: number;
+  n: number;
+  pct: number;
 }
 
 /** Aggregation result per question */
@@ -15,14 +17,11 @@ export interface AggResult {
   question: string;
   type: "SA" | "MA";
   cells: Cell[];
-  /** Denominator (n) per sub label: e.g. { "GT": 100, "q1\x011": 40 } */
-  nBySubLabel: Record<string, number>;
 }
 
-/** Aggregator return type (cells + n map) */
+/** Aggregator return type */
 export interface AggCells {
   cells: Cell[];
-  nBySubLabel: Record<string, number>;
 }
 
 export type QuestionDef = SAQuestion | MAQuestion;
@@ -91,24 +90,14 @@ export async function aggregate(
         crossAggregators.map((ca) => ca.aggregateSA(q.column)),
       );
       const cells = [...gtResult.cells, ...crossResults.flatMap((r) => r.cells)];
-      const nBySubLabel = Object.assign(
-        {},
-        gtResult.nBySubLabel,
-        ...crossResults.map((r) => r.nBySubLabel),
-      );
-      results.push({ question: q.column, type: "SA", cells, nBySubLabel });
+      results.push({ question: q.column, type: "SA", cells });
     } else {
       const gtResult = await gt.aggregateMA(q.columns);
       const crossResults = await Promise.all(
         crossAggregators.map((ca) => ca.aggregateMA(q.columns)),
       );
       const cells = [...gtResult.cells, ...crossResults.flatMap((r) => r.cells)];
-      const nBySubLabel = Object.assign(
-        {},
-        gtResult.nBySubLabel,
-        ...crossResults.map((r) => r.nBySubLabel),
-      );
-      results.push({ question: q.prefix, type: "MA", cells, nBySubLabel });
+      results.push({ question: q.prefix, type: "MA", cells });
     }
   }
 

--- a/src/lib/agg/crossAggregator.ts
+++ b/src/lib/agg/crossAggregator.ts
@@ -93,10 +93,16 @@ export class CrossAggregator {
 
   private async saSA(col: string, crossQ: SAQuestion): Promise<AggCells> {
     const crossCol = crossQ.column;
-    const { headers, crossValues } = this.crossHeader;
+    const { crossValues } = this.crossHeader;
+    const wExpr = weightExpr(this.weightCol);
 
     const sql = `
-      SELECT "${esc(col)}" AS mv, "${esc(crossCol)}" AS sv, ${weightExpr(this.weightCol)} AS cnt
+      SELECT
+        "${esc(col)}" AS mv,
+        "${esc(crossCol)}" AS sv,
+        ${wExpr} AS cnt,
+        SUM(${wExpr}) OVER (PARTITION BY "${esc(crossCol)}") AS n,
+        ${wExpr} * 100.0 / NULLIF(SUM(${wExpr}) OVER (PARTITION BY "${esc(crossCol)}"), 0) AS pct
       FROM survey
       WHERE "${esc(col)}" IS NOT NULL
         AND "${esc(crossCol)}" IS NOT NULL
@@ -110,15 +116,13 @@ export class CrossAggregator {
       const sv = String(r.sv);
       const idx = crossValues.indexOf(sv);
       if (idx >= 0) {
-        cells.push(mkCell(mv, crossSub(crossCol, sv), Number(r.cnt)));
+        cells.push(
+          mkCell(mv, crossSub(crossCol, sv), Number(r.cnt), Number(r.n), Number(r.pct ?? 0)),
+        );
       }
     }
 
-    const nBySubLabel: Record<string, number> = {};
-    for (let i = 0; i < headers.length; i++) {
-      nBySubLabel[crossSub(crossCol, crossValues[i])] = headers[i].n;
-    }
-    return { cells, nBySubLabel };
+    return { cells };
   }
 
   // ── SA main × MA cross ──
@@ -144,15 +148,14 @@ export class CrossAggregator {
     for (const r of result.toArray()) {
       const mv = String(r.mv);
       for (let i = 0; i < crossQ.columns.length; i++) {
-        cells.push(mkCell(mv, crossSub(crossQ.prefix, crossQ.codes[i]), Number(r[`c${i}`] ?? 0)));
+        const count = Number(r[`c${i}`] ?? 0);
+        const n = headers[i].n;
+        const pct = n > 0 ? (count / n) * 100 : 0;
+        cells.push(mkCell(mv, crossSub(crossQ.prefix, crossQ.codes[i]), count, n, pct));
       }
     }
 
-    const nBySubLabel: Record<string, number> = {};
-    for (let i = 0; i < headers.length; i++) {
-      nBySubLabel[crossSub(crossQ.prefix, crossQ.codes[i])] = headers[i].n;
-    }
-    return { cells, nBySubLabel };
+    return { cells };
   }
 
   // ── MA main × SA cross ──
@@ -192,22 +195,22 @@ export class CrossAggregator {
     for (let maIdx = 0; maIdx < maCols.length; maIdx++) {
       for (let i = 0; i < crossValues.length; i++) {
         const counts = rowMap.get(crossValues[i]);
-        cells.push(mkCell(maCols[maIdx], crossSub(crossCol, crossValues[i]), counts?.[maIdx] ?? 0));
+        const count = counts?.[maIdx] ?? 0;
+        const n = headers[i].n;
+        const pct = n > 0 ? (count / n) * 100 : 0;
+        cells.push(mkCell(maCols[maIdx], crossSub(crossCol, crossValues[i]), count, n, pct));
       }
     }
 
     // No-answer cross cells
     for (let i = 0; i < crossValues.length; i++) {
-      cells.push(
-        mkCell(NA_VALUE, crossSub(crossCol, crossValues[i]), naMap.get(crossValues[i]) ?? 0),
-      );
+      const count = naMap.get(crossValues[i]) ?? 0;
+      const n = headers[i].n;
+      const pct = n > 0 ? (count / n) * 100 : 0;
+      cells.push(mkCell(NA_VALUE, crossSub(crossCol, crossValues[i]), count, n, pct));
     }
 
-    const nBySubLabel: Record<string, number> = {};
-    for (let i = 0; i < headers.length; i++) {
-      nBySubLabel[crossSub(crossCol, crossValues[i])] = headers[i].n;
-    }
-    return { cells, nBySubLabel };
+    return { cells };
   }
 
   // ── MA main × MA cross ──
@@ -239,27 +242,21 @@ export class CrossAggregator {
     const cells: AggCells["cells"] = [];
     for (let r = 0; r < rowMaCols.length; r++) {
       for (let c = 0; c < crossQ.columns.length; c++) {
-        cells.push(
-          mkCell(
-            rowMaCols[r],
-            crossSub(crossQ.prefix, crossQ.codes[c]),
-            Number(row[`r${r}c${c}`] ?? 0),
-          ),
-        );
+        const count = Number(row[`r${r}c${c}`] ?? 0);
+        const n = headers[c].n;
+        const pct = n > 0 ? (count / n) * 100 : 0;
+        cells.push(mkCell(rowMaCols[r], crossSub(crossQ.prefix, crossQ.codes[c]), count, n, pct));
       }
     }
 
     // No-answer cross cells
     for (let c = 0; c < crossQ.columns.length; c++) {
-      cells.push(
-        mkCell(NA_VALUE, crossSub(crossQ.prefix, crossQ.codes[c]), Number(row[`na_c${c}`] ?? 0)),
-      );
+      const count = Number(row[`na_c${c}`] ?? 0);
+      const n = headers[c].n;
+      const pct = n > 0 ? (count / n) * 100 : 0;
+      cells.push(mkCell(NA_VALUE, crossSub(crossQ.prefix, crossQ.codes[c]), count, n, pct));
     }
 
-    const nBySubLabel: Record<string, number> = {};
-    for (let c = 0; c < headers.length; c++) {
-      nBySubLabel[crossSub(crossQ.prefix, crossQ.codes[c])] = headers[c].n;
-    }
-    return { cells, nBySubLabel };
+    return { cells };
   }
 }

--- a/src/lib/agg/gtAggregator.ts
+++ b/src/lib/agg/gtAggregator.ts
@@ -20,19 +20,23 @@ export class GtAggregator {
   ) {}
 
   async aggregateSA(col: string): Promise<AggCells> {
+    const wExpr = weightExpr(this.weightCol);
     const sql = `
-      SELECT "${esc(col)}" AS mv, ${weightExpr(this.weightCol)} AS cnt
+      SELECT
+        "${esc(col)}" AS mv,
+        ${wExpr} AS cnt,
+        SUM(${wExpr}) OVER () AS n,
+        ${wExpr} * 100.0 / NULLIF(SUM(${wExpr}) OVER (), 0) AS pct
       FROM survey
       WHERE "${esc(col)}" IS NOT NULL
       GROUP BY "${esc(col)}"
     `;
 
     const result = await this.conn.query(sql);
-    const rows = result.toArray();
-
-    const questionN = rows.reduce((sum, r) => sum + Number(r.cnt), 0);
-    const cells = rows.map((r) => mkCell(String(r.mv), "GT", Number(r.cnt)));
-    return { cells, nBySubLabel: { GT: questionN } };
+    const cells = result
+      .toArray()
+      .map((r) => mkCell(String(r.mv), "GT", Number(r.cnt), Number(r.n), Number(r.pct ?? 0)));
+    return { cells };
   }
 
   async aggregateMA(cols: string[]): Promise<AggCells> {
@@ -57,11 +61,17 @@ export class GtAggregator {
     const row = result.toArray()[0];
 
     const questionN = Number(row.question_n ?? 0);
-    const cells = cols.map((col, i) => mkCell(col, "GT", Number(row[`c${i}`] ?? 0)));
+    const cells = cols.map((col, i) => {
+      const count = Number(row[`c${i}`] ?? 0);
+      const pct = questionN > 0 ? (count / questionN) * 100 : 0;
+      return mkCell(col, "GT", count, questionN, pct);
+    });
 
     // No-answer row
-    cells.push(mkCell(NA_VALUE, "GT", Number(row.na_cnt ?? 0)));
+    const naCount = Number(row.na_cnt ?? 0);
+    const naPct = questionN > 0 ? (naCount / questionN) * 100 : 0;
+    cells.push(mkCell(NA_VALUE, "GT", naCount, questionN, naPct));
 
-    return { cells, nBySubLabel: { GT: questionN } };
+    return { cells };
   }
 }

--- a/src/lib/agg/pivot.ts
+++ b/src/lib/agg/pivot.ts
@@ -1,26 +1,20 @@
 import type { Cell } from "./aggregate";
 
-export interface PivotCell {
-  count: number;
-  pct: number;
-}
-
-/** Convert flat cells array into a grid structure with pct computed from nBySubLabel */
-export function pivot(
-  cells: Cell[],
-  nBySubLabel: Record<string, number>,
-): {
+/** Convert flat cells array into a grid structure */
+export function pivot(cells: Cell[]): {
   mains: string[];
   subs: { label: string; n: number }[];
-  lookup: Map<string, PivotCell>;
+  lookup: Map<string, Cell>;
 } {
   const mains = [...new Set(cells.map((c) => c.main))];
   const subOrder = [...new Set(cells.map((c) => c.sub))];
-  const subs = subOrder.map((label) => ({ label, n: nBySubLabel[label] ?? 0 }));
-  const lookup = new Map<string, PivotCell>();
+  const subs = subOrder.map((label) => {
+    const cell = cells.find((c) => c.sub === label);
+    return { label, n: cell?.n ?? 0 };
+  });
+  const lookup = new Map<string, Cell>();
   for (const c of cells) {
-    const n = nBySubLabel[c.sub] ?? 0;
-    lookup.set(`${c.main}\0${c.sub}`, { count: c.count, pct: n > 0 ? (c.count / n) * 100 : 0 });
+    lookup.set(`${c.main}\0${c.sub}`, c);
   }
   return { mains, subs, lookup };
 }

--- a/src/lib/agg/sqlHelpers.ts
+++ b/src/lib/agg/sqlHelpers.ts
@@ -31,8 +31,8 @@ export function maNoneSelectedCondition(cols: string[]): string {
   return cols.map((c) => `"${esc(c)}" != 1`).join(" AND ");
 }
 
-export function mkCell(main: string, sub: string, count: number): Cell {
-  return { main, sub, count };
+export function mkCell(main: string, sub: string, count: number, n: number, pct: number): Cell {
+  return { main, sub, count, n, pct };
 }
 
 /** No-answer marker */

--- a/src/lib/aiComment.ts
+++ b/src/lib/aiComment.ts
@@ -85,8 +85,8 @@ function summarizeResults(
   }
 
   for (const res of results) {
-    const pv = pivot(res.cells, res.nBySubLabel);
-    const gtN = res.nBySubLabel["GT"] ?? 0;
+    const pv = pivot(res.cells);
+    const gtN = res.cells.find((c) => c.sub === "GT")?.n ?? 0;
     if (pv.mains.length === 0) continue;
 
     const qLabel = resolveQuestionLabel(res.question, labelMap);

--- a/src/lib/export/export.ts
+++ b/src/lib/export/export.ts
@@ -22,7 +22,7 @@ export async function executeExport(
   weightCol: string,
   labelMap: LabelMap,
 ): Promise<boolean> {
-  const hasCross = results.some((r) => pivot(r.cells, r.nBySubLabel).subs.length > 1);
+  const hasCross = results.some((r) => pivot(r.cells).subs.length > 1);
 
   switch (action) {
     case "download-csv": {

--- a/src/lib/export/exportGrid.ts
+++ b/src/lib/export/exportGrid.ts
@@ -13,7 +13,7 @@ export interface ExportGrid {
 }
 
 export function buildExportGrids(results: AggResult[], labelMap: LabelMap): ExportGrid[] {
-  const hasCross = results.some((r) => pivot(r.cells, r.nBySubLabel).subs.length > 1);
+  const hasCross = results.some((r) => pivot(r.cells).subs.length > 1);
   if (hasCross) {
     return buildCrossGrids(results, labelMap);
   }
@@ -27,7 +27,7 @@ export function resolveMainLabel(main: string): string {
 }
 
 function buildGtGrid(res: AggResult): ExportGrid {
-  const { mains, subs, lookup } = pivot(res.cells, res.nBySubLabel);
+  const { mains, subs, lookup } = pivot(res.cells);
   const gtSub = subs.find((s) => s.label === "GT")!;
   const headers = [
     [
@@ -56,10 +56,10 @@ function buildGtGrid(res: AggResult): ExportGrid {
 }
 
 function buildCrossGrids(results: AggResult[], labelMap: LabelMap): ExportGrid[] {
-  const firstResult = results.find((r) => pivot(r.cells, r.nBySubLabel).subs.length > 1);
+  const firstResult = results.find((r) => pivot(r.cells).subs.length > 1);
   if (!firstResult) return results.map((res) => buildGtGrid(res));
 
-  const firstPivot = pivot(firstResult.cells, firstResult.nBySubLabel);
+  const firstPivot = pivot(firstResult.cells);
   const crossSubs = firstPivot.subs.filter((s) => s.label !== "GT");
 
   const headerRow1 = [
@@ -77,7 +77,7 @@ function buildCrossGrids(results: AggResult[], labelMap: LabelMap): ExportGrid[]
   const sharedHeaders = [headerRow1, headerRow2];
 
   return results.map((res) => {
-    const { mains, subs, lookup } = pivot(res.cells, res.nBySubLabel);
+    const { mains, subs, lookup } = pivot(res.cells);
     const resCrossSubs = subs.filter((s) => s.label !== "GT");
     const gtSub = subs.find((s) => s.label === "GT")!;
     const rows: string[][] = [];

--- a/src/lib/export/formatters/json.ts
+++ b/src/lib/export/formatters/json.ts
@@ -26,7 +26,7 @@ interface JsonExport {
 
 export function formatJSON(results: AggResult[], weightCol: string, labelMap: LabelMap): string {
   const entries: JsonExportEntry[] = results.map((res) => {
-    const { mains, subs, lookup } = pivot(res.cells, res.nBySubLabel);
+    const { mains, subs, lookup } = pivot(res.cells);
     const gtSub = subs.find((s) => s.label === "GT")!;
     const crossSubs = subs.filter((s) => s.label !== "GT");
 

--- a/tests/aggregate.test.ts
+++ b/tests/aggregate.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { aggregate, type Query, type Cell, crossSub } from "../src/lib/agg/aggregate";
-import { pivot } from "../src/lib/agg/pivot";
 import { setupDuckDB, teardownDuckDB } from "./helpers/duckdb";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -63,12 +62,11 @@ describe("aggregate - 重みなし", () => {
       // q1=3: 行4,8 = 2件
       // q1=99(無回答): 行11,13 = 2件
       const n = 13;
-      expect(r.nBySubLabel["GT"]).toBe(n);
       const cell1 = findCell(r.cells, "1", "GT")!;
       expect(cell1).toBeDefined();
       expect(cell1.count).toBe(6);
-      const pv = pivot(r.cells, r.nBySubLabel);
-      expect(pv.lookup.get("1\0GT")!.pct).toBeCloseTo((6 / n) * 100, 5);
+      expect(cell1.n).toBe(n);
+      expect(cell1.pct).toBeCloseTo((6 / n) * 100, 5);
 
       const cell2 = findCell(r.cells, "2", "GT")!;
       expect(cell2.count).toBe(3);
@@ -105,8 +103,8 @@ describe("aggregate - 重みなし", () => {
       // 無回答(shown but none='1'): 行11(0,0,0),12(0,0,0) = 2件
       const n = 13;
 
-      expect(r.nBySubLabel["GT"]).toBe(n);
       const cellQ3_1 = findCell(r.cells, "q3_1", "GT")!;
+      expect(cellQ3_1.n).toBe(n);
       expect(cellQ3_1).toBeDefined();
       expect(cellQ3_1.count).toBe(7);
 
@@ -140,7 +138,7 @@ describe("aggregate - 重みなし", () => {
       // q2=3: 行1,5,8 = 3件
       // q2=99(無回答): 行11 = 1件
       const gtN = 13;
-      expect(r.nBySubLabel["GT"]).toBe(gtN);
+      expect(findCell(r.cells, "1", "GT")!.n).toBe(gtN);
       expect(findCell(r.cells, "1", "GT")!.count).toBe(5);
       expect(findCell(r.cells, "2", "GT")!.count).toBe(4);
       expect(findCell(r.cells, "3", "GT")!.count).toBe(3);
@@ -252,9 +250,8 @@ describe("aggregate - 重み付き", () => {
       const cell1 = findCell(r.cells, "1", "GT")!;
       expect(cell1).toBeDefined();
       expect(cell1.count).toBeCloseTo(6.9, 1);
-      expect(r.nBySubLabel["GT"]).toBeCloseTo(13.8, 1);
-      const pv = pivot(r.cells, r.nBySubLabel);
-      expect(pv.lookup.get("1\0GT")!.pct).toBeCloseTo((6.9 / 13.8) * 100, 1);
+      expect(cell1.n).toBeCloseTo(13.8, 1);
+      expect(cell1.pct).toBeCloseTo((6.9 / 13.8) * 100, 1);
 
       const cell2 = findCell(r.cells, "2", "GT")!;
       expect(cell2.count).toBeCloseTo(3.3, 1);


### PR DESCRIPTION
## Summary
- `Cell` を `{ main, sub, count, n, pct }` に拡張し、pct/n の算出を SQL 側・集計側に移動
- SA GT / SA×SA クロスはウィンドウ関数で SQL が n/pct を算出
- MA 系は `CrossHeader.n` / `question_n` を分母に JS で pct 算出
- `AggResult.nBySubLabel` を削除し、`PivotCell` 型も削除
- `pivot()` を純粋な構造変換（1引数、pct 算出なし）に簡素化
- 全消費側（テーブル/チャート/エクスポート/AI コメント/テスト）を新 API に移行

## Motivation
PR #101 で Cell から n/pct を除去し pivot で算出する形にしたが、本 PR ではさらに進めて「集計は SQL/集計層、JS は表示」の責務分離を実現する。

## Test plan
- [x] `pnpm check` (tsc + lint + fmt) パス
- [x] `pnpm test` 全 311 テストパス
- [ ] `pnpm dev` で手動確認: GT/クロス集計 → テーブル/チャート/エクスポート

🤖 Generated with [Claude Code](https://claude.com/claude-code)