### PR TITLE
refactor: AggResult → AggOutput にリネーム

### DIFF
--- a/src/lib/agg/aggregateCross.ts
+++ b/src/lib/agg/aggregateCross.ts
@@ -1,7 +1,7 @@
 /** Cross-tabulation aggregation — one cross axis at a time */
 
 import type * as duckdb from "@duckdb/duckdb-wasm";
-import type { AggInput, AggResult } from "./types";
+import type { AggInput, AggOutput } from "./types";
 import {
   esc,
   weightExpr,
@@ -23,7 +23,7 @@ export async function aggregateCross(
   question: AggInput,
   by: AggInput,
   weightCol: string,
-): Promise<AggResult> {
+): Promise<AggOutput> {
   const ca = new CrossAggregator(conn, weightCol, by);
   const isMainSa = question.type === "SA";
   const isCrossSa = by.type === "SA";
@@ -43,7 +43,7 @@ class CrossAggregator {
 
   // ── SA main × SA cross ──
 
-  async saSA(column: string, codes: string[]): Promise<AggResult> {
+  async saSA(column: string, codes: string[]): Promise<AggOutput> {
     const crossCol = this.crossQ.columns[0];
     const crossValues = this.crossQ.codes;
     const wExpr = weightExpr(this.weightCol);
@@ -88,7 +88,7 @@ class CrossAggregator {
 
   // ── SA main × MA cross ──
 
-  async saMA(column: string, codes: string[]): Promise<AggResult> {
+  async saMA(column: string, codes: string[]): Promise<AggOutput> {
     const selectClauses = this.crossQ.columns.map(
       (maCol, i) => `${maWeightedCountExpr(maCol, this.weightCol)} AS c${i}`,
     );
@@ -126,7 +126,7 @@ class CrossAggregator {
 
   // ── MA main × SA cross ──
 
-  async maSA(columns: string[], codes: string[]): Promise<AggResult> {
+  async maSA(columns: string[], codes: string[]): Promise<AggOutput> {
     const crossCol = this.crossQ.columns[0];
     const crossValues = this.crossQ.codes;
     const wExpr = weightExpr(this.weightCol);
@@ -176,7 +176,7 @@ class CrossAggregator {
 
   // ── shared slice builder ──
 
-  private buildSlices(data: CrossSliceData[], codes: string[]): AggResult {
+  private buildSlices(data: CrossSliceData[], codes: string[]): AggOutput {
     const slices = data.map(({ code, n, counts }) => ({
       code,
       n,
@@ -190,7 +190,7 @@ class CrossAggregator {
 
   // ── MA main × MA cross ──
 
-  async maMA(columns: string[], codes: string[]): Promise<AggResult> {
+  async maMA(columns: string[], codes: string[]): Promise<AggOutput> {
     const shownCond = maShownCondition(columns);
 
     const selectClauses: string[] = [];

--- a/src/lib/agg/aggregateGt.ts
+++ b/src/lib/agg/aggregateGt.ts
@@ -1,7 +1,7 @@
 /** GT (Grand Total) aggregation — SA and MA */
 
 import type * as duckdb from "@duckdb/duckdb-wasm";
-import type { AggInput, AggResult } from "./types";
+import type { AggInput, AggOutput } from "./types";
 import {
   esc,
   weightExpr,
@@ -16,7 +16,7 @@ export async function aggregateGt(
   conn: duckdb.AsyncDuckDBConnection,
   question: AggInput,
   weightCol: string,
-): Promise<AggResult> {
+): Promise<AggOutput> {
   const gt = new GtAggregator(conn, weightCol);
   return question.type === "SA"
     ? gt.aggregateSA(question.columns[0], question.codes)
@@ -29,7 +29,7 @@ class GtAggregator {
     private weightCol: string,
   ) {}
 
-  async aggregateSA(column: string, codes: string[]): Promise<AggResult> {
+  async aggregateSA(column: string, codes: string[]): Promise<AggOutput> {
     const wExpr = weightExpr(this.weightCol);
     const sql = `
       SELECT
@@ -55,7 +55,7 @@ class GtAggregator {
     return { codes, slices: [{ code: null, n, cells }] };
   }
 
-  async aggregateMA(columns: string[], codes: string[]): Promise<AggResult> {
+  async aggregateMA(columns: string[], codes: string[]): Promise<AggOutput> {
     const selectClauses = columns.map((col, i) => {
       return `${maWeightedCountExpr(col, this.weightCol)} AS c${i}`;
     });

--- a/src/lib/agg/buildTallies.ts
+++ b/src/lib/agg/buildTallies.ts
@@ -1,7 +1,7 @@
 import type * as duckdb from "@duckdb/duckdb-wasm";
 import type {
   Question,
-  AggResult,
+  AggOutput,
   Tally,
   CategoricalTally,
   NumericTally,
@@ -43,7 +43,7 @@ export async function buildTallies(
 
 function toCategoricalTally(
   question: Question,
-  aggResult: AggResult,
+  aggResult: AggOutput,
   byQuestion?: Question,
 ): CategoricalTally {
   const labels: Record<string, string> = { ...question.labels };
@@ -80,7 +80,7 @@ function toNaTally(
   };
 }
 
-function buildAxis(aggResult: AggResult, byQuestion?: Question): Axis | null {
+function buildAxis(aggResult: AggOutput, byQuestion?: Question): Axis | null {
   if (!byQuestion) return null;
   const axisLabels: Record<string, string> = { ...byQuestion.labels };
   const hasNoAnswer = aggResult.slices.some((s) => s.code === NO_ANSWER_VALUE);

--- a/src/lib/agg/types.ts
+++ b/src/lib/agg/types.ts
@@ -23,7 +23,7 @@ export interface Slice {
 }
 
 /** aggregate() の戻り値 — rawdata 由来のみ */
-export interface AggResult {
+export interface AggOutput {
   codes: string[];
   slices: Slice[];
 }

--- a/tests/helpers/invariants.ts
+++ b/tests/helpers/invariants.ts
@@ -1,8 +1,8 @@
 import { expect } from "vitest";
-import type { AggResult } from "../../src/lib/agg/types";
+import type { AggOutput } from "../../src/lib/agg/types";
 
 export function assertGtInvariants(
-  result: AggResult,
+  result: AggOutput,
   type: "SA" | "MA",
 ): void {
   expect(result.slices).toHaveLength(1);
@@ -34,7 +34,7 @@ export function assertGtInvariants(
 }
 
 export function assertCrossInvariants(
-  result: AggResult,
+  result: AggOutput,
   type: "SA" | "MA",
   expectedSliceCount: number,
 ): void {


### PR DESCRIPTION
## Summary
- `AggResult` を `AggOutput` にリネームし、`AggInput` / `AggOutput` の対称性を統一
- 型定義(`types.ts`)、集計ロジック(`aggregateGt.ts`, `aggregateCross.ts`, `buildTallies.ts`)、テストヘルパー(`invariants.ts`)を更新

## Test plan
- [x] `pnpm check` (型チェック + lint + format) 通過
- [x] `pnpm test` 全1651テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)