### PR TITLE
feat: Playwright E2Eテストを導入（Chromium/Firefox/WebKit）

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write
   deployments: write
+  pull-requests: write
 
 jobs:
   benchmark:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,35 @@
+name: E2E
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: ${{ github.event_name == 'push' && fromJSON('["chromium","firefox","webkit"]') || fromJSON('["chromium"]') }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Install Playwright browser
+        run: pnpm exec playwright install --with-deps ${{ matrix.browser }}
+      - name: Run E2E tests
+        run: pnpm exec playwright test --project=${{ matrix.browser }}
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report-${{ matrix.browser }}
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ dist/
 .claude/settings.local.json
 .claude/worktrees/
 bench/data/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/e2e/aggregation.spec.ts
+++ b/e2e/aggregation.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "@playwright/test";
+import { waitForWasmReady, uploadFiles, proceedToAggregation } from "./helpers";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/");
+  await waitForWasmReady(page);
+});
+
+test("ファイルアップロード → 検証 → 集計画面遷移", async ({ page }) => {
+  await uploadFiles(page);
+
+  // ファイル名が表示されること
+  await expect(page.getByText("test_data.csv")).toBeVisible();
+  await expect(page.getByText("test_layout.json")).toBeVisible();
+
+  // 検証 → 集計画面へ進む
+  await proceedToAggregation(page);
+
+  // 集計画面の「集計を実行」ボタンが表示される
+  await expect(
+    page.getByRole("button", { name: /集計を実行/ }),
+  ).toBeVisible();
+});
+
+test("GT集計結果の自動表示", async ({ page }) => {
+  await uploadFiles(page);
+  await proceedToAggregation(page);
+
+  // 自動実行による GT テーブルが表示される
+  // テーブル caption でラベルを確認（getByText だと複数要素にマッチするため）
+  await expect(page.getByText("性別 の集計結果")).toBeAttached({
+    timeout: 30_000,
+  });
+  await expect(page.getByText("満足度 の集計結果")).toBeAttached();
+  await expect(
+    page.getByText("利用しているサービス の集計結果"),
+  ).toBeAttached();
+
+  // テーブルが 3 つ以上存在すること
+  const tables = page.locator("table");
+  await expect(tables).toHaveCount(3, { timeout: 15_000 });
+});
+
+test("クロス集計", async ({ page }) => {
+  await uploadFiles(page);
+  await proceedToAggregation(page);
+
+  // GT テーブル表示を待つ
+  await expect(page.getByText("性別 の集計結果")).toBeAttached({
+    timeout: 30_000,
+  });
+
+  // クロス集計軸セクションから q1 のチェックボックスを ON
+  const crossAxisGroup = page.getByRole("group", {
+    name: /クロス集計軸の選択/,
+  });
+  await crossAxisGroup.getByRole("checkbox").first().check();
+
+  // 集計を実行
+  await page.getByRole("button", { name: /集計を実行/ }).click();
+
+  // クロス集計ヘッダー（「性別」列ヘッダー）がテーブル内に表示されること
+  const crossHeader = page.locator("table th", { hasText: "性別" });
+  await expect(crossHeader.first()).toBeVisible({ timeout: 30_000 });
+});

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,30 @@
+import { type Page, expect } from "@playwright/test";
+import path from "node:path";
+
+export const TESTDATA = path.resolve(import.meta.dirname, "../testdata");
+
+/** DuckDB Wasm が "DuckDB Ready" になるまで明示待機 + エラー文言不在確認 */
+export async function waitForWasmReady(page: Page): Promise<void> {
+  const statusEl = page.locator('[role="status"]');
+  await statusEl
+    .filter({ hasText: "DuckDB Ready" })
+    .waitFor({ timeout: 30_000 });
+  await expect(statusEl).not.toContainText("エラー");
+}
+
+/** CSV + Layout JSON をアップロード */
+export async function uploadFiles(page: Page): Promise<void> {
+  const csvInput = page.locator('input[type="file"][accept=".csv"]');
+  const jsonInput = page.locator('input[type="file"][accept=".json"]');
+  await csvInput.setInputFiles(path.join(TESTDATA, "test_data.csv"));
+  await jsonInput.setInputFiles(path.join(TESTDATA, "test_layout.json"));
+}
+
+/** Step 1 → Step 2 (検証) → 集計画面へ進む */
+export async function proceedToAggregation(page: Page): Promise<void> {
+  await page.getByRole("button", { name: /検証/ }).click();
+  await page
+    .getByRole("button", { name: /集計画面へ進む/ })
+    .waitFor({ timeout: 15_000 });
+  await page.getByRole("button", { name: /集計画面へ進む/ }).click();
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "test:watch": "vitest",
     "check": "pnpm run fmt:check && pnpm run lint && tsc --noEmit",
     "bench:gen": "tsx bench/generate.ts",
-    "bench": "tsx bench/run.ts"
+    "bench": "tsx bench/run.ts",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@duckdb/duckdb-wasm": "^1.33.1-dev18.0",
@@ -24,6 +26,7 @@
     "preact": "^10.28.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@preact/preset-vite": "^2.10.3",
     "@tailwindcss/vite": "^4.2.1",
     "oxfmt": "^0.35.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  fullyParallel: false,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [["html"], ["github"]] : [["html"]],
+  use: {
+    baseURL: "http://localhost:4173",
+    locale: "ja-JP",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  webServer: {
+    command: "pnpm build && pnpm preview --port 4173 --strictPort",
+    url: "http://localhost:4173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+    { name: "firefox", use: { ...devices["Desktop Firefox"] } },
+    { name: "webkit", use: { ...devices["Desktop Safari"] } },
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
         specifier: ^10.28.4
         version: 10.28.4
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
       '@preact/preset-vite':
         specifier: ^2.10.3
         version: 2.10.3(@babel/core@7.29.0)(preact@10.28.4)(rollup@4.59.0)(vite@7.3.1(@types/node@20.19.34)(jiti@2.6.1)(lightningcss@1.31.1))
@@ -549,6 +552,11 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@preact/preset-vite@2.10.3':
     resolution: {integrity: sha512-1SiS+vFItpkNdBs7q585PSAIln0wBeBdcpJYbzPs1qipsb/FssnkUioNXuRsb8ZnU8YEQHr+3v8+/mzWSnTQmg==}
@@ -1122,6 +1130,11 @@ packages:
   flatbuffers@24.12.23:
     resolution: {integrity: sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1324,6 +1337,16 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -1898,6 +1921,10 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.50.0':
     optional: true
 
+  '@playwright/test@1.58.2':
+    dependencies:
+      playwright: 1.58.2
+
   '@preact/preset-vite@2.10.3(@babel/core@7.29.0)(preact@10.28.4)(rollup@4.59.0)(vite@7.3.1(@types/node@20.19.34)(jiti@2.6.1)(lightningcss@1.31.1))':
     dependencies:
       '@babel/core': 7.29.0
@@ -2407,6 +2434,9 @@ snapshots:
 
   flatbuffers@24.12.23: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -2591,6 +2621,14 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.6:
     dependencies:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   plugins: [tailwindcss(), preact(), wasm(), topLevelAwait()],
   test: {
     pool: "forks",
+    exclude: ["e2e/**", "node_modules/**"],
   },
   server: {
     headers: {


### PR DESCRIPTION
## Summary

- Playwright によるクロスブラウザ E2E テストを導入（Chromium / Firefox / WebKit）
- ファイルアップロード → 検証 → GT集計自動表示 → クロス集計の主要フローをカバー
- CI ワークフロー（`.github/workflows/e2e.yml`）を追加: PR=Chromium のみ、main push=全3ブラウザの2層戦略

## Test plan

- [x] `pnpm check` パス確認
- [x] `pnpm e2e` で全3ブラウザ（9テスト）パス確認
- [x] `pnpm e2e --project=chromium` で単一ブラウザ絞り込み確認
- [ ] CI での E2E ワークフロー実行確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)