### PR TITLE
refactor: NumericTallyを統合し単一Tally型に統一

### DIFF
--- a/src/components/aggregation/ChartCardBody.tsx
+++ b/src/components/aggregation/ChartCardBody.tsx
@@ -1,5 +1,5 @@
 import { useRef, useEffect } from "preact/hooks";
-import type { CategoricalTally } from "../../lib/agg/types";
+import type { Tally } from "../../lib/agg/types";
 import { Chart, getSeriesColor, getThemeColors, type PaletteId } from "../../lib/chartConfig";
 
 import type { ChartConfiguration } from "chart.js";
@@ -7,8 +7,8 @@ import type { ChartConfiguration } from "chart.js";
 export type ChartType = "bar-h" | "bar-v" | "obi";
 
 interface ChartCardBodyProps {
-  gtTally: CategoricalTally;
-  crossTallies: CategoricalTally[];
+  gtTally: Tally;
+  crossTallies: Tally[];
   gtChartType: ChartType;
   paletteId: PaletteId;
 }
@@ -57,13 +57,13 @@ export function ChartCardBody({
   );
 }
 
-function resolveLabel(code: string, tally: CategoricalTally): string {
+function resolveLabel(code: string, tally: Tally): string {
   return tally.labels[code];
 }
 
 function buildGtChart(
   canvas: HTMLCanvasElement,
-  tally: CategoricalTally,
+  tally: Tally,
   chartType: ChartType,
   theme: ReturnType<typeof getThemeColors>,
   paletteId: PaletteId,
@@ -153,8 +153,8 @@ function buildGtChart(
 
 function buildCrossChart(
   canvas: HTMLCanvasElement,
-  gtTally: CategoricalTally,
-  crossTallies: CategoricalTally[],
+  gtTally: Tally,
+  crossTallies: Tally[],
   gtChartType: ChartType,
   theme: ReturnType<typeof getThemeColors>,
   paletteId: PaletteId,

--- a/src/components/aggregation/CrossTable.tsx
+++ b/src/components/aggregation/CrossTable.tsx
@@ -1,4 +1,4 @@
-import type { Tally, Slice, Axis } from "../../lib/agg/types";
+import type { Tally, Slice } from "../../lib/agg/types";
 import { t } from "../../lib/i18n";
 import type { PctDirection } from "./viewTypes";
 import { formatN } from "../../lib/format";
@@ -17,28 +17,14 @@ export function CrossTable({ gtTally, crossTallies, pctDir }: CrossTableProps) {
   return <VerticalCrossTable gtTally={gtTally} crossTallies={crossTallies} />;
 }
 
-function resolveAxisLabel(code: string, axis: Axis): string {
-  return axis.labels[code];
-}
-
 const TH_BASE = "py-3 px-4 text-xs font-bold tracking-wide border-b-2 border-border-strong";
 const TD_BASE = "py-3 px-4 border-b border-row-border leading-[1.2]";
 const MONO = "text-right tabular-nums font-mono";
 
-interface CrossGroup {
-  axis: Axis;
-  tally: Tally;
-}
-
 function VerticalCrossTable({ gtTally, crossTallies }: { gtTally: Tally; crossTallies: Tally[] }) {
   const gtSlice = gtTally.slices[0];
   const codes = gtTally.codes;
-
-  const crossGroups: CrossGroup[] = crossTallies.map((ct) => ({
-    axis: ct.by!,
-    tally: ct,
-  }));
-  const hasMultipleAxes = crossGroups.length > 1;
+  const hasMultipleAxes = crossTallies.length > 1;
 
   return (
     <table class="w-full border-collapse text-sm tabular-nums min-w-[400px]">
@@ -49,26 +35,26 @@ function VerticalCrossTable({ gtTally, crossTallies }: { gtTally: Tally; crossTa
           <th colSpan={2} class={`${TH_BASE} text-center bg-gt-bg text-accent`}>
             {t("table.total")}
           </th>
-          {crossGroups.map((group) => (
+          {crossTallies.map((ct) => (
             <th
-              key={group.axis.code}
-              colSpan={group.tally.slices.length}
+              key={ct.by!.code}
+              colSpan={ct.slices.length}
               class={`${TH_BASE} text-center bg-cross-bg border-l border-border text-accent2 ${hasMultipleAxes ? "border-l-2 border-l-border-strong" : ""}`}
             >
-              {group.axis.label}
+              {ct.by!.label}
             </th>
           ))}
         </tr>
         <tr>
           <Th right>n</Th>
           <Th right>%</Th>
-          {crossGroups.map((group, gi) =>
-            group.tally.slices.map((slice, si) => (
+          {crossTallies.map((ct, gi) =>
+            ct.slices.map((slice, si) => (
               <th
-                key={`${group.axis.code}-${slice.code}`}
+                key={`${ct.by!.code}-${slice.code}`}
                 class={`${TH_BASE} text-right text-xs whitespace-nowrap border-l border-row-border bg-surface2 ${hasMultipleAxes && si === 0 && gi > 0 ? "border-l-2 border-l-border-strong" : ""}`}
               >
-                {resolveAxisLabel(slice.code!, group.axis)}
+                {ct.by!.labels[slice.code!]}
                 <br />
                 <span class="text-muted text-xs font-normal">n={formatN(slice.n)}</span>
               </th>
@@ -88,12 +74,12 @@ function VerticalCrossTable({ gtTally, crossTallies }: { gtTally: Tally; crossTa
               <Td right mono class="text-muted">
                 {gtCell.pct.toFixed(1)}%
               </Td>
-              {crossGroups.map((group, gi) =>
-                group.tally.slices.map((slice, si) => {
+              {crossTallies.map((ct, gi) =>
+                ct.slices.map((slice, si) => {
                   const cell = slice.cells[i];
                   return (
                     <td
-                      key={`${group.axis.code}-${slice.code}`}
+                      key={`${ct.by!.code}-${slice.code}`}
                       class={`${TD_BASE} ${MONO} text-accent2 border-l border-l-row-border ${hasMultipleAxes && si === 0 && gi > 0 ? "border-l-2 border-l-border-strong" : ""}`}
                     >
                       {cell ? cell.pct.toFixed(1) + "%" : "-"}
@@ -118,11 +104,6 @@ function TransposedCrossTable({
 }) {
   const gtSlice = gtTally.slices[0];
   const codes = gtTally.codes;
-
-  const crossGroups: CrossGroup[] = crossTallies.map((ct) => ({
-    axis: ct.by!,
-    tally: ct,
-  }));
 
   return (
     <table class="w-full border-collapse text-sm tabular-nums min-w-[400px]">
@@ -159,21 +140,21 @@ function TransposedCrossTable({
         </tr>
 
         {/* Cross sub rows */}
-        {crossGroups.map((group) => (
+        {crossTallies.map((ct) => (
           <>
-            <tr key={`hdr-${group.axis.code}`}>
+            <tr key={`hdr-${ct.by!.code}`}>
               <td
                 colSpan={codes.length + 1}
                 class="py-3 px-4 bg-cross-bg text-accent2 font-bold text-xs tracking-wide border-b-2 border-border-strong border-t-2 border-t-border-strong"
               >
-                {group.axis.label}
+                {ct.by!.label}
               </td>
             </tr>
-            {group.tally.slices.map((slice) => (
+            {ct.slices.map((slice) => (
               <TransposedSubRow
-                key={`${group.axis.code}-${slice.code}`}
+                key={`${ct.by!.code}-${slice.code}`}
                 slice={slice}
-                axis={group.axis}
+                by={ct.by!}
                 codes={codes}
               />
             ))}
@@ -184,13 +165,21 @@ function TransposedCrossTable({
   );
 }
 
-function TransposedSubRow({ slice, axis, codes }: { slice: Slice; axis: Axis; codes: string[] }) {
+function TransposedSubRow({
+  slice,
+  by,
+  codes,
+}: {
+  slice: Slice;
+  by: Tally["by"] & {};
+  codes: string[];
+}) {
   return (
     <tr>
       <td
         class={`${TD_BASE} text-left text-xs font-bold whitespace-nowrap border-r-2 border-r-border-strong text-accent2`}
       >
-        {resolveAxisLabel(slice.code!, axis)}
+        {by.labels[slice.code!]}
         <br />
         <span class="text-muted text-xs font-normal">n={formatN(slice.n)}</span>
       </td>

--- a/src/components/aggregation/CrossTable.tsx
+++ b/src/components/aggregation/CrossTable.tsx
@@ -1,12 +1,12 @@
-import type { CategoricalTally, Slice, Axis } from "../../lib/agg/types";
+import type { Tally, Slice, Axis } from "../../lib/agg/types";
 import { t } from "../../lib/i18n";
 import type { PctDirection } from "./viewTypes";
 import { formatN } from "../../lib/format";
 import { Th, Td } from "./TableCells";
 
 interface CrossTableProps {
-  gtTally: CategoricalTally;
-  crossTallies: CategoricalTally[];
+  gtTally: Tally;
+  crossTallies: Tally[];
   pctDir: PctDirection;
 }
 
@@ -27,16 +27,10 @@ const MONO = "text-right tabular-nums font-mono";
 
 interface CrossGroup {
   axis: Axis;
-  tally: CategoricalTally;
+  tally: Tally;
 }
 
-function VerticalCrossTable({
-  gtTally,
-  crossTallies,
-}: {
-  gtTally: CategoricalTally;
-  crossTallies: CategoricalTally[];
-}) {
+function VerticalCrossTable({ gtTally, crossTallies }: { gtTally: Tally; crossTallies: Tally[] }) {
   const gtSlice = gtTally.slices[0];
   const codes = gtTally.codes;
 
@@ -119,8 +113,8 @@ function TransposedCrossTable({
   gtTally,
   crossTallies,
 }: {
-  gtTally: CategoricalTally;
-  crossTallies: CategoricalTally[];
+  gtTally: Tally;
+  crossTallies: Tally[];
 }) {
   const gtSlice = gtTally.slices[0];
   const codes = gtTally.codes;

--- a/src/components/aggregation/GtTable.tsx
+++ b/src/components/aggregation/GtTable.tsx
@@ -1,9 +1,9 @@
-import type { CategoricalTally } from "../../lib/agg/types";
+import type { Tally } from "../../lib/agg/types";
 import { formatN } from "../../lib/format";
 import { t } from "../../lib/i18n";
 import { Th, Td } from "./TableCells";
 interface GtTableProps {
-  tally: CategoricalTally;
+  tally: Tally;
   maxPct: number;
 }
 

--- a/src/components/aggregation/NaChartCardBody.tsx
+++ b/src/components/aggregation/NaChartCardBody.tsx
@@ -1,12 +1,12 @@
 import { useRef, useEffect } from "preact/hooks";
-import type { NumericTally } from "../../lib/agg/types";
+import type { Tally } from "../../lib/agg/types";
 import { Chart, getSeriesColor, getThemeColors, type PaletteId } from "../../lib/chartConfig";
 import { t } from "../../lib/i18n";
 import type { ChartConfiguration } from "chart.js";
 
 interface NaChartCardBodyProps {
-  gtTally: NumericTally;
-  crossTallies: NumericTally[];
+  gtTally: Tally;
+  crossTallies: Tally[];
   paletteId: PaletteId;
 }
 
@@ -43,13 +43,14 @@ export function NaChartCardBody({ gtTally, crossTallies, paletteId }: NaChartCar
 
 function buildFreqChart(
   canvas: HTMLCanvasElement,
-  tally: NumericTally,
+  tally: Tally,
   theme: ReturnType<typeof getThemeColors>,
   paletteId: PaletteId,
 ): Chart {
-  const { freq, stats } = tally.slices[0];
-  const labels = freq.map((f) => String(f.value));
-  const data = freq.map((f) => f.count);
+  const slice = tally.slices[0];
+  const stats = slice.stats!;
+  const labels = tally.codes;
+  const data = slice.cells.map((c) => c.count);
 
   return new Chart(canvas, {
     type: "bar",
@@ -98,8 +99,8 @@ function buildFreqChart(
 
 function buildMeanComparisonChart(
   canvas: HTMLCanvasElement,
-  _gtTally: NumericTally,
-  crossTallies: NumericTally[],
+  _gtTally: Tally,
+  crossTallies: Tally[],
   theme: ReturnType<typeof getThemeColors>,
   paletteId: PaletteId,
 ): Chart {
@@ -107,7 +108,7 @@ function buildMeanComparisonChart(
     const axis = ct.by!;
     return ct.slices.map((s) => ({
       label: axis.labels[s.code!],
-      stats: s.stats,
+      stats: s.stats!,
     }));
   });
 

--- a/src/components/aggregation/NaCrossTable.tsx
+++ b/src/components/aggregation/NaCrossTable.tsx
@@ -1,10 +1,10 @@
-import type { NumericTally } from "../../lib/agg/types";
+import type { Tally } from "../../lib/agg/types";
 import { formatN } from "../../lib/format";
 import { t } from "../../lib/i18n";
 
 interface NaCrossTableProps {
-  gtTally: NumericTally;
-  crossTallies: NumericTally[];
+  gtTally: Tally;
+  crossTallies: Tally[];
 }
 
 const STAT_KEYS = ["n", "mean", "median", "sd", "min", "max"] as const;
@@ -14,7 +14,7 @@ const TD_BASE = "py-3 px-4 border-b border-row-border leading-[1.2]";
 const MONO = "text-right tabular-nums font-mono";
 
 export function NaCrossTable({ gtTally, crossTallies }: NaCrossTableProps) {
-  const gtStats = gtTally.slices[0].stats;
+  const gtStats = gtTally.slices[0].stats!;
 
   const crossGroups = crossTallies.map((ct) => ({
     axis: ct.by!,
@@ -50,7 +50,7 @@ export function NaCrossTable({ gtTally, crossTallies }: NaCrossTableProps) {
               >
                 {group.axis.labels[slice.code!]}
                 <br />
-                <span class="text-muted text-xs font-normal">n={formatN(slice.stats.n)}</span>
+                <span class="text-muted text-xs font-normal">n={formatN(slice.n)}</span>
               </th>
             )),
           )}
@@ -67,7 +67,7 @@ export function NaCrossTable({ gtTally, crossTallies }: NaCrossTableProps) {
                   key={`${group.axis.code}-${slice.code}`}
                   class={`${TD_BASE} ${MONO} text-accent2 border-l border-l-row-border ${hasMultipleAxes && si === 0 && gi > 0 ? "border-l-2 border-l-border-strong" : ""}`}
                 >
-                  {formatStat(key, slice.stats[key])}
+                  {formatStat(key, slice.stats![key])}
                 </td>
               )),
             )}

--- a/src/components/aggregation/NaGtTable.tsx
+++ b/src/components/aggregation/NaGtTable.tsx
@@ -1,15 +1,15 @@
-import type { NumericTally } from "../../lib/agg/types";
+import type { Tally } from "../../lib/agg/types";
 import { t } from "../../lib/i18n";
 import { Th, Td } from "./TableCells";
 
 interface NaGtTableProps {
-  tally: NumericTally;
+  tally: Tally;
 }
 
 const STAT_KEYS = ["n", "mean", "median", "sd", "min", "max"] as const;
 
 export function NaGtTable({ tally }: NaGtTableProps) {
-  const { stats } = tally.slices[0];
+  const stats = tally.slices[0].stats!;
 
   return (
     <table class="w-full border-collapse text-sm tabular-nums">

--- a/src/components/aggregation/ResultCard.tsx
+++ b/src/components/aggregation/ResultCard.tsx
@@ -1,5 +1,4 @@
 import type { TallyGroup } from "../../lib/agg/groupByQuestion";
-import type { CategoricalTally, NumericTally } from "../../lib/agg/types";
 import { ChartCardBody } from "./ChartCardBody";
 import { CrossTable } from "./CrossTable";
 import { GtTable } from "./GtTable";
@@ -20,8 +19,7 @@ export function ResultCard({ group, viewMode, tableOpts, chartOpts }: ResultCard
   const { gtTally } = group;
   const hasCross = group.crossTallies.length > 0;
 
-  const gtN =
-    gtTally.type === "NA" ? (gtTally.slices[0]?.stats.n ?? 0) : (gtTally.slices[0]?.n ?? 0);
+  const gtN = gtTally.slices[0]?.n ?? 0;
 
   return (
     <div
@@ -44,34 +42,37 @@ function CardBody({ group, viewMode, tableOpts, chartOpts }: ResultCardProps) {
   const { gtTally, crossTallies } = group;
 
   if (gtTally.type === "NA") {
-    // 同一設問内のtallyは同じtypeなのでキャスト安全
-    const crossNa = crossTallies as NumericTally[];
     if (viewMode === "chart") {
       return (
-        <NaChartCardBody gtTally={gtTally} crossTallies={crossNa} paletteId={chartOpts.paletteId} />
+        <NaChartCardBody
+          gtTally={gtTally}
+          crossTallies={crossTallies}
+          paletteId={chartOpts.paletteId}
+        />
       );
     }
-    if (crossNa.length > 0) {
-      return <NaCrossTable gtTally={gtTally} crossTallies={crossNa} />;
+    if (crossTallies.length > 0) {
+      return <NaCrossTable gtTally={gtTally} crossTallies={crossTallies} />;
     }
     return <NaGtTable tally={gtTally} />;
   }
 
-  // SA | MA — 同一設問内のtallyは同じtypeなのでキャスト安全
-  const crossCat = crossTallies as CategoricalTally[];
+  // SA | MA
   if (viewMode === "chart") {
     const { saChartType, maChartType, paletteId } = chartOpts;
     return (
       <ChartCardBody
         gtTally={gtTally}
-        crossTallies={crossCat}
+        crossTallies={crossTallies}
         gtChartType={gtTally.type === "SA" ? saChartType : maChartType}
         paletteId={paletteId}
       />
     );
   }
-  if (crossCat.length > 0) {
-    return <CrossTable gtTally={gtTally} crossTallies={crossCat} pctDir={tableOpts.pctDirection} />;
+  if (crossTallies.length > 0) {
+    return (
+      <CrossTable gtTally={gtTally} crossTallies={crossTallies} pctDir={tableOpts.pctDirection} />
+    );
   }
   return <GtTable tally={gtTally} maxPct={tableOpts.maxPct} />;
 }

--- a/src/lib/agg/aggregateNa.ts
+++ b/src/lib/agg/aggregateNa.ts
@@ -1,8 +1,13 @@
 /** NA (Numerical Answer) aggregation — GT and Cross */
 
 import type * as duckdb from "@duckdb/duckdb-wasm";
-import type { AggInput, NumericSlice, NaStats, ValueCount } from "./types";
+import type { AggInput, AggOutput, NaStats, Slice } from "./types";
 import { esc, maShownCondition } from "./sqlHelpers";
+
+interface ValueCount {
+  value: number;
+  count: number;
+}
 
 // ── GT ──
 
@@ -10,14 +15,15 @@ export async function aggregateNaGt(
   conn: duckdb.AsyncDuckDBConnection,
   column: string,
   weightCol: string,
-): Promise<NumericSlice> {
+): Promise<AggOutput> {
   const valExpr = `CAST("${esc(column)}" AS DOUBLE)`;
   const whereCond = `"${esc(column)}" IS NOT NULL AND TRY_CAST("${esc(column)}" AS DOUBLE) IS NOT NULL`;
 
   const stats = await queryStats(conn, valExpr, whereCond, weightCol);
   const freq = await queryFreq(conn, valExpr, whereCond, weightCol);
 
-  return { code: null, freq, stats };
+  const { codes, cells } = freqToCells(freq, stats.n);
+  return { codes, slices: [{ code: null, n: stats.n, cells, stats }] };
 }
 
 // ── Cross (NA × SA or NA × MA) ──
@@ -27,11 +33,49 @@ export async function aggregateNaCross(
   naColumn: string,
   crossQ: AggInput,
   weightCol: string,
-): Promise<NumericSlice[]> {
+): Promise<AggOutput> {
   if (crossQ.type === "SA") {
     return crossSA(conn, naColumn, crossQ.columns[0], crossQ.codes, weightCol);
   }
   return crossMA(conn, naColumn, crossQ.columns, crossQ.codes, weightCol);
+}
+
+// ── Helpers ──
+
+function freqToCells(
+  freq: ValueCount[],
+  n: number,
+): { codes: string[]; cells: import("./types").Cell[] } {
+  const codes = freq.map((f) => String(f.value));
+  const cells = freq.map((f) => ({
+    count: f.count,
+    pct: n > 0 ? (f.count / n) * 100 : 0,
+  }));
+  return { codes, cells };
+}
+
+/** Union all value keys across slices, returning sorted codes and aligned cells per slice */
+function alignSlices(sliceData: { code: string; freq: ValueCount[]; stats: NaStats }[]): {
+  codes: string[];
+  slices: Slice[];
+} {
+  const allValues = new Set<number>();
+  for (const s of sliceData) {
+    for (const f of s.freq) allValues.add(f.value);
+  }
+  const sortedValues = [...allValues].sort((a, b) => a - b);
+  const codes = sortedValues.map(String);
+
+  const slices: Slice[] = sliceData.map((s) => {
+    const freqMap = new Map(s.freq.map((f) => [f.value, f.count]));
+    const cells = sortedValues.map((v) => {
+      const count = freqMap.get(v) ?? 0;
+      return { count, pct: s.stats.n > 0 ? (count / s.stats.n) * 100 : 0 };
+    });
+    return { code: s.code, n: s.stats.n, cells, stats: s.stats };
+  });
+
+  return { codes, slices };
 }
 
 // ── Internal ──
@@ -196,18 +240,21 @@ async function crossSA(
   crossCol: string,
   crossCodes: string[],
   weightCol: string,
-): Promise<NumericSlice[]> {
+): Promise<AggOutput> {
   const valExpr = `CAST("${esc(naColumn)}" AS DOUBLE)`;
   const whereCond = `"${esc(naColumn)}" IS NOT NULL AND TRY_CAST("${esc(naColumn)}" AS DOUBLE) IS NOT NULL`;
 
   const statsMap = await queryStatsGrouped(conn, valExpr, whereCond, weightCol, crossCol);
   const freqMap = await queryFreqGrouped(conn, valExpr, whereCond, weightCol, crossCol);
 
-  return crossCodes.map((code) => ({
+  const emptyStats: NaStats = { n: 0, mean: 0, median: 0, sd: 0, min: 0, max: 0 };
+  const sliceData = crossCodes.map((code) => ({
     code,
-    stats: statsMap.get(code) ?? { n: 0, mean: 0, median: 0, sd: 0, min: 0, max: 0 },
+    stats: statsMap.get(code) ?? emptyStats,
     freq: freqMap.get(code) ?? [],
   }));
+
+  return alignSlices(sliceData);
 }
 
 // ── NA × MA cross ──
@@ -218,17 +265,18 @@ async function crossMA(
   maCols: string[],
   maCodes: string[],
   weightCol: string,
-): Promise<NumericSlice[]> {
+): Promise<AggOutput> {
   const valExpr = `CAST("${esc(naColumn)}" AS DOUBLE)`;
   const baseWhere = `"${esc(naColumn)}" IS NOT NULL AND TRY_CAST("${esc(naColumn)}" AS DOUBLE) IS NOT NULL AND (${maShownCondition(maCols)})`;
 
-  const slices: NumericSlice[] = [];
+  const sliceData: { code: string; freq: ValueCount[]; stats: NaStats }[] = [];
   for (let i = 0; i < maCols.length; i++) {
     const maCol = maCols[i];
     const whereCond = `${baseWhere} AND "${esc(maCol)}" = 1`;
     const stats = await queryStats(conn, valExpr, whereCond, weightCol);
     const freq = await queryFreq(conn, valExpr, whereCond, weightCol);
-    slices.push({ code: maCodes[i], stats, freq });
+    sliceData.push({ code: maCodes[i], stats, freq });
   }
-  return slices;
+
+  return alignSlices(sliceData);
 }

--- a/src/lib/agg/buildTallies.ts
+++ b/src/lib/agg/buildTallies.ts
@@ -1,13 +1,5 @@
 import type * as duckdb from "@duckdb/duckdb-wasm";
-import type {
-  Question,
-  AggOutput,
-  Tally,
-  CategoricalTally,
-  NumericTally,
-  Axis,
-  NumericSlice,
-} from "./types";
+import type { Question, AggOutput, Tally, Axis } from "./types";
 import { aggregateGt } from "./aggregateGt";
 import { aggregateCross } from "./aggregateCross";
 import { aggregateNaGt, aggregateNaCross } from "./aggregateNa";
@@ -23,60 +15,46 @@ export async function buildTallies(
   const tallies: Tally[] = [];
   for (const q of questions) {
     if (q.type === "NA") {
-      const gtSlice = await aggregateNaGt(conn, q.columns[0], weightCol);
-      tallies.push(toNaTally(q, [gtSlice]));
+      const gtResult = await aggregateNaGt(conn, q.columns[0], weightCol);
+      tallies.push(toTally(q, gtResult));
       for (const cross of crossCols) {
-        const crossSlices = await aggregateNaCross(conn, q.columns[0], cross, weightCol);
-        tallies.push(toNaTally(q, crossSlices, cross));
+        const crossResult = await aggregateNaCross(conn, q.columns[0], cross, weightCol);
+        tallies.push(toTally(q, crossResult, cross));
       }
     } else {
       const gtResult = await aggregateGt(conn, q, weightCol);
-      tallies.push(toCategoricalTally(q, gtResult));
+      tallies.push(toTally(q, gtResult));
       for (const cross of crossCols) {
         const crossResult = await aggregateCross(conn, q, cross, weightCol);
-        tallies.push(toCategoricalTally(q, crossResult, cross));
+        tallies.push(toTally(q, crossResult, cross));
       }
     }
   }
   return tallies;
 }
 
-function toCategoricalTally(
-  question: Question,
-  aggResult: AggOutput,
-  byQuestion?: Question,
-): CategoricalTally {
+function toTally(question: Question, aggResult: AggOutput, byQuestion?: Question): Tally {
   const labels: Record<string, string> = { ...question.labels };
+
+  if (question.type === "NA") {
+    // NA: self-labeling (value string as label)
+    for (const code of aggResult.codes) {
+      labels[code] = code;
+    }
+  }
+
   if (aggResult.codes.includes(NO_ANSWER_VALUE)) {
     labels[NO_ANSWER_VALUE] = t("label.noAnswer");
   }
 
   return {
     questionCode: question.code,
-    type: question.type as "SA" | "MA",
+    type: question.type,
     label: question.label,
     labels,
     codes: aggResult.codes,
     by: buildAxis(aggResult, byQuestion),
     slices: aggResult.slices,
-  };
-}
-
-function toNaTally(
-  question: Question,
-  slices: NumericSlice[],
-  byQuestion?: Question,
-): NumericTally {
-  let by: Axis | null = null;
-  if (byQuestion) {
-    by = { code: byQuestion.code, label: byQuestion.label, labels: { ...byQuestion.labels } };
-  }
-  return {
-    type: "NA",
-    questionCode: question.code,
-    label: question.label,
-    by,
-    slices,
   };
 }
 

--- a/src/lib/agg/groupByQuestion.ts
+++ b/src/lib/agg/groupByQuestion.ts
@@ -1,4 +1,4 @@
-import type { Tally, CategoricalTally } from "./types";
+import type { Tally } from "./types";
 
 export interface TallyGroup {
   gtTally: Tally;
@@ -16,7 +16,7 @@ export function groupByQuestion(tallies: Tally[]): TallyGroup[] {
 export function computeMaxPct(tallies: Tally[]): number {
   return Math.max(
     ...tallies
-      .filter((t): t is CategoricalTally => t.by === null && t.type !== "NA")
+      .filter((t) => t.by === null && t.type !== "NA")
       .flatMap((t) => t.slices[0]?.cells.map((c) => c.pct) ?? []),
     0,
   );

--- a/src/lib/agg/types.ts
+++ b/src/lib/agg/types.ts
@@ -20,6 +20,7 @@ export interface Slice {
   code: string | null;
   n: number;
   cells: Cell[];
+  stats?: NaStats;
 }
 
 /** aggregate() の戻り値 — rawdata 由来のみ */
@@ -35,12 +36,6 @@ export interface Axis {
   labels: Record<string, string>; // { "1": "男性", ... }, NA 含む
 }
 
-/** NA (Numerical Answer) 用の型 */
-export interface ValueCount {
-  value: number;
-  count: number;
-}
-
 export interface NaStats {
   n: number;
   mean: number;
@@ -50,15 +45,9 @@ export interface NaStats {
   max: number;
 }
 
-export interface NumericSlice {
-  code: string | null;
-  freq: ValueCount[];
-  stats: NaStats;
-}
-
-/** 消費用フラット型 — Discriminated Union */
-export interface CategoricalTally {
-  type: "SA" | "MA";
+/** 消費用フラット型 */
+export interface Tally {
+  type: "SA" | "MA" | "NA";
   questionCode: string;
   label: string;
   by: Axis | null;
@@ -66,13 +55,3 @@ export interface CategoricalTally {
   labels: Record<string, string>;
   slices: Slice[];
 }
-
-export interface NumericTally {
-  type: "NA";
-  questionCode: string;
-  label: string;
-  by: Axis | null;
-  slices: NumericSlice[];
-}
-
-export type Tally = CategoricalTally | NumericTally;

--- a/src/lib/aiComment.ts
+++ b/src/lib/aiComment.ts
@@ -73,7 +73,7 @@ function summarizeResults(tallies: Tally[], weightCol: string, topN: number): st
 
   for (const tally of gtTallies) {
     if (tally.type === "NA") {
-      const { stats } = tally.slices[0];
+      const stats = tally.slices[0].stats!;
       lines.push(`${tally.questionCode}: ${tally.label} (NA, n=${stats.n})`);
       lines.push(
         `  mean=${stats.mean.toFixed(2)}, median=${stats.median.toFixed(2)}, sd=${stats.sd.toFixed(2)}`,

--- a/src/lib/export/formatters/grid.ts
+++ b/src/lib/export/formatters/grid.ts
@@ -1,4 +1,4 @@
-import type { Tally, CategoricalTally, NumericTally } from "../../agg/types";
+import type { Tally } from "../../agg/types";
 import { t } from "../../i18n";
 
 export interface ExportGrid {
@@ -20,7 +20,7 @@ export function buildExportGrids(tallies: Tally[]): ExportGrid[] {
 
 // ─── Internal ───────────────────────────────────────────────
 
-function resolveLabel(code: string, tally: CategoricalTally): string {
+function resolveLabel(code: string, tally: Tally): string {
   return tally.labels[code];
 }
 
@@ -29,7 +29,7 @@ function buildGtGrid(tally: Tally): ExportGrid {
   return buildCategoricalGtGrid(tally);
 }
 
-function buildCategoricalGtGrid(tally: CategoricalTally): ExportGrid {
+function buildCategoricalGtGrid(tally: Tally): ExportGrid {
   const slice = tally.slices[0];
   const headers = [
     [
@@ -58,8 +58,8 @@ function buildCategoricalGtGrid(tally: CategoricalTally): ExportGrid {
   return { questionCode: tally.questionCode, type: tally.type, headers, rows };
 }
 
-function buildNaGtGrid(tally: NumericTally): ExportGrid {
-  const { stats } = tally.slices[0];
+function buildNaGtGrid(tally: Tally): ExportGrid {
+  const stats = tally.slices[0].stats!;
   const headers = [[t("export.header.variable"), t("export.header.type"), t("table.option"), ""]];
   const rows: string[][] = NA_STAT_KEYS.map((key) => [
     tally.questionCode,
@@ -114,7 +114,7 @@ function buildCrossGrids(tallies: Tally[]): ExportGrid[] {
     const qCrossTallies = tallies.filter((t) => t.questionCode === qCode && t.by !== null);
 
     if (gtTally.type === "NA") {
-      return buildNaCrossGrid(gtTally, qCrossTallies as NumericTally[]);
+      return buildNaCrossGrid(gtTally, qCrossTallies);
     }
 
     const gtSlice = gtTally.slices[0];
@@ -153,8 +153,8 @@ function buildCrossGrids(tallies: Tally[]): ExportGrid[] {
   });
 }
 
-function buildNaCrossGrid(gtTally: NumericTally, crossTallies: NumericTally[]): ExportGrid {
-  const gtStats = gtTally.slices[0].stats;
+function buildNaCrossGrid(gtTally: Tally, crossTallies: Tally[]): ExportGrid {
+  const gtStats = gtTally.slices[0].stats!;
 
   const headerRow1 = [
     t("export.header.variable"),
@@ -181,7 +181,7 @@ function buildNaCrossGrid(gtTally: NumericTally, crossTallies: NumericTally[]): 
     ];
     for (const ct of crossTallies) {
       for (const slice of ct.slices) {
-        row.push(key === "n" ? slice.stats.n.toFixed(1) : slice.stats[key].toFixed(2));
+        row.push(key === "n" ? slice.stats!.n.toFixed(1) : slice.stats![key].toFixed(2));
       }
     }
     return row;

--- a/src/lib/export/formatters/longFormat.ts
+++ b/src/lib/export/formatters/longFormat.ts
@@ -22,26 +22,6 @@ export function talliesToLongRows(tallies: Tally[]): string[][] {
   for (const tally of tallies) {
     const crossAxis = tally.by === null ? total : tally.by.label;
 
-    if (tally.type === "NA") {
-      for (const slice of tally.slices) {
-        const crossValue = tally.by === null ? total : tally.by.labels[slice.code!];
-        const { stats, freq } = slice;
-        for (const f of freq) {
-          rows.push([
-            tally.questionCode,
-            "NA",
-            String(f.value),
-            crossAxis,
-            crossValue,
-            String(stats.n),
-            String(f.count),
-            String(stats.n > 0 ? (f.count / stats.n) * 100 : 0),
-          ]);
-        }
-      }
-      continue;
-    }
-
     for (const slice of tally.slices) {
       const crossValue = tally.by === null ? total : tally.by.labels[slice.code!];
 

--- a/tests/aggregateNa.test.ts
+++ b/tests/aggregateNa.test.ts
@@ -30,80 +30,93 @@ afterAll(async () => {
 
 describe("aggregateNaGt - unweighted", () => {
   it("returns correct stats for score column", async () => {
-    const slice = await aggregateNaGt(getConn(), "score", "");
+    const result = await aggregateNaGt(getConn(), "score", "");
 
+    expect(result.slices).toHaveLength(1);
+    const slice = result.slices[0];
     expect(slice.code).toBeNull();
     // Valid scores: 8,6,9,4,7,5,10,3,8 = 9 rows (row 10 has NULL)
-    expect(slice.stats.n).toBe(9);
+    expect(slice.stats!.n).toBe(9);
     // mean = (8+6+9+4+7+5+10+3+8)/9 = 60/9 ≈ 6.6667
-    expect(slice.stats.mean).toBeCloseTo(60 / 9, 2);
+    expect(slice.stats!.mean).toBeCloseTo(60 / 9, 2);
     // sorted: 3,4,5,6,7,8,8,9,10 → median = 7
-    expect(slice.stats.median).toBeCloseTo(7, 1);
-    expect(slice.stats.min).toBe(3);
-    expect(slice.stats.max).toBe(10);
-    expect(slice.stats.sd).toBeGreaterThan(0);
+    expect(slice.stats!.median).toBeCloseTo(7, 1);
+    expect(slice.stats!.min).toBe(3);
+    expect(slice.stats!.max).toBe(10);
+    expect(slice.stats!.sd).toBeGreaterThan(0);
   });
 
-  it("returns correct frequency distribution", async () => {
-    const slice = await aggregateNaGt(getConn(), "score", "");
+  it("returns correct frequency distribution as codes/cells", async () => {
+    const result = await aggregateNaGt(getConn(), "score", "");
 
     // Unique values: 3,4,5,6,7,8,9,10
-    const values = slice.freq.map((f) => f.value);
-    expect(values).toEqual([3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(result.codes).toEqual(["3", "4", "5", "6", "7", "8", "9", "10"]);
 
+    const slice = result.slices[0];
     // 8 appears twice, others once
-    const countFor8 = slice.freq.find((f) => f.value === 8)!.count;
-    expect(countFor8).toBe(2);
+    const idx8 = result.codes.indexOf("8");
+    expect(slice.cells[idx8].count).toBe(2);
 
-    const countFor3 = slice.freq.find((f) => f.value === 3)!.count;
-    expect(countFor3).toBe(1);
+    const idx3 = result.codes.indexOf("3");
+    expect(slice.cells[idx3].count).toBe(1);
+
+    // pct check: count=2 out of n=9 → 2/9*100 ≈ 22.22
+    expect(slice.cells[idx8].pct).toBeCloseTo((2 / 9) * 100, 1);
   });
 });
 
 describe("aggregateNaGt - weighted", () => {
   it("returns weighted stats", async () => {
-    const slice = await aggregateNaGt(getConn(), "score", "weight");
+    const result = await aggregateNaGt(getConn(), "score", "weight");
 
+    const slice = result.slices[0];
     // Weighted n = sum of weights for valid score rows
     // 1.2+0.9+1.5+0.8+1.1+1.0+1.3+0.7+1.4 = 9.9
-    expect(slice.stats.n).toBeCloseTo(9.9, 1);
+    expect(slice.stats!.n).toBeCloseTo(9.9, 1);
     // Weighted mean = sum(score*weight)/sum(weight)
     // = (8*1.2+6*0.9+9*1.5+4*0.8+7*1.1+5*1.0+10*1.3+3*0.7+8*1.4) / 9.9
     // = (9.6+5.4+13.5+3.2+7.7+5.0+13.0+2.1+11.2) / 9.9
     // = 70.7 / 9.9 ≈ 7.1414
-    expect(slice.stats.mean).toBeCloseTo(70.7 / 9.9, 1);
+    expect(slice.stats!.mean).toBeCloseTo(70.7 / 9.9, 1);
   });
 });
 
 describe("aggregateNaCross - NA × SA", () => {
   it("returns slices grouped by cross column", async () => {
-    const slices = await aggregateNaCross(getConn(), "score", crossSA, "");
+    const result = await aggregateNaCross(getConn(), "score", crossSA, "");
 
-    expect(slices).toHaveLength(2);
-    expect(slices[0].code).toBe("1");
-    expect(slices[1].code).toBe("2");
+    expect(result.slices).toHaveLength(2);
+    expect(result.slices[0].code).toBe("1");
+    expect(result.slices[1].code).toBe("2");
 
     // q1=1: rows 1(8),2(6),5(7),7(10),9(8) → n=5, mean=(8+6+7+10+8)/5=39/5=7.8
-    expect(slices[0].stats.n).toBe(5);
-    expect(slices[0].stats.mean).toBeCloseTo(7.8, 1);
+    expect(result.slices[0].stats!.n).toBe(5);
+    expect(result.slices[0].stats!.mean).toBeCloseTo(7.8, 1);
 
     // q1=2: rows 3(9),4(4),6(5),8(3) → n=4, mean=(9+4+5+3)/4=21/4=5.25
     // row 10 has score=NULL so excluded
-    expect(slices[1].stats.n).toBe(4);
-    expect(slices[1].stats.mean).toBeCloseTo(5.25, 1);
+    expect(result.slices[1].stats!.n).toBe(4);
+    expect(result.slices[1].stats!.mean).toBeCloseTo(5.25, 1);
   });
 
-  it("returns frequency distributions per cross segment", async () => {
-    const slices = await aggregateNaCross(getConn(), "score", crossSA, "");
+  it("returns aligned codes and cells per cross segment", async () => {
+    const result = await aggregateNaCross(getConn(), "score", crossSA, "");
 
-    // q1=1 values: 6,7,8,8,10
-    const freq1 = slices[0].freq.map((f) => f.value);
-    expect(freq1).toEqual([6, 7, 8, 10]);
-    // 8 appears twice in q1=1
-    expect(slices[0].freq.find((f) => f.value === 8)!.count).toBe(2);
+    // All unique values across both segments: 3,4,5,6,7,8,9,10
+    expect(result.codes).toEqual(["3", "4", "5", "6", "7", "8", "9", "10"]);
 
-    // q1=2 values: 3,4,5,9
-    const freq2 = slices[1].freq.map((f) => f.value);
-    expect(freq2).toEqual([3, 4, 5, 9]);
+    // q1=1 values: 6,7,8,8,10 — so 3,4,5 should be 0
+    const slice1 = result.slices[0];
+    const idx3 = result.codes.indexOf("3");
+    expect(slice1.cells[idx3].count).toBe(0);
+    const idx8 = result.codes.indexOf("8");
+    expect(slice1.cells[idx8].count).toBe(2);
+
+    // q1=2 values: 3,4,5,9 — so 6,7,8,10 should be 0
+    const slice2 = result.slices[1];
+    const idx6 = result.codes.indexOf("6");
+    expect(slice2.cells[idx6].count).toBe(0);
+    const idx9 = result.codes.indexOf("9");
+    expect(slice2.cells[idx9].count).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- `CategoricalTally` / `NumericTally` の discriminated union を廃止し、単一の `Tally` interface に統合
- `Slice` に `stats?: NaStats` を追加し、NA の統計情報をオプショナルフィールドとして保持
- `aggregateNa` の戻り値を `AggOutput`（codes/cells 形式）に変更し、SA/MA と同じデータ構造に統一
- クロス集計時に全 slice の value を union → 単一 codes 配列に揃え、欠損を `{count:0, pct:0}` で埋める
- 削除した型: `ValueCount`(export), `NumericSlice`, `CategoricalTally`, `NumericTally`

## Test plan
- [x] `pnpm check` (tsc + lint + fmt) パス
- [x] `pnpm test` 全テストパス（aggregateNa.test.ts 含む）
- [x] `pnpm build` プロダクションビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)