### PR TITLE
refactor: NA_VALUE関連の変数名をNO_ANSWER_VALUE系にrename

### DIFF
--- a/src/lib/agg/aggregateCross.ts
+++ b/src/lib/agg/aggregateCross.ts
@@ -9,7 +9,7 @@ import {
   maWeightedCountExpr,
   maShownCondition,
   maNoneSelectedCondition,
-  NA_VALUE,
+  NO_ANSWER_VALUE,
 } from "./sqlHelpers";
 
 type CrossSliceData = {
@@ -153,22 +153,22 @@ class CrossAggregator {
 
     const result = await this.conn.query(sql);
     const rowMap = new Map<string, number[]>();
-    const naMap = new Map<string, number>();
+    const noAnswerMap = new Map<string, number>();
     const nMap = new Map<string, number>();
     for (const r of result.toArray()) {
       const cv = String(r.cv);
       const counts = columns.map((_, i) => Number(r[`c${i}`] ?? 0));
       rowMap.set(cv, counts);
-      naMap.set(cv, Number(r.na_cnt ?? 0));
+      noAnswerMap.set(cv, Number(r.na_cnt ?? 0));
       nMap.set(cv, Number(r.n ?? 0));
     }
 
-    const hasNA = [...naMap.values()].some((v) => v > 0);
-    const resultCodes = hasNA ? [...codes, NA_VALUE] : codes;
+    const hasNoAnswer = [...noAnswerMap.values()].some((v) => v > 0);
+    const resultCodes = hasNoAnswer ? [...codes, NO_ANSWER_VALUE] : codes;
     const data: CrossSliceData[] = crossValues.map((cv) => {
       const rowCounts = rowMap.get(cv);
       const counts = columns.map((_col, maIdx) => rowCounts?.[maIdx] ?? 0);
-      if (hasNA) counts.push(naMap.get(cv) ?? 0);
+      if (hasNoAnswer) counts.push(noAnswerMap.get(cv) ?? 0);
       return { code: cv, n: nMap.get(cv) ?? 0, counts };
     });
     return this.buildSlices(data, resultCodes);
@@ -220,11 +220,11 @@ class CrossAggregator {
     const result = await this.conn.query(sql);
     const row = result.toArray()[0];
 
-    const hasNA = this.crossQ.codes.some((_, c) => Number(row[`na_c${c}`] ?? 0) > 0);
-    const resultCodes = hasNA ? [...codes, NA_VALUE] : codes;
+    const hasNoAnswer = this.crossQ.codes.some((_, c) => Number(row[`na_c${c}`] ?? 0) > 0);
+    const resultCodes = hasNoAnswer ? [...codes, NO_ANSWER_VALUE] : codes;
     const data: CrossSliceData[] = this.crossQ.codes.map((crossCode, c) => {
       const counts = columns.map((_col, r) => Number(row[`r${r}c${c}`] ?? 0));
-      if (hasNA) counts.push(Number(row[`na_c${c}`] ?? 0));
+      if (hasNoAnswer) counts.push(Number(row[`na_c${c}`] ?? 0));
       return { code: crossCode, n: Number(row[`n_c${c}`] ?? 0), counts };
     });
     return this.buildSlices(data, resultCodes);

--- a/src/lib/agg/aggregateGt.ts
+++ b/src/lib/agg/aggregateGt.ts
@@ -9,7 +9,7 @@ import {
   maWeightedCountExpr,
   maShownCondition,
   maNoneSelectedCondition,
-  NA_VALUE,
+  NO_ANSWER_VALUE,
 } from "./sqlHelpers";
 
 export async function aggregateGt(
@@ -86,7 +86,7 @@ class GtAggregator {
     if (naCount > 0) {
       const naPct = questionN > 0 ? (naCount / questionN) * 100 : 0;
       cells.push({ count: naCount, pct: naPct });
-      resultCodes.push(NA_VALUE);
+      resultCodes.push(NO_ANSWER_VALUE);
     }
 
     return { codes: resultCodes, slices: [{ code: null, n: questionN, cells }] };

--- a/src/lib/agg/buildTallies.ts
+++ b/src/lib/agg/buildTallies.ts
@@ -2,7 +2,7 @@ import type * as duckdb from "@duckdb/duckdb-wasm";
 import type { Question, AggResult, Tally, Axis } from "./types";
 import { aggregateGt } from "./aggregateGt";
 import { aggregateCross } from "./aggregateCross";
-import { NA_VALUE } from "./sqlHelpers";
+import { NO_ANSWER_VALUE } from "./sqlHelpers";
 import { t } from "../i18n";
 
 export async function buildTallies(
@@ -26,17 +26,17 @@ export async function buildTallies(
 function toTally(question: Question, aggResult: AggResult, byQuestion?: Question): Tally {
   // Build labels including NA if present in codes
   const labels: Record<string, string> = { ...question.labels };
-  if (aggResult.codes.includes(NA_VALUE)) {
-    labels[NA_VALUE] = t("label.na");
+  if (aggResult.codes.includes(NO_ANSWER_VALUE)) {
+    labels[NO_ANSWER_VALUE] = t("label.noAnswer");
   }
 
   let by: Axis | null = null;
   if (byQuestion) {
     const axisLabels: Record<string, string> = { ...byQuestion.labels };
-    // Check if any slice code is NA_VALUE to add NA label
-    const hasNA = aggResult.slices.some((s) => s.code === NA_VALUE);
-    if (hasNA) {
-      axisLabels[NA_VALUE] = t("label.na");
+    // Check if any slice code is NO_ANSWER_VALUE to add no-answer label
+    const hasNoAnswer = aggResult.slices.some((s) => s.code === NO_ANSWER_VALUE);
+    if (hasNoAnswer) {
+      axisLabels[NO_ANSWER_VALUE] = t("label.noAnswer");
     }
     by = { code: byQuestion.code, label: byQuestion.label, labels: axisLabels };
   }

--- a/src/lib/agg/sqlHelpers.ts
+++ b/src/lib/agg/sqlHelpers.ts
@@ -29,4 +29,4 @@ export function maNoneSelectedCondition(cols: string[]): string {
   return cols.map((c) => `"${esc(c)}" != 1`).join(" AND ");
 }
 /** No-answer marker */
-export const NA_VALUE = "N/A";
+export const NO_ANSWER_VALUE = "N/A";

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -80,7 +80,7 @@ const en: Record<string, string> = {
   "export.long.crossAxis": "Cross Axis",
   "export.long.crossValue": "Cross Value",
   "export.long.count": "Count",
-  "label.na": "No answer",
+  "label.noAnswer": "No answer",
 
   // Chart type
   "chart.barH": "Horizontal Bar",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -80,7 +80,7 @@ const ja: Record<string, string> = {
   "export.long.crossAxis": "クロス軸",
   "export.long.crossValue": "クロス値",
   "export.long.count": "度数",
-  "label.na": "無回答",
+  "label.noAnswer": "無回答",
 
   // Chart type
   "chart.barH": "横棒",


### PR DESCRIPTION
## Summary
- 将来のNAタイプ追加に備え、無回答（No answer）マーカー関連の命名を明確化
- `NA_VALUE` → `NO_ANSWER_VALUE`、`hasNA` → `hasNoAnswer`、`naMap` → `noAnswerMap`
- ロケールキー `label.na` → `label.noAnswer`

## Test plan
- [x] `pnpm check` (fmt:check + lint + tsc) 通過
- [x] `pnpm test` 全662テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)