### PR TITLE
refactor: 集計関数のディスパッチ簡素化と引数型統一

### DIFF
--- a/src/lib/agg/aggregateCross.ts
+++ b/src/lib/agg/aggregateCross.ts
@@ -19,10 +19,13 @@ export async function aggregateCross(
   weightCol: string,
 ): Promise<AggResult> {
   const ca = new CrossAggregator(conn, weightCol, by);
+  const isMainSa = question.type === "SA";
+  const isCrossSa = by.type === "SA";
 
-  return question.type === "SA"
-    ? ca.aggregateSA(question.columns[0], question.codes)
-    : ca.aggregateMA(question.columns, question.codes);
+  if (isMainSa && isCrossSa) return ca.saSA(question.columns[0], question.codes);
+  if (isMainSa && !isCrossSa) return ca.saMA(question.columns[0], question.codes);
+  if (!isMainSa && isCrossSa) return ca.maSA(question.columns, question.codes);
+  return ca.maMA(question.columns, question.codes);
 }
 
 class CrossAggregator {
@@ -32,26 +35,9 @@ class CrossAggregator {
     private crossQ: Question,
   ) {}
 
-  /** Cross-tabulate an SA main question against this cross axis.
-   *  `codes` should match the Tally's codes (from GT discovery). */
-  async aggregateSA(column: string, codes: string[]): Promise<AggResult> {
-    if (this.crossQ.type === "SA") {
-      return this.saSA(column, codes);
-    }
-    return this.saMA(column, codes);
-  }
-
-  /** Cross-tabulate an MA main question against this cross axis */
-  async aggregateMA(columns: string[], codes: string[]): Promise<AggResult> {
-    if (this.crossQ.type === "SA") {
-      return this.maSA(columns, codes);
-    }
-    return this.maMA(columns, codes);
-  }
-
   // ── SA main × SA cross ──
 
-  private async saSA(column: string, codes: string[]): Promise<AggResult> {
+  async saSA(column: string, codes: string[]): Promise<AggResult> {
     const crossCol = this.crossQ.columns[0];
     const crossValues = this.crossQ.codes;
     const wExpr = weightExpr(this.weightCol);
@@ -97,7 +83,7 @@ class CrossAggregator {
 
   // ── SA main × MA cross ──
 
-  private async saMA(column: string, codes: string[]): Promise<AggResult> {
+  async saMA(column: string, codes: string[]): Promise<AggResult> {
     const selectClauses = this.crossQ.columns.map(
       (maCol, i) => `${maWeightedCountExpr(maCol, this.weightCol)} AS c${i}`,
     );
@@ -140,7 +126,7 @@ class CrossAggregator {
 
   // ── MA main × SA cross ──
 
-  private async maSA(columns: string[], codes: string[]): Promise<AggResult> {
+  async maSA(columns: string[], codes: string[]): Promise<AggResult> {
     const crossCol = this.crossQ.columns[0];
     const crossValues = this.crossQ.codes;
     const wExpr = weightExpr(this.weightCol);
@@ -199,7 +185,7 @@ class CrossAggregator {
 
   // ── MA main × MA cross ──
 
-  private async maMA(columns: string[], codes: string[]): Promise<AggResult> {
+  async maMA(columns: string[], codes: string[]): Promise<AggResult> {
     const shownCond = maShownCondition(columns);
 
     const selectClauses: string[] = [];

--- a/src/lib/agg/aggregateCross.ts
+++ b/src/lib/agg/aggregateCross.ts
@@ -1,7 +1,7 @@
 /** Cross-tabulation aggregation — one cross axis at a time */
 
 import type * as duckdb from "@duckdb/duckdb-wasm";
-import type { AggResult, Question } from "./types";
+import type { AggInput, AggResult } from "./types";
 import {
   esc,
   weightExpr,
@@ -14,8 +14,8 @@ import {
 
 export async function aggregateCross(
   conn: duckdb.AsyncDuckDBConnection,
-  question: { type: string; columns: string[]; codes: string[] },
-  by: Question,
+  question: AggInput,
+  by: AggInput,
   weightCol: string,
 ): Promise<AggResult> {
   const ca = new CrossAggregator(conn, weightCol, by);
@@ -32,7 +32,7 @@ class CrossAggregator {
   constructor(
     private conn: duckdb.AsyncDuckDBConnection,
     private weightCol: string,
-    private crossQ: Question,
+    private crossQ: AggInput,
   ) {}
 
   // ── SA main × SA cross ──

--- a/src/lib/agg/aggregateGt.ts
+++ b/src/lib/agg/aggregateGt.ts
@@ -1,7 +1,7 @@
 /** GT (Grand Total) aggregation — SA and MA */
 
 import type * as duckdb from "@duckdb/duckdb-wasm";
-import type { AggResult } from "./types";
+import type { AggInput, AggResult } from "./types";
 import {
   esc,
   weightExpr,
@@ -14,7 +14,7 @@ import {
 
 export async function aggregateGt(
   conn: duckdb.AsyncDuckDBConnection,
-  question: { type: string; columns: string[]; codes: string[] },
+  question: AggInput,
   weightCol: string,
 ): Promise<AggResult> {
   const gt = new GtAggregator(conn, weightCol);

--- a/src/lib/agg/types.ts
+++ b/src/lib/agg/types.ts
@@ -9,6 +9,8 @@ export interface Question {
   labels: Record<string, string>;
 }
 
+export type AggInput = Pick<Question, "type" | "columns" | "codes">;
+
 export interface Cell {
   count: number;
   pct: number;


### PR DESCRIPTION
## Summary
- crossAggregatorの2段階SA/MA分岐をフラットな4分岐に簡素化し、中間メソッド `aggregateSA`/`aggregateMA` を削除
- 集計関数の引数型を `AggInput = Pick<Question, "type" | "columns" | "codes">` に統一し、集計ロジックがrawdata由来の最小限フィールドのみに依存するようにした

## Test plan
- [x] `pnpm check` パス（型チェック・lint・フォーマット）
- [x] `pnpm test` 全331テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)