### PR TITLE
ui: ヘルプボタンを「使い方」/「Guide」ラベル付きに変更

### DIFF
--- a/src/components/ImportScreen.tsx
+++ b/src/components/ImportScreen.tsx
@@ -88,11 +88,12 @@ function LoadedInfo({ info }: { info: string | null }) {
 function HelpButton({ onClick }: { onClick: () => void }) {
   return (
     <button
-      class="fixed bottom-5 left-5 z-900 flex h-10 w-10 cursor-pointer items-center justify-center rounded-full border-[1.5px] border-border-strong bg-surface text-base font-bold text-text-secondary shadow-[0_2px_8px_rgba(0,0,0,0.12)] transition-[background,color,transform] duration-150 hover:scale-[1.08] hover:border-[var(--color-primary-500)] hover:bg-[var(--color-primary-50)] hover:text-[var(--color-primary-700)]"
+      class="fixed bottom-5 left-5 z-900 flex h-9 cursor-pointer items-center gap-1.5 rounded-full border-[1.5px] border-border-strong bg-surface px-3.5 text-sm font-semibold text-text-secondary shadow-[0_2px_8px_rgba(0,0,0,0.12)] transition-[background,color,transform] duration-150 hover:scale-[1.03] hover:border-[var(--color-primary-500)] hover:bg-[var(--color-primary-50)] hover:text-[var(--color-primary-700)]"
       aria-label={t("help.label")}
       onClick={onClick}
     >
-      ?
+      <span class="text-base leading-none">?</span>
+      {t("help.button")}
     </button>
   );
 }

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -148,7 +148,8 @@ const en: Record<string, string> = {
   "gs.ok": "Get Started",
 
   // Help button
-  "help.label": "User Guide",
+  "help.label": "Open user guide",
+  "help.button": "Guide",
 
   // Settings modal
   "settings.title": "Settings",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -133,7 +133,7 @@ const en: Record<string, string> = {
   "gs.section1.p1":
     "This tool reads a <strong>raw data file</strong> (CSV) and a <strong>layout file</strong> (JSON) to perform aggregation.",
   "gs.section1.p2":
-    "Please prepare and format the files yourself.<br>We provide a dedicated <strong>Agent Skill</strong> so you can delegate the conversion to your AI tool.",
+    "Please prepare and format the files yourself.<br>A dedicated <strong>Agent Skill</strong> is coming soon — once available, you can delegate the conversion to your AI tool.",
   "gs.section1.sample": "Try it out with <strong>sample files</strong> first:",
   "gs.section1.sampleCsv": "Sample Raw Data",
   "gs.section1.sampleLayout": "Sample Layout",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -133,7 +133,7 @@ const ja: Record<string, string> = {
   "gs.section1.p1":
     "本ツールでは、アンケートの<strong>ローデータファイル</strong>（CSV）と<strong>レイアウトファイル</strong>（JSON）の2つを読み込んで集計を行います。",
   "gs.section1.p2":
-    "ファイルの変換・整形は<strong>ユーザーご自身</strong>で行ってください。<br>専用の <strong>Agent Skill</strong> を用意していますので、お使いのAIツールに変換作業を任せることができます。",
+    "ファイルの変換・整形は<strong>ユーザーご自身</strong>で行ってください。<br>専用の <strong>Agent Skill</strong> も準備中です。公開後はお使いのAIツールに変換作業を任せることができるようになります。",
   "gs.section1.sample": "まずは<strong>サンプルファイル</strong>で試してみましょう：",
   "gs.section1.sampleCsv": "サンプルローデータ",
   "gs.section1.sampleLayout": "サンプルレイアウト",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -148,7 +148,8 @@ const ja: Record<string, string> = {
   "gs.ok": "はじめる",
 
   // Help button
-  "help.label": "使い方ガイド",
+  "help.label": "使い方ガイドを開く",
+  "help.button": "使い方",
 
   // Settings modal
   "settings.title": "設定",


### PR DESCRIPTION
## Summary
- ヘルプボタンを丸型「?」からpill型「? 使い方」/「? Guide」に変更し、発見性を向上
- aria-labelをより説明的な文言に更新（`使い方ガイドを開く` / `Open user guide`）

## Test plan
- [ ] ja/enそれぞれでボタンのテキスト表示を確認
- [ ] ホバー時のスタイルが正しく適用されることを確認
- [ ] クリックでGetting Startedモーダルが開くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)