### PR TITLE
ci: benchmark結果コメント投稿失敗時にCIを失敗させない

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,6 +30,7 @@ jobs:
         run: BENCH_OUTPUT=bench/output.json pnpm bench
 
       - name: Store benchmark result
+        continue-on-error: true
         uses: benchmark-action/github-action-benchmark@v1
         with:
           tool: customSmallerIsBetter


### PR DESCRIPTION
## Summary
- `benchmark-action/github-action-benchmark` のステップに `continue-on-error: true` を追加
- GitHub APIの一時的な500エラーでPRコメント投稿が失敗した際、CI全体が失敗するのを防ぐ
- ベンチマーク結果自体はgh-pagesブランチに保存済みのため、コメント投稿失敗による実害はなし

## Background
PRへのベンチマーク結果コメント投稿時に `POST /repos/.../pulls/.../reviews` が GitHub API側で500を返すことがあり、再実行すれば成功するがflakyになっていた。

## Test plan
- [ ] PRのCIが正常に通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)