### PR TITLE
refactor: type/interfaceの重複・冗長を整理

### DIFF
--- a/src/components/aggregation/ChartCardBody.tsx
+++ b/src/components/aggregation/ChartCardBody.tsx
@@ -1,10 +1,9 @@
 import { useRef, useEffect } from "preact/hooks";
 import type { Tally } from "../../lib/agg/types";
 import { Chart, getSeriesColor, getThemeColors, type PaletteId } from "../../lib/chartConfig";
+import type { ChartType } from "./viewTypes";
 
 import type { ChartConfiguration } from "chart.js";
-
-export type ChartType = "bar-h" | "bar-v" | "obi";
 
 interface ChartCardBodyProps {
   gtTally: Tally;

--- a/src/components/aggregation/ResultView.tsx
+++ b/src/components/aggregation/ResultView.tsx
@@ -3,8 +3,7 @@ import type { Tally } from "../../lib/agg/types";
 import { Toolbar, ViewOpts } from "./Toolbar";
 import { ResultCard } from "./ResultCard";
 import { AIBubble } from "./AIBubble";
-import type { PctDirection, ViewMode } from "./viewTypes";
-import type { ChartType } from "./ChartCardBody";
+import type { ChartType, PctDirection, ViewMode } from "./viewTypes";
 import type { PaletteId } from "../../lib/chartConfig";
 
 interface ResultViewProps {

--- a/src/components/aggregation/Toolbar.tsx
+++ b/src/components/aggregation/Toolbar.tsx
@@ -1,11 +1,10 @@
 import type { Tally } from "../../lib/agg/types";
 import { t } from "../../lib/i18n";
 import { PALETTE_BASES, PALETTE_IDS, type PaletteId } from "../../lib/chartConfig";
-import type { ChartType } from "./ChartCardBody";
 import { ToggleButton, ToggleGroup } from "../shared/ToggleButton";
 import { ExportMenu } from "./ExportMenu";
 import { executeExport, type ExportAction } from "../../lib/export/export";
-import type { ChartOpts, PctDirection, ViewMode } from "./viewTypes";
+import type { ChartOpts, ChartType, PctDirection, ViewMode } from "./viewTypes";
 
 export interface ToolbarCallbacks {
   onViewModeChange: (mode: ViewMode) => void;

--- a/src/components/aggregation/viewTypes.ts
+++ b/src/components/aggregation/viewTypes.ts
@@ -1,6 +1,6 @@
 import type { PaletteId } from "../../lib/chartConfig";
-import type { ChartType } from "./ChartCardBody";
 
+export type ChartType = "bar-h" | "bar-v" | "obi";
 export type ViewMode = "table" | "chart";
 export type PctDirection = "vertical" | "horizontal";
 

--- a/src/components/import/SavedFiles.tsx
+++ b/src/components/import/SavedFiles.tsx
@@ -1,12 +1,8 @@
 import { useCallback, useEffect, useState } from "preact/hooks";
-import { listSaved, deleteSaved } from "../../lib/opfs";
+import { type SavedEntry, listSaved, deleteSaved } from "../../lib/opfs";
 import { t } from "../../lib/i18n";
 
-export interface SavedEntry {
-  folderId: string;
-  csvName: string;
-  timestamp: number;
-}
+export type { SavedEntry };
 
 /** Trigger refresh from outside Preact (e.g. after saving to OPFS) */
 export function triggerSavedFilesRefresh(): void {

--- a/src/components/import/SavedFiles.tsx
+++ b/src/components/import/SavedFiles.tsx
@@ -2,8 +2,6 @@ import { useCallback, useEffect, useState } from "preact/hooks";
 import { type SavedEntry, listSaved, deleteSaved } from "../../lib/opfs";
 import { t } from "../../lib/i18n";
 
-export type { SavedEntry };
-
 /** Trigger refresh from outside Preact (e.g. after saving to OPFS) */
 export function triggerSavedFilesRefresh(): void {
   for (const fn of listeners) fn();

--- a/src/lib/agg/buildTallies.ts
+++ b/src/lib/agg/buildTallies.ts
@@ -1,5 +1,5 @@
 import type * as duckdb from "@duckdb/duckdb-wasm";
-import type { Question, AggOutput, Tally, Axis } from "./types";
+import type { Question, AggOutput, Tally } from "./types";
 import { aggregateGt } from "./aggregateGt";
 import { aggregateCross } from "./aggregateCross";
 import { aggregateNaGt, aggregateNaCross } from "./aggregateNa";
@@ -58,7 +58,7 @@ function toTally(question: Question, aggResult: AggOutput, byQuestion?: Question
   };
 }
 
-function buildAxis(aggResult: AggOutput, byQuestion?: Question): Axis | null {
+function buildAxis(aggResult: AggOutput, byQuestion?: Question): Tally["by"] {
   if (!byQuestion) return null;
   const axisLabels: Record<string, string> = { ...byQuestion.labels };
   const hasNoAnswer = aggResult.slices.some((s) => s.code === NO_ANSWER_VALUE);

--- a/src/lib/agg/types.ts
+++ b/src/lib/agg/types.ts
@@ -1,7 +1,9 @@
 /** New aggregation type system */
 
+export type QuestionType = "SA" | "MA" | "NA";
+
 export interface Question {
-  type: "SA" | "MA" | "NA";
+  type: QuestionType;
   code: string;
   columns: string[];
   codes: string[];
@@ -47,7 +49,7 @@ export interface NaStats {
 
 /** 消費用フラット型 */
 export interface Tally {
-  type: "SA" | "MA" | "NA";
+  type: QuestionType;
   questionCode: string;
   label: string;
   by: Axis | null;

--- a/src/lib/agg/types.ts
+++ b/src/lib/agg/types.ts
@@ -31,13 +31,6 @@ export interface AggOutput {
   slices: Slice[];
 }
 
-/** クロス軸情報 */
-export interface Axis {
-  code: string; // "q1"
-  label: string; // "性別"
-  labels: Record<string, string>; // { "1": "男性", ... }, NA 含む
-}
-
 export interface NaStats {
   n: number;
   mean: number;
@@ -52,7 +45,7 @@ export interface Tally {
   type: QuestionType;
   questionCode: string;
   label: string;
-  by: Axis | null;
+  by: { code: string; label: string; labels: Record<string, string> } | null;
   codes: string[];
   labels: Record<string, string>;
   slices: Slice[];

--- a/src/lib/export/formatters/grid.ts
+++ b/src/lib/export/formatters/grid.ts
@@ -1,9 +1,9 @@
-import type { Tally } from "../../agg/types";
+import type { QuestionType, Tally } from "../../agg/types";
 import { t } from "../../i18n";
 
 export interface ExportGrid {
   questionCode: string;
-  type: "SA" | "MA" | "NA";
+  type: QuestionType;
   headers: string[][];
   rows: string[][];
 }

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -1,4 +1,4 @@
-import type { Question } from "./agg/types";
+import type { Question, QuestionType } from "./agg/types";
 
 interface LayoutItem {
   code: string;
@@ -10,7 +10,7 @@ export type DateGranularity = "year" | "month" | "week" | "day";
 interface LayoutEntry {
   key: string;
   label?: string;
-  type: "SA" | "MA" | "NA" | "WEIGHT" | "DATE";
+  type: QuestionType | "WEIGHT" | "DATE";
   items?: LayoutItem[];
   granularity?: DateGranularity;
 }


### PR DESCRIPTION
## Summary

- **SavedEntry統一**: `SavedFiles.tsx`の重複`SavedEntry`定義を削除し、`opfs.ts`からの再エクスポートに変更
- **QuestionType導入**: `"SA" | "MA" | "NA"`文字列リテラルの重複を`QuestionType`型エイリアスに統一（`types.ts`, `grid.ts`, `layout.ts`）
- **ChartType移動**: `ChartCardBody.tsx`から`viewTypes.ts`へ`ChartType`定義を移動し、インポート元を統一
- **Axis インライン化**: 単一箇所でしか使われていない`Axis`インターフェースを`Tally.by`にインライン化

## Test plan
- [x] `pnpm check` (fmt:check + lint + tsc --noEmit) が各コミットで通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)