### PR TITLE
refactor: buildQuestionsからフィルタリングを分離し内部型を非公開化

### DIFF
--- a/bench/run.ts
+++ b/bench/run.ts
@@ -14,7 +14,7 @@ import { performance } from "node:perf_hooks";
 import { aggregateGt } from "../src/lib/agg/aggregateGt";
 import { aggregateCross } from "../src/lib/agg/aggregateCross";
 import type { Question } from "../src/lib/agg/types";
-import { parseLayout, buildQuestions } from "../src/lib/layout";
+import { parseLayout, filterLayout, buildQuestions } from "../src/lib/layout";
 import { generate, PATTERNS, type PatternDef } from "./generate";
 
 // ---------------------------------------------------------------------------
@@ -145,7 +145,8 @@ async function main(): Promise<void> {
 
     // Extract headers from CSV first line
     const headers = csvText.slice(0, csvText.indexOf("\n")).split(",");
-    const questions = buildQuestions(headers, layout);
+    const filtered = filterLayout(headers, layout);
+    const questions = buildQuestions(filtered);
 
     // Pick 2 questions for cross-tab (prefer SA; fall back to MA for MA-only patterns)
     const saQuestions = questions.filter((q) => q.type === "SA");

--- a/src/components/AggregationScreen.tsx
+++ b/src/components/AggregationScreen.tsx
@@ -3,7 +3,7 @@ import CrossConfig from "./aggregation/CrossConfig";
 import ResultView from "./aggregation/ResultView";
 import { AggregationContext, type AggregationContextValue } from "./aggregation/AggregationContext";
 import { runAggregation } from "../lib/duckdbBridge";
-import { buildQuestions, findWeightColumn, countLayoutColumns } from "../lib/layout";
+import { filterLayout, buildQuestions, findWeightColumn, countLayoutColumns } from "../lib/layout";
 import { t } from "../lib/i18n";
 import { ToggleButton, ToggleGroup } from "./shared/ToggleButton";
 import type { CsvData, LayoutData } from "../lib/types";
@@ -14,7 +14,8 @@ interface AggregationScreenProps {
 }
 
 export default function AggregationScreen({ csv, layout }: AggregationScreenProps) {
-  const questions = buildQuestions(csv.headers, layout.layout);
+  const filtered = filterLayout(csv.headers, layout.layout);
+  const questions = buildQuestions(filtered);
   const weightCol = findWeightColumn(layout.layout);
 
   const [crossSelected, setCrossSelected] = useState<Record<string, boolean>>(() => {

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -41,14 +41,31 @@ export function parseLayout(jsonText: string): Layout {
   return parsed as Layout;
 }
 
-/** Build Question[] from CSV headers and layout definition */
-export function buildQuestions(headers: string[], layout: Layout): Question[] {
+/** Filter layout entries to only include columns present in CSV headers */
+export function filterLayout(headers: string[], layout: Layout): Layout {
   const headerSet = new Set(headers);
+  const filtered: Layout = [];
+
+  for (const entry of layout) {
+    if (entry.type === "SA" || entry.type === "WEIGHT") {
+      if (headerSet.has(entry.key)) filtered.push(entry);
+    } else if (entry.type === "MA" && entry.items) {
+      const matchedItems = entry.items.filter((item) => headerSet.has(`${entry.key}_${item.code}`));
+      if (matchedItems.length > 0) {
+        filtered.push({ ...entry, items: matchedItems });
+      }
+    }
+  }
+
+  return filtered;
+}
+
+/** Build Question[] from layout definition */
+export function buildQuestions(layout: Layout): Question[] {
   const questions: Question[] = [];
 
   for (const entry of layout) {
     if (entry.type === "SA") {
-      if (!headerSet.has(entry.key)) continue;
       const codes = entry.items?.map((i) => i.code) ?? [];
       const labels: Record<string, string> = {};
       if (entry.items) {
@@ -69,23 +86,18 @@ export function buildQuestions(headers: string[], layout: Layout): Question[] {
       const codes: string[] = [];
       const labels: Record<string, string> = {};
       for (const item of entry.items) {
-        const col = `${entry.key}_${item.code}`;
-        if (headerSet.has(col)) {
-          columns.push(col);
-          codes.push(item.code);
-          labels[item.code] = item.label;
-        }
+        columns.push(`${entry.key}_${item.code}`);
+        codes.push(item.code);
+        labels[item.code] = item.label;
       }
-      if (columns.length > 0) {
-        questions.push({
-          type: "MA",
-          code: entry.key,
-          columns,
-          codes,
-          label: entry.label ?? entry.key,
-          labels,
-        });
-      }
+      questions.push({
+        type: "MA",
+        code: entry.key,
+        columns,
+        codes,
+        label: entry.label ?? entry.key,
+        labels,
+      });
     }
   }
 

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -1,16 +1,14 @@
 import type { Question } from "./agg/types";
 
-export interface LayoutItem {
+interface LayoutItem {
   code: string;
   label: string;
 }
 
-export type LayoutColType = "SA" | "MA" | "WEIGHT";
-
-export interface LayoutEntry {
+interface LayoutEntry {
   key: string;
   label?: string;
-  type: LayoutColType;
+  type: "SA" | "MA" | "WEIGHT";
   items?: LayoutItem[];
 }
 

--- a/tests/layout.test.ts
+++ b/tests/layout.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { filterLayout, buildQuestions } from "../src/lib/layout";
+import type { Layout } from "../src/lib/layout";
+
+const layout: Layout = [
+  {
+    key: "q1",
+    label: "Gender",
+    type: "SA",
+    items: [
+      { code: "1", label: "Male" },
+      { code: "2", label: "Female" },
+    ],
+  },
+  {
+    key: "q2",
+    label: "Hobbies",
+    type: "MA",
+    items: [
+      { code: "1", label: "Sports" },
+      { code: "2", label: "Music" },
+      { code: "3", label: "Reading" },
+    ],
+  },
+  { key: "weight", type: "WEIGHT" },
+];
+
+describe("filterLayout", () => {
+  it("keeps entries whose columns exist in headers", () => {
+    const headers = ["q1", "q2_1", "q2_2", "q2_3", "weight"];
+    const filtered = filterLayout(headers, layout);
+    expect(filtered).toHaveLength(3);
+    expect(filtered[0].key).toBe("q1");
+    expect(filtered[1].key).toBe("q2");
+    expect(filtered[2].key).toBe("weight");
+  });
+
+  it("removes SA entry when column is missing", () => {
+    const headers = ["q2_1", "q2_2", "q2_3", "weight"];
+    const filtered = filterLayout(headers, layout);
+    expect(filtered.map((e) => e.key)).toEqual(["q2", "weight"]);
+  });
+
+  it("removes WEIGHT entry when column is missing", () => {
+    const headers = ["q1"];
+    const filtered = filterLayout(headers, layout);
+    expect(filtered.map((e) => e.key)).toEqual(["q1"]);
+  });
+
+  it("keeps only matched MA items", () => {
+    const headers = ["q2_1", "q2_3"];
+    const filtered = filterLayout(headers, layout);
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].items).toEqual([
+      { code: "1", label: "Sports" },
+      { code: "3", label: "Reading" },
+    ]);
+  });
+
+  it("removes MA entry when no items match", () => {
+    const headers = ["q1"];
+    const filtered = filterLayout(headers, layout);
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].key).toBe("q1");
+  });
+
+  it("returns empty for completely unmatched headers", () => {
+    const filtered = filterLayout(["other"], layout);
+    expect(filtered).toEqual([]);
+  });
+});
+
+describe("buildQuestions", () => {
+  it("builds SA question from layout entry", () => {
+    const questions = buildQuestions([layout[0]]);
+    expect(questions).toHaveLength(1);
+    expect(questions[0]).toEqual({
+      type: "SA",
+      code: "q1",
+      columns: ["q1"],
+      codes: ["1", "2"],
+      label: "Gender",
+      labels: { "1": "Male", "2": "Female" },
+    });
+  });
+
+  it("builds MA question from layout entry", () => {
+    const questions = buildQuestions([layout[1]]);
+    expect(questions).toHaveLength(1);
+    expect(questions[0]).toEqual({
+      type: "MA",
+      code: "q2",
+      columns: ["q2_1", "q2_2", "q2_3"],
+      codes: ["1", "2", "3"],
+      label: "Hobbies",
+      labels: { "1": "Sports", "2": "Music", "3": "Reading" },
+    });
+  });
+
+  it("skips WEIGHT entries", () => {
+    const questions = buildQuestions([layout[2]]);
+    expect(questions).toHaveLength(0);
+  });
+
+  it("uses key as label fallback when label is omitted", () => {
+    const questions = buildQuestions([{ key: "q9", type: "SA" }]);
+    expect(questions[0].label).toBe("q9");
+  });
+});


### PR DESCRIPTION
## Summary
- `buildQuestions` からCSVヘッダーによるフィルタリング責務を `filterLayout` として分離
- `LayoutItem`, `LayoutEntry`, `LayoutColType` を非公開化し、公開APIを `Layout` 型と関数群のみに最小化
- `LayoutColType` をインラインのリテラル型に置き換え
- `filterLayout` / `buildQuestions` のユニットテストを追加

## Test plan
- [x] `pnpm check` パス（型チェック・lint・フォーマット）
- [x] `pnpm test` パス（新規テスト含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)