### PR TITLE
refactor: OPFS保存用の生テキストをドメイン型から分離

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,4 +33,3 @@ pnpm bench:gen  # generate benchmark data
 - Component files: PascalCase `.tsx`; lib files: camelCase `.ts`
 - Module-level singleton state for infrastructure (`duckdbBridge`, `i18n`); UI state uses hooks + Context
 - File ordering: `imports → exports (Public API) → internal implementation`. Props interfaces stay with their exported component
-- DuckDB Wasm runs sequentially on a single Web Worker — never use `Promise.all` with `duckdbBridge` methods; call them with sequential `await`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,3 +33,4 @@ pnpm bench:gen  # generate benchmark data
 - Component files: PascalCase `.tsx`; lib files: camelCase `.ts`
 - Module-level singleton state for infrastructure (`duckdbBridge`, `i18n`); UI state uses hooks + Context
 - File ordering: `imports → exports (Public API) → internal implementation`. Props interfaces stay with their exported component
+- DuckDB Wasm runs sequentially on a single Web Worker — never use `Promise.all` with `duckdbBridge` methods; call them with sequential `await`

--- a/src/components/ImportScreen.tsx
+++ b/src/components/ImportScreen.tsx
@@ -101,6 +101,12 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
   const [gsOpen, setGsOpen] = useState(false);
 
   const loadedFromSavedRef = useRef(false);
+  const opfsPayloadRef = useRef<{
+    csvText?: string;
+    csvFileName?: string;
+    layoutJson?: string;
+    layoutFileName?: string;
+  }>({});
 
   const { entries, deleteEntry } = useSavedFiles();
 
@@ -111,8 +117,8 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
     try {
       const text = await file.text();
       const result = await loadCSV(text);
+      opfsPayloadRef.current = { ...opfsPayloadRef.current, csvText: text, csvFileName: file.name };
       setCsv({
-        text,
         fileName: file.name,
         headers: result.headers,
         rowCount: result.rowCount,
@@ -127,7 +133,12 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
     try {
       const text = await file.text();
       const parsed = parseLayout(text);
-      setLayout({ json: text, fileName: file.name, layout: parsed });
+      opfsPayloadRef.current = {
+        ...opfsPayloadRef.current,
+        layoutJson: text,
+        layoutFileName: file.name,
+      };
+      setLayout({ fileName: file.name, layout: parsed });
       loadedFromSavedRef.current = false;
     } catch (e) {
       console.error("Layout load failed:", e);
@@ -140,13 +151,18 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
       const parsed = parseLayout(layoutJson);
       const result = await loadCSV(csvText);
 
+      opfsPayloadRef.current = {
+        csvText,
+        csvFileName: csvName,
+        layoutJson,
+        layoutFileName: layoutName,
+      };
       setCsv({
-        text: csvText,
         fileName: csvName,
         headers: result.headers,
         rowCount: result.rowCount,
       });
-      setLayout({ json: layoutJson, fileName: layoutName, layout: parsed });
+      setLayout({ fileName: layoutName, layout: parsed });
       loadedFromSavedRef.current = true;
     } catch (e) {
       console.error("Saved data load failed:", e);
@@ -155,9 +171,15 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
 
   async function handleProceed(): Promise<void> {
     if (!csv || !layout) return;
-    if (!loadedFromSavedRef.current) {
+    const payload = opfsPayloadRef.current;
+    if (!loadedFromSavedRef.current && payload.csvText && payload.layoutJson) {
       try {
-        await saveData(csv.fileName, csv.text, layout.fileName, layout.json);
+        await saveData(
+          payload.csvFileName!,
+          payload.csvText,
+          payload.layoutFileName!,
+          payload.layoutJson,
+        );
         triggerSavedFilesRefresh();
       } catch (e) {
         console.warn("OPFS save failed:", e);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
 import type { Layout } from "./layout";
 
-export type CsvData = { text: string; fileName: string; headers: string[]; rowCount: number };
-export type LayoutData = { json: string; fileName: string; layout: Layout };
+export type CsvData = { fileName: string; headers: string[]; rowCount: number };
+export type LayoutData = { fileName: string; layout: Layout };


### PR DESCRIPTION
## Summary
- `CsvData`から`text`、`LayoutData`から`json`を削除し、ドメイン型をクリーンに
- OPFS保存用の生テキストは`ImportScreen`内の`opfsPayloadRef`に集約
- 再シリアライズなし — アップロードされた元テキストをそのまま保持

## Test plan
- [x] `pnpm check` パス
- [x] `pnpm test` パス
- [ ] ブラウザで: ファイルアップロード → 集計実行が動作すること
- [ ] ブラウザで: OPFS保存 → 履歴から復元が動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)