### PR TITLE
feat: Questionにcrossableフラグを追加

### DIFF
--- a/src/components/AggregationScreen.tsx
+++ b/src/components/AggregationScreen.tsx
@@ -38,7 +38,7 @@ export default function AggregationScreen({ csv, layout, dateWarnings }: Aggrega
     setErrorMsg("");
 
     const wCol = weightEnabled ? weightCol : "";
-    const crossCols = questions.filter((q) => q.crossable && crossSelected[q.code]);
+    const crossCols = questions.filter((q) => crossSelected[q.code]);
 
     try {
       const tallies = await runAggregation(questions, crossCols, wCol);

--- a/src/components/AggregationScreen.tsx
+++ b/src/components/AggregationScreen.tsx
@@ -38,7 +38,7 @@ export default function AggregationScreen({ csv, layout, dateWarnings }: Aggrega
     setErrorMsg("");
 
     const wCol = weightEnabled ? weightCol : "";
-    const crossCols = questions.filter((q) => crossSelected[q.code]);
+    const crossCols = questions.filter((q) => q.crossable && crossSelected[q.code]);
 
     try {
       const tallies = await runAggregation(questions, crossCols, wCol);
@@ -86,7 +86,7 @@ export default function AggregationScreen({ csv, layout, dateWarnings }: Aggrega
             aria-label={t("section.cross.label")}
           >
             <CrossConfig
-              questions={questions}
+              questions={questions.filter((q) => q.crossable)}
               crossSelected={crossSelected}
               onToggle={(key, checked) => setCrossSelected((prev) => ({ ...prev, [key]: checked }))}
             />

--- a/src/lib/agg/types.ts
+++ b/src/lib/agg/types.ts
@@ -7,6 +7,7 @@ export interface Question {
   codes: string[];
   label: string;
   labels: Record<string, string>;
+  crossable: boolean;
 }
 
 export type AggInput = Pick<Question, "type" | "columns" | "codes">;

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -72,6 +72,7 @@ export function buildQuestions(layout: Layout): Question[] {
       codes: (e.items ?? []).map((i) => i.code),
       label: e.label ?? e.key,
       labels: Object.fromEntries((e.items ?? []).map((i) => [i.code, i.label])),
+      crossable: true,
     }));
 }
 

--- a/tests/layout.test.ts
+++ b/tests/layout.test.ts
@@ -96,6 +96,7 @@ describe("buildQuestions", () => {
       codes: ["1", "2"],
       label: "Gender",
       labels: { "1": "Male", "2": "Female" },
+      crossable: true,
     });
   });
 
@@ -109,6 +110,7 @@ describe("buildQuestions", () => {
       codes: ["1", "2", "3"],
       label: "Hobbies",
       labels: { "1": "Sports", "2": "Music", "3": "Reading" },
+      crossable: true,
     });
   });
 


### PR DESCRIPTION
## Summary
- `Question`型に`crossable: boolean`を追加し、クロス軸になれるかをQuestion自身が宣言的に持つように変更
- `buildQuestions()`でSA/MAともに`crossable: true`を付与
- `AggregationScreen`でCrossConfigへの表示・crossColsフィルタに`q.crossable`を使用

## Test plan
- [x] `pnpm check` 通過（tsc, lint, fmt）
- [x] `pnpm test` 全662テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)