### PR TITLE
refactor: ImportScreenのref+state二重管理を解消

### DIFF
--- a/src/components/ImportScreen.tsx
+++ b/src/components/ImportScreen.tsx
@@ -9,6 +9,14 @@ import { SavedFilesList, triggerSavedFilesRefresh, useSavedFiles } from "./impor
 import { GettingStartedModal } from "./import/GettingStarted";
 import type { CsvData, LayoutData } from "../lib/types";
 
+function formatLoadedInfo(csv: CsvData | null): string | null {
+  if (!csv) return null;
+  return t("summary.rows", {
+    rows: csv.rowCount.toLocaleString(),
+    cols: csv.headers.length,
+  });
+}
+
 interface ImportScreenProps {
   onComplete: (csv: CsvData, layout: LayoutData) => void;
 }
@@ -84,64 +92,28 @@ function HelpButton({ onClick }: { onClick: () => void }) {
 }
 
 export default function ImportScreen({ onComplete }: ImportScreenProps) {
-  const [csvFileName, setCsvFileName] = useState<string | null>(null);
-  const [layoutFileName, setLayoutFileName] = useState<string | null>(null);
-  const [bothLoaded, setBothLoaded] = useState(false);
-  const [loadedInfo, setLoadedInfo] = useState<string | null>(null);
+  const [csv, setCsv] = useState<CsvData | null>(null);
+  const [layout, setLayout] = useState<LayoutData | null>(null);
   const [gsOpen, setGsOpen] = useState(false);
 
-  const csvRef = useRef<CsvData | null>(null);
-  const layoutRef = useRef<LayoutData | null>(null);
   const loadedFromSavedRef = useRef(false);
 
   const { entries, deleteEntry } = useSavedFiles();
 
-  function updateLoadedInfo(): void {
-    const csv = csvRef.current;
-    if (csv) {
-      setLoadedInfo(
-        t("summary.rows", {
-          rows: csv.rowCount.toLocaleString(),
-          cols: csv.headers.length,
-        }),
-      );
-    } else {
-      setLoadedInfo(null);
-    }
-  }
-
-  function checkBothLoaded(): void {
-    if (!csvRef.current || !layoutRef.current) return;
-    setBothLoaded(true);
-    updateLoadedInfo();
-  }
-
-  async function saveToOPFS(): Promise<void> {
-    const csv = csvRef.current;
-    const layout = layoutRef.current;
-    if (!csv || !layout) return;
-    try {
-      await saveData(csv.fileName, csv.text, layout.fileName, layout.json);
-      triggerSavedFilesRefresh();
-    } catch (e) {
-      console.warn("OPFS save failed:", e);
-    }
-  }
+  const bothLoaded = csv !== null && layout !== null;
+  const loadedInfo = formatLoadedInfo(csv);
 
   const handleCsvFile = useCallback(async (file: File) => {
     try {
       const text = await file.text();
       const result = await loadCSV(text);
-      csvRef.current = {
+      setCsv({
         text,
         fileName: file.name,
         headers: result.headers,
         rowCount: result.rowCount,
-      };
+      });
       loadedFromSavedRef.current = false;
-      setCsvFileName(file.name);
-      updateLoadedInfo();
-      checkBothLoaded();
     } catch (e) {
       console.error("CSV load failed:", e);
     }
@@ -151,11 +123,8 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
     try {
       const text = await file.text();
       const parsed = parseLayout(text);
-      layoutRef.current = { json: text, fileName: file.name, layout: parsed };
+      setLayout({ json: text, fileName: file.name, layout: parsed });
       loadedFromSavedRef.current = false;
-      setLayoutFileName(file.name);
-      updateLoadedInfo();
-      checkBothLoaded();
     } catch (e) {
       console.error("Layout load failed:", e);
     }
@@ -167,29 +136,30 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
       const parsed = parseLayout(layoutJson);
       const result = await loadCSV(csvText);
 
-      csvRef.current = {
+      setCsv({
         text: csvText,
         fileName: csvName,
         headers: result.headers,
         rowCount: result.rowCount,
-      };
-      layoutRef.current = { json: layoutJson, fileName: layoutName, layout: parsed };
-
+      });
+      setLayout({ json: layoutJson, fileName: layoutName, layout: parsed });
       loadedFromSavedRef.current = true;
-      setCsvFileName(csvName);
-      setLayoutFileName(layoutName);
-      updateLoadedInfo();
-      checkBothLoaded();
     } catch (e) {
       console.error("Saved data load failed:", e);
     }
   }, []);
 
-  function handleProceed(): void {
-    if (csvRef.current && layoutRef.current) {
-      if (!loadedFromSavedRef.current) saveToOPFS();
-      onComplete(csvRef.current, layoutRef.current);
+  async function handleProceed(): Promise<void> {
+    if (!csv || !layout) return;
+    if (!loadedFromSavedRef.current) {
+      try {
+        await saveData(csv.fileName, csv.text, layout.fileName, layout.json);
+        triggerSavedFilesRefresh();
+      } catch (e) {
+        console.warn("OPFS save failed:", e);
+      }
     }
+    onComplete(csv, layout);
   }
 
   return (
@@ -200,8 +170,8 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
         <StepIndicator bothLoaded={bothLoaded} />
 
         <FileUploadPanel
-          csvFileName={csvFileName}
-          layoutFileName={layoutFileName}
+          csvFileName={csv?.fileName ?? null}
+          layoutFileName={layout?.fileName ?? null}
           onCsvFile={handleCsvFile}
           onLayoutFile={handleLayoutFile}
         />


### PR DESCRIPTION
## Summary
- `csvRef`/`layoutRef` (ref) と `csvFileName`/`layoutFileName`/`bothLoaded`/`loadedInfo` (state) の二重管理を、`useState<CsvData | null>` / `useState<LayoutData | null>` に統合
- `bothLoaded` と `loadedInfo` をderived valueに変更し、`checkBothLoaded()` / `updateLoadedInfo()` / `saveToOPFS()` を削除
- 239行 → 209行 (30行削減)

## Test plan
- [x] `pnpm check` パス
- [x] `pnpm test` 全321テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)