### PR TITLE
refactor: テストのQuestion定義をtest_layout.jsonから生成するように統一

### DIFF
--- a/tests/aggregateCross.test.ts
+++ b/tests/aggregateCross.test.ts
@@ -1,13 +1,10 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { aggregateCross } from "../src/lib/agg/aggregateCross";
 import type { AggResult } from "../src/lib/agg/types";
-import { setupDuckDB, teardownDuckDB, getAggInput } from "./helpers/duckdb";
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let conn: any;
+import { setupDuckDB, teardownDuckDB, getConn, getAggInput } from "./helpers/duckdb";
 
 beforeAll(async () => {
-  conn = await setupDuckDB();
+  await setupDuckDB();
 }, 30_000);
 
 afterAll(async () => {
@@ -48,7 +45,7 @@ function findCell(result: AggResult, sliceCode: string, code: string): Cell {
 describe("aggregateCross - 重みなし", () => {
   describe("SA × SA クロス集計", () => {
     it("q2 を q1 でクロスした結果が正しい", async () => {
-      const result = await aggregateCross(conn, q2, q1, "");
+      const result = await aggregateCross(getConn(), q2, q1, "");
 
       expect(result.slices.length).toBeGreaterThan(0);
 
@@ -62,7 +59,7 @@ describe("aggregateCross - 重みなし", () => {
 
   describe("SA × MA クロス集計", () => {
     it("q1 を q3 でクロスした結果が正しい", async () => {
-      const result = await aggregateCross(conn, q1, q3, "");
+      const result = await aggregateCross(getConn(), q1, q3, "");
 
       // SA×MA: q1有効行の中でq3_1='1'のカウント
       // q1=1 の行: 行1,3,5,7,10,12
@@ -75,7 +72,7 @@ describe("aggregateCross - 重みなし", () => {
 
   describe("MA × SA クロス集計", () => {
     it("q3 を q1 でクロスした結果が正しい", async () => {
-      const result = await aggregateCross(conn, q3, q1, "");
+      const result = await aggregateCross(getConn(), q3, q1, "");
 
       // codes should be ["1", "2", "3", "N/A"] (MA codes + NA)
       expect(result.codes).toEqual(["1", "2", "3", "N/A"]);
@@ -93,7 +90,7 @@ describe("aggregateCross - 重みなし", () => {
 
   describe("MA × MA クロス集計", () => {
     it("q3 を自身でクロスした結果にセルが存在する", async () => {
-      const result = await aggregateCross(conn, q3, q3, "");
+      const result = await aggregateCross(getConn(), q3, q3, "");
 
       // q3_1='1' かつ q3_1='1': 行1,3,4,6,8,9,14 = 7件
       const cell = findCell(result, "1", "1"); // slice "1" = cross q3 code, code "1" = row q3 code

--- a/tests/aggregateCross.test.ts
+++ b/tests/aggregateCross.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { aggregateCross } from "../src/lib/agg/aggregateCross";
-import type { AggResult } from "../src/lib/agg/types";
 import { setupDuckDB, teardownDuckDB, getConn, getAggInput } from "./helpers/duckdb";
 
 beforeAll(async () => {
@@ -15,9 +14,10 @@ const q1 = getAggInput("q1");
 const q2 = getAggInput("q2");
 const q3 = getAggInput("q3");
 
-function findCell(result: AggResult, sliceCode: string, code: string): Cell {
+/** スライスのcounts配列を取得 */
+function sliceCounts(result: { codes: string[]; slices: { code: string | null; cells: { count: number }[] }[] }, sliceCode: string): number[] {
   const slice = result.slices.find((s) => s.code === sliceCode)!;
-  return slice.cells[result.codes.indexOf(code)];
+  return slice.cells.map((c) => c.count);
 }
 
 // ============================================================
@@ -47,13 +47,10 @@ describe("aggregateCross - 重みなし", () => {
     it("q2 を q1 でクロスした結果が正しい", async () => {
       const result = await aggregateCross(getConn(), q2, q1, "");
 
-      expect(result.slices.length).toBeGreaterThan(0);
-
       // q2有効行(IS NOT NULL): 行1-11,13,14 = 13行 (行12=NULL除外)
-      // q1=1 かつ q2有効: 行1,3,5,7,10 (行12はq2=NULL除外) = 5行
-      // q1=1 でq2=1: 行7,10 = 2件
-      const cell = findCell(result, "1", "1"); // slice.code=q1値"1", result.codes中のq2値"1"
-      expect(cell.count).toBe(2);
+      // slice "1" = q1=1 かつ q2有効: 行1,3,5,7,10 = 5行
+      //   q2=1:2件(行7,10), q2=2:1件(行3), q2=3:2件(行1,5), q2=99:0件
+      expect(sliceCounts(result, "1")).toEqual([2, 1, 2, 0]);
     });
   });
 
@@ -61,12 +58,10 @@ describe("aggregateCross - 重みなし", () => {
     it("q1 を q3 でクロスした結果が正しい", async () => {
       const result = await aggregateCross(getConn(), q1, q3, "");
 
-      // SA×MA: q1有効行の中でq3_1='1'のカウント
-      // q1=1 の行: 行1,3,5,7,10,12
-      // q1=1 かつ q3_1='1': 行1,3 = 2件
-      // Slice code "1" = q3のcodes[0], result.codes中の"1" = q1の値"1"
-      const cell = findCell(result, "1", "1");
-      expect(cell.count).toBe(2);
+      // slice "1" = q3_1='1' の行: 1,3,4,6,8,9,14
+      //   q1有効(非NULL)かつq3_1='1': 行1,3,4,6,8,9 (行14はq1=NULL)
+      //   q1=1:2件(行1,3), q1=2:2件(行6,9), q1=3:2件(行4,8), q1=99:0件
+      expect(sliceCounts(result, "1")).toEqual([2, 2, 2, 0]);
     });
   });
 
@@ -74,31 +69,27 @@ describe("aggregateCross - 重みなし", () => {
     it("q3 を q1 でクロスした結果が正しい", async () => {
       const result = await aggregateCross(getConn(), q3, q1, "");
 
-      // codes should be ["1", "2", "3", "N/A"] (MA codes + NA)
       expect(result.codes).toEqual(["1", "2", "3", "N/A"]);
 
-      // q3_1='1' かつ q1=1: 行1,3 = 2件
-      // code "1" in result.codes maps to q3_1 column
-      const cell = findCell(result, "1", "1"); // slice "1" = q1 value, code "1" = q3 code
-      expect(cell.count).toBe(2);
-
-      // q3_2='1' かつ q1=1: 行3(q3_2=1,q1=1), 行5(q3_2=1,q1=1), 行7(q3_2=1,q1=1) = 3件
-      const cell2 = findCell(result, "1", "2"); // slice "1" = q1 value, code "2" = q3 code
-      expect(cell2.count).toBe(3);
+      // slice "1" = q1=1 の行: 1,3,5,7,10,12
+      //   q3 shown かつ q1=1: 行1,3,5,7,10,12
+      //   q3_1='1':2件(行1,3), q3_2='1':3件(行3,5,7), q3_3='1':3件(行1,5,10), N/A:1件(行12)
+      expect(sliceCounts(result, "1")).toEqual([2, 3, 3, 1]);
     });
   });
 
   describe("MA × MA クロス集計", () => {
-    it("q3 を自身でクロスした結果にセルが存在する", async () => {
+    it("q3 を自身でクロスした結果が正しい", async () => {
       const result = await aggregateCross(getConn(), q3, q3, "");
 
-      // q3_1='1' かつ q3_1='1': 行1,3,4,6,8,9,14 = 7件
-      const cell = findCell(result, "1", "1"); // slice "1" = cross q3 code, code "1" = row q3 code
-      expect(cell.count).toBe(7);
+      // MA×MA自身クロスではN/Aなし（cross側カラム=1の行のみがスライス対象）
+      // slice "1" = q3_1='1' の行: 1,3,4,6,8,9,14
+      //   q3_1='1':7件, q3_2='1':2件(行3,9), q3_3='1':4件(行1,6,8,14)
+      expect(sliceCounts(result, "1")).toEqual([7, 2, 4]);
 
-      // q3_1='1' かつ q3_2='1': 行3,9 = 2件
-      const cell12 = findCell(result, "2", "1"); // slice "2" = cross q3 code, code "1" = row q3 code
-      expect(cell12.count).toBe(2);
+      // slice "2" = q3_2='1' の行: 2,3,5,7,9
+      //   q3_1='1':2件(行3,9), q3_2='1':5件, q3_3='1':2件(行2,5)
+      expect(sliceCounts(result, "2")).toEqual([2, 5, 2]);
     });
   });
 });

--- a/tests/aggregateCross.test.ts
+++ b/tests/aggregateCross.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { aggregateCross } from "../src/lib/agg/aggregateCross";
 import type { AggResult, Cell } from "../src/lib/agg/types";
-import { setupDuckDB, teardownDuckDB, getQuestion } from "./helpers/duckdb";
+import { setupDuckDB, teardownDuckDB, getAggInput } from "./helpers/duckdb";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let conn: any;
@@ -14,9 +14,9 @@ afterAll(async () => {
   await teardownDuckDB();
 });
 
-const q1 = getQuestion("q1");
-const q2 = getQuestion("q2");
-const q3 = getQuestion("q3");
+const q1 = getAggInput("q1");
+const q2 = getAggInput("q2");
+const q3 = getAggInput("q3");
 
 /** Find a cell by code in a slice */
 function findCellByCode(result: AggResult, sliceCode: string, code: string): Cell | undefined {

--- a/tests/aggregateCross.test.ts
+++ b/tests/aggregateCross.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { aggregateCross } from "../src/lib/agg/aggregateCross";
-import type { Question, AggResult, Cell } from "../src/lib/agg/types";
-import { setupDuckDB, teardownDuckDB } from "./helpers/duckdb";
+import type { AggResult, Cell } from "../src/lib/agg/types";
+import { setupDuckDB, teardownDuckDB, getQuestion } from "./helpers/duckdb";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let conn: any;
@@ -14,34 +14,9 @@ afterAll(async () => {
   await teardownDuckDB();
 });
 
-// ── Helper questions ──
-
-const q1: Question = {
-  type: "SA",
-  code: "q1",
-  columns: ["q1"],
-  codes: ["1", "2", "3", "99"],
-  label: "q1",
-  labels: {},
-};
-
-const q2: Question = {
-  type: "SA",
-  code: "q2",
-  columns: ["q2"],
-  codes: ["1", "2", "3", "99"],
-  label: "q2",
-  labels: {},
-};
-
-const q3: Question = {
-  type: "MA",
-  code: "q3",
-  columns: ["q3_1", "q3_2", "q3_3"],
-  codes: ["1", "2", "3"],
-  label: "q3",
-  labels: {},
-};
+const q1 = getQuestion("q1");
+const q2 = getQuestion("q2");
+const q3 = getQuestion("q3");
 
 /** Find a cell by code in a slice */
 function findCellByCode(result: AggResult, sliceCode: string, code: string): Cell | undefined {

--- a/tests/aggregateCross.test.ts
+++ b/tests/aggregateCross.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { aggregateCross } from "../src/lib/agg/aggregateCross";
-import type { AggResult, Cell } from "../src/lib/agg/types";
+import type { AggResult } from "../src/lib/agg/types";
 import { setupDuckDB, teardownDuckDB, getAggInput } from "./helpers/duckdb";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -18,13 +18,9 @@ const q1 = getAggInput("q1");
 const q2 = getAggInput("q2");
 const q3 = getAggInput("q3");
 
-/** Find a cell by code in a slice */
-function findCellByCode(result: AggResult, sliceCode: string, code: string): Cell | undefined {
-  const slice = result.slices.find((s) => s.code === sliceCode);
-  if (!slice) return undefined;
-  const idx = result.codes.indexOf(code);
-  if (idx < 0) return undefined;
-  return slice.cells[idx];
+function findCell(result: AggResult, sliceCode: string, code: string): Cell {
+  const slice = result.slices.find((s) => s.code === sliceCode)!;
+  return slice.cells[result.codes.indexOf(code)];
 }
 
 // ============================================================
@@ -59,9 +55,8 @@ describe("aggregateCross - 重みなし", () => {
       // q2有効行(IS NOT NULL): 行1-11,13,14 = 13行 (行12=NULL除外)
       // q1=1 かつ q2有効: 行1,3,5,7,10 (行12はq2=NULL除外) = 5行
       // q1=1 でq2=1: 行7,10 = 2件
-      const cell = findCellByCode(result, "1", "1"); // slice.code=q1値"1", result.codes中のq2値"1"
-      expect(cell).toBeDefined();
-      expect(cell!.count).toBe(2);
+      const cell = findCell(result, "1", "1"); // slice.code=q1値"1", result.codes中のq2値"1"
+      expect(cell.count).toBe(2);
     });
   });
 
@@ -73,9 +68,8 @@ describe("aggregateCross - 重みなし", () => {
       // q1=1 の行: 行1,3,5,7,10,12
       // q1=1 かつ q3_1='1': 行1,3 = 2件
       // Slice code "1" = q3のcodes[0], result.codes中の"1" = q1の値"1"
-      const cell = findCellByCode(result, "1", "1");
-      expect(cell).toBeDefined();
-      expect(cell!.count).toBe(2);
+      const cell = findCell(result, "1", "1");
+      expect(cell.count).toBe(2);
     });
   });
 
@@ -88,14 +82,12 @@ describe("aggregateCross - 重みなし", () => {
 
       // q3_1='1' かつ q1=1: 行1,3 = 2件
       // code "1" in result.codes maps to q3_1 column
-      const cell = findCellByCode(result, "1", "1"); // slice "1" = q1 value, code "1" = q3 code
-      expect(cell).toBeDefined();
-      expect(cell!.count).toBe(2);
+      const cell = findCell(result, "1", "1"); // slice "1" = q1 value, code "1" = q3 code
+      expect(cell.count).toBe(2);
 
       // q3_2='1' かつ q1=1: 行3(q3_2=1,q1=1), 行5(q3_2=1,q1=1), 行7(q3_2=1,q1=1) = 3件
-      const cell2 = findCellByCode(result, "1", "2"); // slice "1" = q1 value, code "2" = q3 code
-      expect(cell2).toBeDefined();
-      expect(cell2!.count).toBe(3);
+      const cell2 = findCell(result, "1", "2"); // slice "1" = q1 value, code "2" = q3 code
+      expect(cell2.count).toBe(3);
     });
   });
 
@@ -104,14 +96,12 @@ describe("aggregateCross - 重みなし", () => {
       const result = await aggregateCross(conn, q3, q3, "");
 
       // q3_1='1' かつ q3_1='1': 行1,3,4,6,8,9,14 = 7件
-      const cell = findCellByCode(result, "1", "1"); // slice "1" = cross q3 code, code "1" = row q3 code
-      expect(cell).toBeDefined();
-      expect(cell!.count).toBe(7);
+      const cell = findCell(result, "1", "1"); // slice "1" = cross q3 code, code "1" = row q3 code
+      expect(cell.count).toBe(7);
 
       // q3_1='1' かつ q3_2='1': 行3,9 = 2件
-      const cell12 = findCellByCode(result, "2", "1"); // slice "2" = cross q3 code, code "1" = row q3 code
-      expect(cell12).toBeDefined();
-      expect(cell12!.count).toBe(2);
+      const cell12 = findCell(result, "2", "1"); // slice "2" = cross q3 code, code "1" = row q3 code
+      expect(cell12.count).toBe(2);
     });
   });
 });

--- a/tests/aggregateGt.test.ts
+++ b/tests/aggregateGt.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { aggregateGt } from "../src/lib/agg/aggregateGt";
-import type { Question, AggResult, Cell } from "../src/lib/agg/types";
-import { setupDuckDB, teardownDuckDB } from "./helpers/duckdb";
+import type { AggResult, Cell } from "../src/lib/agg/types";
+import { setupDuckDB, teardownDuckDB, getQuestion } from "./helpers/duckdb";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let conn: any;
@@ -14,25 +14,8 @@ afterAll(async () => {
   await teardownDuckDB();
 });
 
-// ── Helper questions ──
-
-const q1: Question = {
-  type: "SA",
-  code: "q1",
-  columns: ["q1"],
-  codes: ["1", "2", "3", "99"],
-  label: "q1",
-  labels: {},
-};
-
-const q3: Question = {
-  type: "MA",
-  code: "q3",
-  columns: ["q3_1", "q3_2", "q3_3"],
-  codes: ["1", "2", "3"],
-  label: "q3",
-  labels: {},
-};
+const q1 = getQuestion("q1");
+const q3 = getQuestion("q3");
 
 /** Get the GT slice's cell for a given code */
 function gtCell(result: AggResult, code: string): Cell | undefined {

--- a/tests/aggregateGt.test.ts
+++ b/tests/aggregateGt.test.ts
@@ -1,13 +1,10 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { aggregateGt } from "../src/lib/agg/aggregateGt";
 import type { AggResult } from "../src/lib/agg/types";
-import { setupDuckDB, teardownDuckDB, getAggInput } from "./helpers/duckdb";
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let conn: any;
+import { setupDuckDB, teardownDuckDB, getConn, getAggInput } from "./helpers/duckdb";
 
 beforeAll(async () => {
-  conn = await setupDuckDB();
+  await setupDuckDB();
 }, 30_000);
 
 afterAll(async () => {
@@ -47,7 +44,7 @@ function gtCell(result: AggResult, code: string): Cell {
 describe("aggregateGt - 重みなし", () => {
   describe("SA GT集計", () => {
     it("q1 の GT 集計で各値の count/n/pct が正しい", async () => {
-      const result = await aggregateGt(conn, q1, "");
+      const result = await aggregateGt(getConn(), q1, "");
 
       expect(result.slices).toHaveLength(1);
 
@@ -78,7 +75,7 @@ describe("aggregateGt - 重みなし", () => {
 
   describe("MA GT集計", () => {
     it("q3 の GT 集計で各サブカラムの count と無回答が正しい", async () => {
-      const result = await aggregateGt(conn, q3, "");
+      const result = await aggregateGt(getConn(), q3, "");
 
       // MA shown条件: q3_1~q3_3 のいずれかが非NULL
       // 行13: q3_1=NULL,q3_2=NULL,q3_3=NULL → 全部NULLなので除外
@@ -112,7 +109,7 @@ describe("aggregateGt - 重みなし", () => {
 describe("aggregateGt - 重み付き", () => {
   describe("SA GT集計（重み付き）", () => {
     it("q1 の重み付き GT 集計で weighted count が正しい", async () => {
-      const result = await aggregateGt(conn, q1, "weight");
+      const result = await aggregateGt(getConn(), q1, "weight");
 
       // q1有効行: 行1-13 (行14=空のみ除外, N/Aは文字列として有効)
       // q1=1: 行1(1.2)+3(1.5)+5(1.1)+7(1.3)+10(1.0)+12(0.8) = 6.9
@@ -135,7 +132,7 @@ describe("aggregateGt - 重み付き", () => {
 
   describe("MA GT集計（重み付き）", () => {
     it("q3 の重み付き GT 集計で weighted count が正しい", async () => {
-      const result = await aggregateGt(conn, q3, "weight");
+      const result = await aggregateGt(getConn(), q3, "weight");
 
       // shown行: 行1-12,14 = 13行 (行13は全空で除外)
       // q3_1='1': 行1(1.2)+3(1.5)+4(0.8)+6(1.0)+8(0.7)+9(1.4)+14(1.0) = 7.6

--- a/tests/aggregateGt.test.ts
+++ b/tests/aggregateGt.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { aggregateGt } from "../src/lib/agg/aggregateGt";
 import type { AggResult, Cell } from "../src/lib/agg/types";
-import { setupDuckDB, teardownDuckDB, getQuestion } from "./helpers/duckdb";
+import { setupDuckDB, teardownDuckDB, getAggInput } from "./helpers/duckdb";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let conn: any;
@@ -14,8 +14,8 @@ afterAll(async () => {
   await teardownDuckDB();
 });
 
-const q1 = getQuestion("q1");
-const q3 = getQuestion("q3");
+const q1 = getAggInput("q1");
+const q3 = getAggInput("q3");
 
 /** Get the GT slice's cell for a given code */
 function gtCell(result: AggResult, code: string): Cell | undefined {

--- a/tests/aggregateGt.test.ts
+++ b/tests/aggregateGt.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { aggregateGt } from "../src/lib/agg/aggregateGt";
-import type { AggResult } from "../src/lib/agg/types";
 import { setupDuckDB, teardownDuckDB, getConn, getAggInput } from "./helpers/duckdb";
 
 beforeAll(async () => {
@@ -13,11 +12,6 @@ afterAll(async () => {
 
 const q1 = getAggInput("q1");
 const q3 = getAggInput("q3");
-
-function gtCell(result: AggResult, code: string): Cell {
-  const slice = result.slices.find((s) => s.code === null)!;
-  return slice.cells[result.codes.indexOf(code)];
-}
 
 // ============================================================
 // テストデータ (testdata/test_data.csv) 14行
@@ -58,18 +52,13 @@ describe("aggregateGt - 重みなし", () => {
       expect(slice.code).toBeNull();
       expect(slice.n).toBe(n);
 
-      const cell1 = gtCell(result, "1");
-      expect(cell1.count).toBe(6);
-      expect(cell1.pct).toBeCloseTo((6 / n) * 100, 5);
+      const counts = slice.cells.map((c) => c.count);
+      expect(counts).toEqual([6, 3, 2, 2]);
 
-      const cell2 = gtCell(result, "2");
-      expect(cell2.count).toBe(3);
-
-      const cell3 = gtCell(result, "3");
-      expect(cell3.count).toBe(2);
-
-      const cell99 = gtCell(result, "99");
-      expect(cell99.count).toBe(2);
+      const pcts = slice.cells.map((c) => c.pct);
+      expect(pcts.map((p) => Math.round(p * 1e5) / 1e5)).toEqual(
+        [6, 3, 2, 2].map((c) => Math.round((c / n) * 100 * 1e5) / 1e5),
+      );
     });
   });
 
@@ -84,24 +73,12 @@ describe("aggregateGt - 重みなし", () => {
       // q3_2='1': 行2,3,5,7,9 = 5件
       // q3_3='1': 行1,2,5,6,8,10,14 = 7件
       // 無回答(shown but none='1'): 行11(0,0,0),12(0,0,0) = 2件
-      const n = 13;
       const slice = result.slices[0];
-      expect(slice.n).toBe(n);
-
-      // codes should be ["1", "2", "3", "N/A"]
+      expect(slice.n).toBe(13);
       expect(result.codes).toEqual(["1", "2", "3", "N/A"]);
 
-      const cellQ3_1 = gtCell(result, "1");
-      expect(cellQ3_1.count).toBe(7);
-
-      const cellQ3_2 = gtCell(result, "2");
-      expect(cellQ3_2.count).toBe(5);
-
-      const cellQ3_3 = gtCell(result, "3");
-      expect(cellQ3_3.count).toBe(7);
-
-      const cellNA = gtCell(result, "N/A");
-      expect(cellNA.count).toBe(2);
+      const counts = slice.cells.map((c) => c.count);
+      expect(counts).toEqual([7, 5, 7, 2]);
     });
   });
 });
@@ -111,22 +88,23 @@ describe("aggregateGt - 重み付き", () => {
     it("q1 の重み付き GT 集計で weighted count が正しい", async () => {
       const result = await aggregateGt(getConn(), q1, "weight");
 
-      // q1有効行: 行1-13 (行14=空のみ除外, N/Aは文字列として有効)
+      // q1有効行: 行1-13 (行14=空のみ除外)
       // q1=1: 行1(1.2)+3(1.5)+5(1.1)+7(1.3)+10(1.0)+12(0.8) = 6.9
       // q1=2: 行2(0.9)+6(1.0)+9(1.4) = 3.3
       // q1=3: 行4(0.8)+8(0.7) = 1.5
-      // q1=N/A: 行11(1.0)+13(1.1) = 2.1
+      // q1=99: 行11(1.0)+13(1.1) = 2.1
       // n = 6.9+3.3+1.5+2.1 = 13.8
-      const cell1 = gtCell(result, "1");
-      expect(cell1.count).toBeCloseTo(6.9, 1);
-      expect(result.slices[0].n).toBeCloseTo(13.8, 1);
-      expect(cell1.pct).toBeCloseTo((6.9 / 13.8) * 100, 1);
+      const slice = result.slices[0];
+      expect(slice.n).toBeCloseTo(13.8, 1);
 
-      const cell2 = gtCell(result, "2");
-      expect(cell2.count).toBeCloseTo(3.3, 1);
+      const counts = slice.cells.map((c) => c.count);
+      expect(counts[0]).toBeCloseTo(6.9, 1);
+      expect(counts[1]).toBeCloseTo(3.3, 1);
+      expect(counts[2]).toBeCloseTo(1.5, 1);
+      expect(counts[3]).toBeCloseTo(2.1, 1);
 
-      const cell3 = gtCell(result, "3");
-      expect(cell3.count).toBeCloseTo(1.5, 1);
+      const pcts = slice.cells.map((c) => c.pct);
+      expect(pcts[0]).toBeCloseTo((6.9 / 13.8) * 100, 1);
     });
   });
 
@@ -136,8 +114,12 @@ describe("aggregateGt - 重み付き", () => {
 
       // shown行: 行1-12,14 = 13行 (行13は全空で除外)
       // q3_1='1': 行1(1.2)+3(1.5)+4(0.8)+6(1.0)+8(0.7)+9(1.4)+14(1.0) = 7.6
-      const cellQ3_1 = gtCell(result, "1");
-      expect(cellQ3_1.count).toBeCloseTo(7.6, 1);
+      // q3_2='1': 行2(0.9)+3(1.5)+5(1.1)+7(1.3)+9(1.4) = 6.2
+      // q3_3='1': 行1(1.2)+2(0.9)+5(1.1)+6(1.0)+8(0.7)+10(1.0)+14(1.0) = 6.9
+      const counts = result.slices[0].cells.map((c) => c.count);
+      expect(counts[0]).toBeCloseTo(7.6, 1);
+      expect(counts[1]).toBeCloseTo(6.2, 1);
+      expect(counts[2]).toBeCloseTo(6.9, 1);
     });
   });
 });

--- a/tests/aggregateGt.test.ts
+++ b/tests/aggregateGt.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { aggregateGt } from "../src/lib/agg/aggregateGt";
-import type { AggResult, Cell } from "../src/lib/agg/types";
+import type { AggResult } from "../src/lib/agg/types";
 import { setupDuckDB, teardownDuckDB, getAggInput } from "./helpers/duckdb";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -17,13 +17,9 @@ afterAll(async () => {
 const q1 = getAggInput("q1");
 const q3 = getAggInput("q3");
 
-/** Get the GT slice's cell for a given code */
-function gtCell(result: AggResult, code: string): Cell | undefined {
-  const slice = result.slices.find((s) => s.code === null);
-  if (!slice) return undefined;
-  const idx = result.codes.indexOf(code);
-  if (idx < 0) return undefined;
-  return slice.cells[idx];
+function gtCell(result: AggResult, code: string): Cell {
+  const slice = result.slices.find((s) => s.code === null)!;
+  return slice.cells[result.codes.indexOf(code)];
 }
 
 // ============================================================
@@ -65,18 +61,17 @@ describe("aggregateGt - 重みなし", () => {
       expect(slice.code).toBeNull();
       expect(slice.n).toBe(n);
 
-      const cell1 = gtCell(result, "1")!;
-      expect(cell1).toBeDefined();
+      const cell1 = gtCell(result, "1");
       expect(cell1.count).toBe(6);
       expect(cell1.pct).toBeCloseTo((6 / n) * 100, 5);
 
-      const cell2 = gtCell(result, "2")!;
+      const cell2 = gtCell(result, "2");
       expect(cell2.count).toBe(3);
 
-      const cell3 = gtCell(result, "3")!;
+      const cell3 = gtCell(result, "3");
       expect(cell3.count).toBe(2);
 
-      const cell99 = gtCell(result, "99")!;
+      const cell99 = gtCell(result, "99");
       expect(cell99.count).toBe(2);
     });
   });
@@ -99,18 +94,16 @@ describe("aggregateGt - 重みなし", () => {
       // codes should be ["1", "2", "3", "N/A"]
       expect(result.codes).toEqual(["1", "2", "3", "N/A"]);
 
-      const cellQ3_1 = gtCell(result, "1")!;
-      expect(cellQ3_1).toBeDefined();
+      const cellQ3_1 = gtCell(result, "1");
       expect(cellQ3_1.count).toBe(7);
 
-      const cellQ3_2 = gtCell(result, "2")!;
+      const cellQ3_2 = gtCell(result, "2");
       expect(cellQ3_2.count).toBe(5);
 
-      const cellQ3_3 = gtCell(result, "3")!;
+      const cellQ3_3 = gtCell(result, "3");
       expect(cellQ3_3.count).toBe(7);
 
-      const cellNA = gtCell(result, "N/A")!;
-      expect(cellNA).toBeDefined();
+      const cellNA = gtCell(result, "N/A");
       expect(cellNA.count).toBe(2);
     });
   });
@@ -127,16 +120,15 @@ describe("aggregateGt - 重み付き", () => {
       // q1=3: 行4(0.8)+8(0.7) = 1.5
       // q1=N/A: 行11(1.0)+13(1.1) = 2.1
       // n = 6.9+3.3+1.5+2.1 = 13.8
-      const cell1 = gtCell(result, "1")!;
-      expect(cell1).toBeDefined();
+      const cell1 = gtCell(result, "1");
       expect(cell1.count).toBeCloseTo(6.9, 1);
       expect(result.slices[0].n).toBeCloseTo(13.8, 1);
       expect(cell1.pct).toBeCloseTo((6.9 / 13.8) * 100, 1);
 
-      const cell2 = gtCell(result, "2")!;
+      const cell2 = gtCell(result, "2");
       expect(cell2.count).toBeCloseTo(3.3, 1);
 
-      const cell3 = gtCell(result, "3")!;
+      const cell3 = gtCell(result, "3");
       expect(cell3.count).toBeCloseTo(1.5, 1);
     });
   });
@@ -147,8 +139,7 @@ describe("aggregateGt - 重み付き", () => {
 
       // shown行: 行1-12,14 = 13行 (行13は全空で除外)
       // q3_1='1': 行1(1.2)+3(1.5)+4(0.8)+6(1.0)+8(0.7)+9(1.4)+14(1.0) = 7.6
-      const cellQ3_1 = gtCell(result, "1")!;
-      expect(cellQ3_1).toBeDefined();
+      const cellQ3_1 = gtCell(result, "1");
       expect(cellQ3_1.count).toBeCloseTo(7.6, 1);
     });
   });

--- a/tests/export.test.ts
+++ b/tests/export.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { buildTallies } from "../src/lib/agg/buildTallies";
-import type { Question, Tally } from "../src/lib/agg/types";
-import { setupDuckDB, teardownDuckDB } from "./helpers/duckdb";
+import type { Tally } from "../src/lib/agg/types";
+import { setupDuckDB, teardownDuckDB, getQuestion } from "./helpers/duckdb";
 import { buildExportGrids } from "../src/lib/export/formatters/grid";
 import { talliesToLongRows } from "../src/lib/export/formatters/longFormat";
 import { formatCSV } from "../src/lib/export/formatters/csv";
@@ -9,32 +9,9 @@ import { formatTSV } from "../src/lib/export/formatters/tsv";
 import { formatMarkdown } from "../src/lib/export/formatters/markdown";
 import { formatJSON } from "../src/lib/export/formatters/json";
 
-const q1: Question = {
-  type: "SA",
-  code: "q1",
-  columns: ["q1"],
-  codes: ["1", "2", "3", "99"],
-  label: "q1",
-  labels: {},
-};
-
-const q2: Question = {
-  type: "SA",
-  code: "q2",
-  columns: ["q2"],
-  codes: ["1", "2", "3", "99"],
-  label: "q2",
-  labels: {},
-};
-
-const q3: Question = {
-  type: "MA",
-  code: "q3",
-  columns: ["q3_1", "q3_2", "q3_3"],
-  codes: ["1", "2", "3"],
-  label: "q3",
-  labels: {},
-};
+const q1 = getQuestion("q1");
+const q2 = getQuestion("q2");
+const q3 = getQuestion("q3");
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let conn: any;

--- a/tests/export.test.ts
+++ b/tests/export.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { buildTallies } from "../src/lib/agg/buildTallies";
 import type { Tally } from "../src/lib/agg/types";
-import { setupDuckDB, teardownDuckDB, getQuestion } from "./helpers/duckdb";
+import { setupDuckDB, teardownDuckDB, getConn, getQuestion } from "./helpers/duckdb";
 import { buildExportGrids } from "../src/lib/export/formatters/grid";
 import { talliesToLongRows } from "../src/lib/export/formatters/longFormat";
 import { formatCSV } from "../src/lib/export/formatters/csv";
@@ -13,16 +13,14 @@ const q1 = getQuestion("q1");
 const q2 = getQuestion("q2");
 const q3 = getQuestion("q3");
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let conn: any;
 let gtTallies: Tally[];
 let crossTallies: Tally[];
 
 beforeAll(async () => {
-  conn = await setupDuckDB();
+  await setupDuckDB();
 
-  gtTallies = await buildTallies(conn, [q1, q3], [], "");
-  crossTallies = await buildTallies(conn, [q2], [q1], "");
+  gtTallies = await buildTallies(getConn(), [q1, q3], [], "");
+  crossTallies = await buildTallies(getConn(), [q2], [q1], "");
 }, 30_000);
 
 afterAll(async () => {

--- a/tests/helpers/duckdb.ts
+++ b/tests/helpers/duckdb.ts
@@ -1,6 +1,8 @@
 import { createRequire } from "node:module";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { parseLayout, buildQuestions, findWeightColumn } from "../../src/lib/layout";
+import type { Question } from "../../src/lib/agg/types";
 
 const require = createRequire(import.meta.url);
 const DUCKDB_DIST = resolve(require.resolve("@duckdb/duckdb-wasm"), "..");
@@ -46,3 +48,17 @@ export async function teardownDuckDB(): Promise<void> {
     conn = null;
   }
 }
+
+// ── Layout-derived test helpers ──
+
+const layoutPath = resolve(import.meta.dirname!, "../../testdata/test_layout.json");
+const layout = parseLayout(readFileSync(layoutPath, "utf-8"));
+const questions = buildQuestions(layout);
+
+export function getQuestion(code: string): Question {
+  const q = questions.find((q) => q.code === code);
+  if (!q) throw new Error(`Question "${code}" not found in test_layout.json`);
+  return q;
+}
+
+export const weightColumn = findWeightColumn(layout);

--- a/tests/helpers/duckdb.ts
+++ b/tests/helpers/duckdb.ts
@@ -2,7 +2,7 @@ import { createRequire } from "node:module";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { parseLayout, buildQuestions, findWeightColumn } from "../../src/lib/layout";
-import type { Question } from "../../src/lib/agg/types";
+import type { AggInput, Question } from "../../src/lib/agg/types";
 
 const require = createRequire(import.meta.url);
 const DUCKDB_DIST = resolve(require.resolve("@duckdb/duckdb-wasm"), "..");
@@ -54,6 +54,13 @@ export async function teardownDuckDB(): Promise<void> {
 const layoutPath = resolve(import.meta.dirname!, "../../testdata/test_layout.json");
 const layout = parseLayout(readFileSync(layoutPath, "utf-8"));
 const questions = buildQuestions(layout);
+
+export function getAggInput(code: string): AggInput {
+  const q = questions.find((q) => q.code === code);
+  if (!q) throw new Error(`Question "${code}" not found in test_layout.json`);
+  const { type, columns, codes } = q;
+  return { type, columns, codes };
+}
 
 export function getQuestion(code: string): Question {
   const q = questions.find((q) => q.code === code);

--- a/tests/helpers/duckdb.ts
+++ b/tests/helpers/duckdb.ts
@@ -18,8 +18,14 @@ const {
 let db: ReturnType<typeof createDuckDB> extends Promise<infer T> ? T : never;
 let conn: Awaited<ReturnType<typeof db.connect>> | null = null;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getConn(): any {
+  if (!conn) throw new Error("setupDuckDB() has not been called yet");
+  return conn;
+}
+
 export async function setupDuckDB() {
-  if (conn) return conn;
+  if (conn) return;
 
   const logger = new ConsoleLogger();
   const bundles = {
@@ -38,8 +44,6 @@ export async function setupDuckDB() {
   await conn.query(
     `CREATE OR REPLACE VIEW survey AS SELECT * FROM read_csv('survey.csv')`,
   );
-
-  return conn;
 }
 
 export async function teardownDuckDB(): Promise<void> {


### PR DESCRIPTION
## Summary
- 各テストファイル（aggregateGt, aggregateCross, export）に重複していた手書きQuestion定義を削除
- `tests/helpers/duckdb.ts` に `getQuestion(code)` ヘルパーと `weightColumn` を追加し、`testdata/test_layout.json` を唯一の信頼源として使用
- `labels` が空オブジェクト `{}` だったのがレイアウト定義の正しい値（例: `{ "1": "男性", ... }`）に修正

## Test plan
- [x] `pnpm test` で全31テストがパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)