### PR TITLE
ci: PRに毎回ベンチマーク結果をコメント

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,8 +37,5 @@ jobs:
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: bench
           auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-          alert-threshold: "150%"
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          comment-on-alert: true
-          fail-on-alert: false
-          alert-comment-cc-users: "@Yuki-bach"
+          comment-always: true

--- a/bench/run.ts
+++ b/bench/run.ts
@@ -195,7 +195,7 @@ async function main(): Promise<void> {
   // Write JSON for github-action-benchmark (customSmallerIsBetter format)
   if (process.env.BENCH_OUTPUT) {
     const benchmarkEntries = results.map((r) => ({
-      name: `${r.pattern} (${r.rows} rows, cross=${r.cross})`,
+      name: `${r.pattern} (${r.rows} rows, ${r.cols} cols, cross=${r.cross})`,
       unit: "ms",
       value: Math.round(r.medianMs * 10) / 10,
     }));


### PR DESCRIPTION
## Summary
- `benchmark-action/github-action-benchmark` の `comment-always: true` を有効化し、PRごとにベンチマーク結果がコメントされるように変更
- 不要になった alert 関連設定（`alert-threshold`, `comment-on-alert`, `fail-on-alert`, `alert-comment-cc-users`）を削除

## Test plan
- [ ] PRでベンチマークCIが走り、コメントが投稿されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)