### PR TITLE
docs: add DuckDB Wasm sequential execution convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,3 +33,4 @@ pnpm bench:gen  # generate benchmark data
 - Component files: PascalCase `.tsx`; lib files: camelCase `.ts`
 - Module-level singleton state for infrastructure (`duckdbBridge`, `i18n`); UI state uses hooks + Context
 - File ordering: `imports → exports (Public API) → internal implementation`. Props interfaces stay with their exported component
+- DuckDB Wasm runs sequentially on a single Web Worker — never use `Promise.all` with `duckdbBridge` methods; call them with sequential `await`


### PR DESCRIPTION
## Summary
- Add convention to CLAUDE.md: never use `Promise.all` with `duckdbBridge` methods since DuckDB Wasm runs sequentially on a single Web Worker

## Context
DuckDB Wasm executes queries sequentially on a single Web Worker. Using `Promise.all` to call `duckdbBridge` methods concurrently provides no performance benefit and risks unexpected behavior on a shared connection. This documents the convention to always use sequential `await`.

## Test plan
- [ ] Verify `pnpm check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)