### PR TITLE
refactor: CrossTable/GtTableからuseAggregation依存を除去

### DIFF
--- a/src/components/aggregation/CrossTable.tsx
+++ b/src/components/aggregation/CrossTable.tsx
@@ -2,19 +2,21 @@ import type { Tally, Slice, Axis } from "../../lib/agg/types";
 import { t } from "../../lib/i18n";
 import type { PctDirection } from "./Toolbar";
 import { Th, Td } from "./TableCells";
-import { useAggregation } from "./AggregationContext";
 
 interface CrossTableProps {
   gtTally: Tally;
   crossTallies: Tally[];
   pctDir: PctDirection;
+  weightCol: string;
 }
 
-export function CrossTable({ gtTally, crossTallies, pctDir }: CrossTableProps) {
+export function CrossTable({ gtTally, crossTallies, pctDir, weightCol }: CrossTableProps) {
   if (pctDir === "horizontal") {
-    return <TransposedCrossTable gtTally={gtTally} crossTallies={crossTallies} />;
+    return (
+      <TransposedCrossTable gtTally={gtTally} crossTallies={crossTallies} weightCol={weightCol} />
+    );
   }
-  return <VerticalCrossTable gtTally={gtTally} crossTallies={crossTallies} />;
+  return <VerticalCrossTable gtTally={gtTally} crossTallies={crossTallies} weightCol={weightCol} />;
 }
 
 function resolveAxisLabel(code: string, axis: Axis): string {
@@ -34,8 +36,15 @@ interface CrossGroup {
   tally: Tally;
 }
 
-function VerticalCrossTable({ gtTally, crossTallies }: { gtTally: Tally; crossTallies: Tally[] }) {
-  const { weightCol } = useAggregation();
+function VerticalCrossTable({
+  gtTally,
+  crossTallies,
+  weightCol,
+}: {
+  gtTally: Tally;
+  crossTallies: Tally[];
+  weightCol: string;
+}) {
   const gtSlice = gtTally.slices[0];
   const codes = gtTally.codes;
 
@@ -121,11 +130,12 @@ function VerticalCrossTable({ gtTally, crossTallies }: { gtTally: Tally; crossTa
 function TransposedCrossTable({
   gtTally,
   crossTallies,
+  weightCol,
 }: {
   gtTally: Tally;
   crossTallies: Tally[];
+  weightCol: string;
 }) {
-  const { weightCol } = useAggregation();
   const gtSlice = gtTally.slices[0];
   const codes = gtTally.codes;
 
@@ -194,6 +204,7 @@ function TransposedCrossTable({
                 slice={slice}
                 axis={group.axis}
                 codes={codes}
+                weightCol={weightCol}
               />
             ))}
           </>
@@ -203,8 +214,17 @@ function TransposedCrossTable({
   );
 }
 
-function TransposedSubRow({ slice, axis, codes }: { slice: Slice; axis: Axis; codes: string[] }) {
-  const { weightCol } = useAggregation();
+function TransposedSubRow({
+  slice,
+  axis,
+  codes,
+  weightCol,
+}: {
+  slice: Slice;
+  axis: Axis;
+  codes: string[];
+  weightCol: string;
+}) {
   return (
     <tr>
       <td

--- a/src/components/aggregation/GtTable.tsx
+++ b/src/components/aggregation/GtTable.tsx
@@ -1,15 +1,13 @@
 import type { Tally } from "../../lib/agg/types";
 import { t } from "../../lib/i18n";
 import { Th, Td } from "./TableCells";
-import { useAggregation } from "./AggregationContext";
-
 interface GtTableProps {
   tally: Tally;
   maxPct: number;
+  weightCol: string;
 }
 
-export function GtTable({ tally, maxPct }: GtTableProps) {
-  const { weightCol } = useAggregation();
+export function GtTable({ tally, maxPct, weightCol }: GtTableProps) {
   const slice = tally.slices[0];
 
   return (

--- a/src/components/aggregation/TableContent.tsx
+++ b/src/components/aggregation/TableContent.tsx
@@ -9,7 +9,7 @@ interface TableContentProps {
 }
 
 export function TableContent({ pctDirection }: TableContentProps) {
-  const { tallies } = useAggregation();
+  const { tallies, weightCol } = useAggregation();
   const hasCross = tallies.some((t) => t.by !== null);
 
   // Compute maxPct across all GT slices for bar chart scaling
@@ -42,9 +42,14 @@ export function TableContent({ pctDirection }: TableContentProps) {
             extraClass={crossTallies.length > 0 ? "overflow-x-auto" : undefined}
           >
             {crossTallies.length > 0 ? (
-              <CrossTable gtTally={gtTally} crossTallies={crossTallies} pctDir={pctDirection} />
+              <CrossTable
+                gtTally={gtTally}
+                crossTallies={crossTallies}
+                pctDir={pctDirection}
+                weightCol={weightCol}
+              />
             ) : (
-              <GtTable tally={gtTally} maxPct={maxPct} />
+              <GtTable tally={gtTally} maxPct={maxPct} weightCol={weightCol} />
             )}
           </ResultCard>
         );


### PR DESCRIPTION
## Summary
- `CrossTable`と`GtTable`から`useAggregation()`の呼び出しを除去し、`weightCol`をprops経由で受け取るように変更
- Context依存を`TableContent`に集約し、テーブルコンポーネントを純粋な表示コンポーネントに統一
- 内部コンポーネント（VerticalCrossTable, TransposedCrossTable, TransposedSubRow）も同様にprops経由に変更

## Test plan
- [x] `pnpm check` (fmt, lint, tsc) パス
- [ ] GT表示・クロス集計表示が正常に動作すること
- [ ] ウェイト付き集計でn値の表示形式が正しいこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)