### PR TITLE
chore: バージョン表記を v0.1 から β に変更

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1,6 +1,6 @@
 const en: Record<string, string> = {
   // Header
-  "header.subtitle": "SURVEY AGGREGATOR v0.1",
+  "header.subtitle": "SURVEY AGGREGATOR β",
   "header.settings": "Open settings",
   "header.back": "Back to data import",
 

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -1,6 +1,6 @@
 const ja: Record<string, string> = {
   // Header
-  "header.subtitle": "アンケート集計ツール v0.1",
+  "header.subtitle": "アンケート集計ツール β",
   "header.settings": "設定を開く",
   "header.back": "データ読み込みに戻る",
 


### PR DESCRIPTION
## Summary
- ヘッダーのサブタイトル表記を `v0.1` から `β` に変更し、ベータ版であることを強調
- 日本語・英語両ロケールに反映

## Test plan
- [ ] 日本語表示で「アンケート集計ツール β」と表示されること
- [ ] 英語表示で「SURVEY AGGREGATOR β」と表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)