### PR TITLE
refactor: loadCSVの責務分離とCsvData型の縮小

### DIFF
--- a/src/components/AggregationScreen.tsx
+++ b/src/components/AggregationScreen.tsx
@@ -2,8 +2,9 @@ import { useEffect, useRef, useState } from "preact/hooks";
 import CrossConfig from "./aggregation/CrossConfig";
 import ResultView from "./aggregation/ResultView";
 import { AggregationContext, type AggregationContextValue } from "./aggregation/AggregationContext";
-import { runAggregation } from "../lib/duckdbBridge";
-import { filterLayout, buildQuestions, findWeightColumn, countLayoutColumns } from "../lib/layout";
+import { runAggregation, getHeaders, getRowCount } from "../lib/duckdbBridge";
+import { filterLayout, buildQuestions, findWeightColumn } from "../lib/layout";
+import type { Question } from "../lib/agg/types";
 import { t } from "../lib/i18n";
 import { ToggleButton, ToggleGroup } from "./shared/ToggleButton";
 import type { CsvData, LayoutData } from "../lib/types";
@@ -14,35 +15,53 @@ interface AggregationScreenProps {
 }
 
 export default function AggregationScreen({ csv, layout }: AggregationScreenProps) {
-  const filtered = filterLayout(csv.headers, layout.layout);
-  const questions = buildQuestions(filtered);
   const weightCol = findWeightColumn(layout.layout);
 
-  const [crossSelected, setCrossSelected] = useState<Record<string, boolean>>(() => {
-    const sel: Record<string, boolean> = {};
-    questions.forEach((q) => (sel[q.code] = false));
-    return sel;
-  });
+  const [questions, setQuestions] = useState<Question[]>([]);
+  const [summaryInfo, setSummaryInfo] = useState<{ rowCount: number; colCount: number } | null>(
+    null,
+  );
+  const [crossSelected, setCrossSelected] = useState<Record<string, boolean>>({});
   const [weightEnabled, setWeightEnabled] = useState(true);
   const [errorMsg, setErrorMsg] = useState("");
   const [aggCtx, setAggCtx] = useState<AggregationContextValue | null>(null);
 
-  const didAutoRun = useRef(false);
+  const questionsRef = useRef(questions);
+  questionsRef.current = questions;
+
+  // Initialize: fetch headers from bridge, build questions, then auto-run aggregation
   useEffect(() => {
-    if (!didAutoRun.current) {
-      didAutoRun.current = true;
-      handleRunAggregation();
-    }
+    (async () => {
+      try {
+        const [headers, rowCount] = await Promise.all([getHeaders(), getRowCount()]);
+        const filtered = filterLayout(headers, layout.layout);
+        const qs = buildQuestions(filtered);
+        const sel: Record<string, boolean> = {};
+        qs.forEach((q) => (sel[q.code] = false));
+
+        setQuestions(qs);
+        setCrossSelected(sel);
+        setSummaryInfo({ rowCount, colCount: headers.length });
+
+        // Auto-run GT aggregation
+        const wCol = weightCol;
+        const tallies = await runAggregation(qs, [], wCol);
+        setAggCtx({ tallies, weightCol: wCol });
+      } catch (e) {
+        setErrorMsg(t("error.aggregation", { msg: (e as Error).message }));
+        console.error(e);
+      }
+    })();
   }, []);
 
   async function handleRunAggregation(): Promise<void> {
     setErrorMsg("");
 
     const wCol = weightEnabled ? weightCol : "";
-    const crossCols = questions.filter((q) => crossSelected[q.code]);
+    const crossCols = questionsRef.current.filter((q) => crossSelected[q.code]);
 
     try {
-      const tallies = await runAggregation(questions, crossCols, wCol);
+      const tallies = await runAggregation(questionsRef.current, crossCols, wCol);
       setAggCtx({
         tallies,
         weightCol: wCol,
@@ -66,15 +85,9 @@ export default function AggregationScreen({ csv, layout }: AggregationScreenProp
           <h2 class="mb-3 text-sm font-bold tracking-wider text-muted">{t("section.summary")}</h2>
           <div class="text-sm leading-relaxed text-text-secondary">
             <DataSummary
-              csv={{
-                fileName: csv.fileName,
-                rowCount: csv.rowCount,
-                headers: csv.headers,
-              }}
-              layout={{
-                fileName: layout.fileName,
-                colCount: countLayoutColumns(layout.layout),
-              }}
+              csvFileName={csv.fileName}
+              layoutFileName={layout.fileName}
+              summaryInfo={summaryInfo}
             />
           </div>
         </section>
@@ -142,29 +155,36 @@ export default function AggregationScreen({ csv, layout }: AggregationScreenProp
 }
 
 export function DataSummary({
-  csv,
-  layout,
+  csvFileName,
+  layoutFileName,
+  summaryInfo,
 }: {
-  csv: { fileName: string; rowCount: number; headers: string[] };
-  layout: { fileName: string; colCount: number };
+  csvFileName: string;
+  layoutFileName: string;
+  summaryInfo: { rowCount: number; colCount: number } | null;
 }) {
   return (
     <>
       <div class="mb-1 flex items-baseline gap-2 pl-4">
         <span class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-text">
-          {csv.fileName}
+          {csvFileName}
         </span>
       </div>
       <div class="mb-1 flex items-baseline gap-2 pl-4">
         <span class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-text">
-          {layout.fileName}
+          {layoutFileName}
         </span>
       </div>
-      <div class="mb-1 flex items-baseline gap-2 pl-4">
-        <span class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-text">
-          {t("summary.rows", { rows: csv.rowCount.toLocaleString(), cols: csv.headers.length })}
-        </span>
-      </div>
+      {summaryInfo && (
+        <div class="mb-1 flex items-baseline gap-2 pl-4">
+          <span class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-text">
+            {t("summary.rows", {
+              rows: summaryInfo.rowCount.toLocaleString(),
+              cols: summaryInfo.colCount,
+            })}
+          </span>
+        </div>
+      )}
     </>
   );
 }

--- a/src/components/ImportScreen.tsx
+++ b/src/components/ImportScreen.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense } from "preact/compat";
-import { useCallback, useRef, useState } from "preact/hooks";
+import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import { parseLayout } from "../lib/layout";
-import { loadCSV } from "../lib/duckdbBridge";
+import { loadCSV, getHeaders, getRowCount } from "../lib/duckdbBridge";
 import { saveData, loadSaved } from "../lib/opfs";
 import { t } from "../lib/i18n";
 
@@ -13,11 +13,11 @@ const GettingStartedModal = lazy(() =>
   import("./import/GettingStarted").then((m) => ({ default: m.GettingStartedModal })),
 );
 
-function formatLoadedInfo(csv: CsvData | null): string | null {
-  if (!csv) return null;
+async function fetchLoadedInfo(): Promise<string> {
+  const [headers, rowCount] = await Promise.all([getHeaders(), getRowCount()]);
   return t("summary.rows", {
-    rows: csv.rowCount.toLocaleString(),
-    cols: csv.headers.length,
+    rows: rowCount.toLocaleString(),
+    cols: headers.length,
   });
 }
 
@@ -104,19 +104,25 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
 
   const { entries, deleteEntry } = useSavedFiles();
 
+  const [loadedInfo, setLoadedInfo] = useState<string | null>(null);
+
   const bothLoaded = csv !== null && layout !== null;
-  const loadedInfo = formatLoadedInfo(csv);
+
+  useEffect(() => {
+    if (!csv) {
+      setLoadedInfo(null);
+      return;
+    }
+    fetchLoadedInfo()
+      .then(setLoadedInfo)
+      .catch(() => setLoadedInfo(null));
+  }, [csv]);
 
   const handleCsvFile = useCallback(async (file: File) => {
     try {
       const text = await file.text();
-      const result = await loadCSV(text);
-      setCsv({
-        text,
-        fileName: file.name,
-        headers: result.headers,
-        rowCount: result.rowCount,
-      });
+      await loadCSV(text);
+      setCsv({ text, fileName: file.name });
       loadedFromSavedRef.current = false;
     } catch (e) {
       console.error("CSV load failed:", e);
@@ -138,14 +144,9 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
     try {
       const { csvText, csvName, layoutJson, layoutName } = await loadSaved(folderId);
       const parsed = parseLayout(layoutJson);
-      const result = await loadCSV(csvText);
+      await loadCSV(csvText);
 
-      setCsv({
-        text: csvText,
-        fileName: csvName,
-        headers: result.headers,
-        rowCount: result.rowCount,
-      });
+      setCsv({ text: csvText, fileName: csvName });
       setLayout({ json: layoutJson, fileName: layoutName, layout: parsed });
       loadedFromSavedRef.current = true;
     } catch (e) {

--- a/src/lib/duckdbBridge.ts
+++ b/src/lib/duckdbBridge.ts
@@ -43,8 +43,8 @@ export async function initDuckDB(): Promise<void> {
   return initPromise;
 }
 
-/** Register CSV text in DuckDB and return headers and row count */
-export async function loadCSV(csvText: string): Promise<{ headers: string[]; rowCount: number }> {
+/** Register CSV text in DuckDB as the survey table */
+export async function loadCSV(csvText: string): Promise<void> {
   await initDuckDB();
   if (!db) throw new Error("DuckDB is not ready");
 
@@ -55,14 +55,20 @@ export async function loadCSV(csvText: string): Promise<{ headers: string[]; row
     `CREATE OR REPLACE TABLE survey AS
      SELECT * FROM read_csv('survey.csv')`,
   );
+}
 
-  const descResult = await c.query(`DESCRIBE survey`);
-  const headers = descResult.toArray().map((r) => String(r.column_name));
+/** Return column names of the survey table */
+export async function getHeaders(): Promise<string[]> {
+  const c = await getConnection();
+  const result = await c.query(`DESCRIBE survey`);
+  return result.toArray().map((r) => String(r.column_name));
+}
 
-  const countResult = await c.query(`SELECT COUNT(*) AS n FROM survey`);
-  const rowCount = Number(countResult.toArray()[0].n);
-
-  return { headers, rowCount };
+/** Return row count of the survey table */
+export async function getRowCount(): Promise<number> {
+  const c = await getConnection();
+  const result = await c.query(`SELECT COUNT(*) AS n FROM survey`);
+  return Number(result.toArray()[0].n);
 }
 
 /** Execute aggregation for all question × axis combinations */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
 import type { Layout } from "./layout";
 
-export type CsvData = { text: string; fileName: string; headers: string[]; rowCount: number };
+export type CsvData = { text: string; fileName: string };
 export type LayoutData = { json: string; fileName: string; layout: Layout };


### PR DESCRIPTION
## Summary
- `loadCSV`からheaders/rowCount取得ロジックを分離し、`getHeaders()`/`getRowCount()`として独立メソッド化
- `CsvData`型を`{ text, fileName }`のみに縮小し、ファイル保持という本来の責務に戻す
- 表示用データ（行数・カラム数）は必要なタイミングでbridgeから非同期取得する設計に変更

## Test plan
- [x] `pnpm check` (型チェック + lint + fmt) pass
- [x] `pnpm test` (332 tests) pass
- [ ] ブラウザでCSV + Layoutアップロード → ImportScreenに行数/カラム数が表示される
- [ ] 集計画面でGT/クロス集計が正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)