### PR TITLE
refactor: aggregateGt/aggregateCross を aggTotals/aggCrossTab にリネーム

### DIFF
--- a/bench/run.ts
+++ b/bench/run.ts
@@ -11,8 +11,8 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { performance } from "node:perf_hooks";
 
-import { aggregateGt } from "../src/lib/agg/aggregateGt";
-import { aggregateCross } from "../src/lib/agg/aggregateCross";
+import { aggTotals } from "../src/lib/agg/aggTotals";
+import { aggCrossTab } from "../src/lib/agg/aggCrossTab";
 import type { Question } from "../src/lib/agg/types";
 import { parseLayout, filterLayout, buildQuestions } from "../src/lib/layout";
 import { generate, PATTERNS, type PatternDef } from "./generate";
@@ -85,9 +85,9 @@ async function benchPattern(
   for (let i = 0; i < RUNS; i++) {
     const start = performance.now();
     for (const q of questions) {
-      await aggregateGt(conn, q, weightCol);
+      await aggTotals(conn, q, weightCol);
       for (const cross of crossCols) {
-        await aggregateCross(conn, q, cross, weightCol);
+        await aggCrossTab(conn, q, cross, weightCol);
       }
     }
     const elapsed = performance.now() - start;

--- a/src/lib/agg/aggCrossTab.ts
+++ b/src/lib/agg/aggCrossTab.ts
@@ -18,13 +18,13 @@ type CrossSliceData = {
   counts: number[];
 };
 
-export async function aggregateCross(
+export async function aggCrossTab(
   conn: duckdb.AsyncDuckDBConnection,
   question: AggInput,
   by: AggInput,
   weightCol: string,
 ): Promise<AggOutput> {
-  const ca = new CrossAggregator(conn, weightCol, by);
+  const ca = new CrossTabAggregator(conn, weightCol, by);
   const isMainSa = question.type === "SA";
   const isCrossSa = by.type === "SA";
 
@@ -34,7 +34,7 @@ export async function aggregateCross(
   return ca.maMA(question.columns, question.codes);
 }
 
-class CrossAggregator {
+class CrossTabAggregator {
   constructor(
     private conn: duckdb.AsyncDuckDBConnection,
     private weightCol: string,

--- a/src/lib/agg/aggTotals.ts
+++ b/src/lib/agg/aggTotals.ts
@@ -1,4 +1,4 @@
-/** GT (Grand Total) aggregation — SA and MA */
+/** Totals aggregation — SA and MA */
 
 import type * as duckdb from "@duckdb/duckdb-wasm";
 import type { AggInput, AggOutput } from "./types";
@@ -12,18 +12,18 @@ import {
   NO_ANSWER_VALUE,
 } from "./sqlHelpers";
 
-export async function aggregateGt(
+export async function aggTotals(
   conn: duckdb.AsyncDuckDBConnection,
   question: AggInput,
   weightCol: string,
 ): Promise<AggOutput> {
-  const gt = new GtAggregator(conn, weightCol);
+  const gt = new TotalsAggregator(conn, weightCol);
   return question.type === "SA"
     ? gt.aggregateSA(question.columns[0], question.codes)
     : gt.aggregateMA(question.columns, question.codes);
 }
 
-class GtAggregator {
+class TotalsAggregator {
   constructor(
     private conn: duckdb.AsyncDuckDBConnection,
     private weightCol: string,

--- a/src/lib/agg/buildTallies.ts
+++ b/src/lib/agg/buildTallies.ts
@@ -1,7 +1,7 @@
 import type * as duckdb from "@duckdb/duckdb-wasm";
 import type { Question, AggOutput, Tally } from "./types";
-import { aggregateGt } from "./aggregateGt";
-import { aggregateCross } from "./aggregateCross";
+import { aggTotals } from "./aggTotals";
+import { aggCrossTab } from "./aggCrossTab";
 import { aggregateNaGt, aggregateNaCross } from "./aggregateNa";
 import { NO_ANSWER_VALUE } from "./sqlHelpers";
 import { t } from "../i18n";
@@ -22,10 +22,10 @@ export async function buildTallies(
         tallies.push(toTally(q, crossResult, cross));
       }
     } else {
-      const gtResult = await aggregateGt(conn, q, weightCol);
+      const gtResult = await aggTotals(conn, q, weightCol);
       tallies.push(toTally(q, gtResult));
       for (const cross of crossCols) {
-        const crossResult = await aggregateCross(conn, q, cross, weightCol);
+        const crossResult = await aggCrossTab(conn, q, cross, weightCol);
         tallies.push(toTally(q, crossResult, cross));
       }
     }

--- a/tests/aggCrossTab.test.ts
+++ b/tests/aggCrossTab.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { aggregateCross } from "../src/lib/agg/aggregateCross";
+import { aggCrossTab } from "../src/lib/agg/aggCrossTab";
 import { setupDuckDB, teardownDuckDB, getConn } from "./helpers/duckdb";
 import { getAggInput } from "./helpers/fixtures";
 
@@ -43,10 +43,10 @@ function sliceCounts(result: { codes: string[]; slices: { code: string | null; c
 // 14: id=14, w=1.0, q1=NULL,q2=1,   q3_1=1, q3_2=0, q3_3=1
 // ============================================================
 
-describe("aggregateCross - 重みなし", () => {
+describe("aggCrossTab - 重みなし", () => {
   describe("SA × SA クロス集計", () => {
     it("q2 を q1 でクロスした結果が正しい", async () => {
-      const result = await aggregateCross(getConn(), q2, q1, "");
+      const result = await aggCrossTab(getConn(), q2, q1, "");
 
       // q2有効行(IS NOT NULL): 行1-11,13,14 = 13行 (行12=NULL除外)
       // slice "1" = q1=1 かつ q2有効: 行1,3,5,7,10 = 5行
@@ -57,7 +57,7 @@ describe("aggregateCross - 重みなし", () => {
 
   describe("SA × MA クロス集計", () => {
     it("q1 を q3 でクロスした結果が正しい", async () => {
-      const result = await aggregateCross(getConn(), q1, q3, "");
+      const result = await aggCrossTab(getConn(), q1, q3, "");
 
       // slice "1" = q3_1='1' の行: 1,3,4,6,8,9,14
       //   q1有効(非NULL)かつq3_1='1': 行1,3,4,6,8,9 (行14はq1=NULL)
@@ -68,7 +68,7 @@ describe("aggregateCross - 重みなし", () => {
 
   describe("MA × SA クロス集計", () => {
     it("q3 を q1 でクロスした結果が正しい", async () => {
-      const result = await aggregateCross(getConn(), q3, q1, "");
+      const result = await aggCrossTab(getConn(), q3, q1, "");
 
       expect(result.codes).toEqual(["1", "2", "3", "N/A"]);
 
@@ -81,7 +81,7 @@ describe("aggregateCross - 重みなし", () => {
 
   describe("MA × MA クロス集計", () => {
     it("q3 を自身でクロスした結果が正しい", async () => {
-      const result = await aggregateCross(getConn(), q3, q3, "");
+      const result = await aggCrossTab(getConn(), q3, q3, "");
 
       // MA×MA自身クロスではN/Aなし（cross側カラム=1の行のみがスライス対象）
       // slice "1" = q3_1='1' の行: 1,3,4,6,8,9,14

--- a/tests/aggCrossTabEdge.test.ts
+++ b/tests/aggCrossTabEdge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { aggregateCross } from "../src/lib/agg/aggregateCross";
+import { aggCrossTab } from "../src/lib/agg/aggCrossTab";
 import { setupDuckDB, teardownDuckDB, getConn, loadCSV } from "./helpers/duckdb";
 import { getAggInput, weightColumn } from "./helpers/fixtures";
 import { buildCSV } from "./helpers/csv";
@@ -40,9 +40,9 @@ function sliceN(
 // 11:w=1.0 12:w=0.8 13:w=1.1 14:w=1.0
 // ============================================================
 
-describe("aggregateCrossEdge - 重みつき手計算", () => {
+describe("aggCrossTabEdge - 重みつき手計算", () => {
   it("SA×SA weighted: q2 × q1", async () => {
-    const result = await aggregateCross(getConn(), q2, q1, weightColumn);
+    const result = await aggCrossTab(getConn(), q2, q1, weightColumn);
 
     // slice "1" (q1=1): q2有効かつq1=1 → 行1,3,5,7,10 (行12:q2=NULL除外)
     //   n = 1.2+1.5+1.1+1.3+1.0 = 6.1
@@ -59,7 +59,7 @@ describe("aggregateCrossEdge - 重みつき手計算", () => {
   });
 
   it("MA×SA weighted: q3 × q1", async () => {
-    const result = await aggregateCross(getConn(), q3, q1, weightColumn);
+    const result = await aggCrossTab(getConn(), q3, q1, weightColumn);
 
     // slice "1" (q1=1): q3 shown かつ q1=1 → 行1,3,5,7,10,12
     //   n = 1.2+1.5+1.1+1.3+1.0+0.8 = 6.9
@@ -76,7 +76,7 @@ describe("aggregateCrossEdge - 重みつき手計算", () => {
   });
 
   it("SA×MA weighted: q1 × q3", async () => {
-    const result = await aggregateCross(getConn(), q1, q3, weightColumn);
+    const result = await aggCrossTab(getConn(), q1, q3, weightColumn);
 
     // slice "1" (q3_1=1): q1有効(非NULL)かつq3_1=1 → 行1,3,4,6,8,9
     //   各行weight: 1.2+1.5+0.8+1.0+0.7+1.4 = 6.6
@@ -93,7 +93,7 @@ describe("aggregateCrossEdge - 重みつき手計算", () => {
   });
 
   it("MA×MA weighted: q3 × q3", async () => {
-    const result = await aggregateCross(getConn(), q3, q3, weightColumn);
+    const result = await aggCrossTab(getConn(), q3, q3, weightColumn);
 
     // slice "1" (q3_1=1): q3 shown かつ q3_1=1 → 行1,3,4,6,8,9,14
     //   n = 1.2+1.5+0.8+1.0+0.7+1.4+1.0 = 7.6
@@ -112,9 +112,9 @@ describe("aggregateCrossEdge - 重みつき手計算", () => {
 // 全スライス網羅（test_data.csv 重みなし）
 // ============================================================
 
-describe("aggregateCrossEdge - 全スライス網羅", () => {
+describe("aggCrossTabEdge - 全スライス網羅", () => {
   it("SA×SA: q2 × q1 → 全4スライス", async () => {
-    const result = await aggregateCross(getConn(), q2, q1, "");
+    const result = await aggCrossTab(getConn(), q2, q1, "");
 
     // q1 codes: ["1","2","3","99"]
     expect(result.slices).toHaveLength(4);
@@ -133,7 +133,7 @@ describe("aggregateCrossEdge - 全スライス網羅", () => {
   });
 
   it("MA×SA: q3 × q1 → 全4スライス", async () => {
-    const result = await aggregateCross(getConn(), q3, q1, "");
+    const result = await aggCrossTab(getConn(), q3, q1, "");
 
     expect(result.slices).toHaveLength(4);
 
@@ -151,7 +151,7 @@ describe("aggregateCrossEdge - 全スライス網羅", () => {
   });
 
   it("SA×MA: q1 × q3 → 全3スライス", async () => {
-    const result = await aggregateCross(getConn(), q1, q3, "");
+    const result = await aggCrossTab(getConn(), q1, q3, "");
 
     // q3 codes: ["1","2","3"]
     expect(result.slices).toHaveLength(3);
@@ -166,7 +166,7 @@ describe("aggregateCrossEdge - 全スライス網羅", () => {
   });
 
   it("MA×MA: q3 × q3 → 全3スライス", async () => {
-    const result = await aggregateCross(getConn(), q3, q3, "");
+    const result = await aggCrossTab(getConn(), q3, q3, "");
 
     expect(result.slices).toHaveLength(3);
 
@@ -180,7 +180,7 @@ describe("aggregateCrossEdge - 全スライス網羅", () => {
 // エッジケース（動的CSV）
 // ============================================================
 
-describe("aggregateCrossEdge - エッジケース", () => {
+describe("aggCrossTabEdge - エッジケース", () => {
   it("クロス軸が1値のみ → スライス1個", async () => {
     await loadCSV(
       buildCSV(["id", "main", "cross"], [
@@ -191,7 +191,7 @@ describe("aggregateCrossEdge - エッジケース", () => {
     );
     const mainInput: AggInput = { type: "SA", columns: ["main"], codes: ["1", "2"] };
     const crossInput: AggInput = { type: "SA", columns: ["cross"], codes: ["5"] };
-    const result = await aggregateCross(getConn(), mainInput, crossInput, "");
+    const result = await aggCrossTab(getConn(), mainInput, crossInput, "");
 
     expect(result.slices).toHaveLength(1);
     expect(result.slices[0].code).toBe("5");
@@ -208,7 +208,7 @@ describe("aggregateCrossEdge - エッジケース", () => {
     );
     const mainInput: AggInput = { type: "SA", columns: ["main"], codes: ["1"] };
     const crossInput: AggInput = { type: "SA", columns: ["cross"], codes: ["1", "2"] };
-    const result = await aggregateCross(getConn(), mainInput, crossInput, "");
+    const result = await aggCrossTab(getConn(), mainInput, crossInput, "");
 
     for (const slice of result.slices) {
       expect(slice.n).toBe(0);
@@ -219,7 +219,7 @@ describe("aggregateCrossEdge - エッジケース", () => {
     await loadCSV(buildCSV(["id", "main", "cross"], [[1, 2, 3]]));
     const mainInput: AggInput = { type: "SA", columns: ["main"], codes: ["1", "2"] };
     const crossInput: AggInput = { type: "SA", columns: ["cross"], codes: ["3", "4"] };
-    const result = await aggregateCross(getConn(), mainInput, crossInput, "");
+    const result = await aggCrossTab(getConn(), mainInput, crossInput, "");
 
     expect(sliceCounts(result, "3")).toEqual([0, 1]);
     expect(sliceCounts(result, "4")).toEqual([0, 0]);

--- a/tests/aggCrossTabPbt.test.ts
+++ b/tests/aggCrossTabPbt.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, beforeAll, afterAll } from "vitest";
-import { aggregateCross } from "../src/lib/agg/aggregateCross";
+import { aggCrossTab } from "../src/lib/agg/aggCrossTab";
 import { setupDuckDB, teardownDuckDB, getConn, loadCSV } from "./helpers/duckdb";
 import { generateCrossDataset } from "./helpers/generators";
 import { assertCrossInvariants } from "./helpers/invariants";
@@ -19,89 +19,89 @@ function rowCount(seed: number): number {
   return ROW_RANGE.min + ((seed * 17) % (ROW_RANGE.max - ROW_RANGE.min + 1));
 }
 
-describe("PBT - aggregateCross SA×SA 重みなし", () => {
+describe("PBT - aggCrossTab SA×SA 重みなし", () => {
   for (let seed = 1; seed <= SEEDS; seed++) {
     it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
       const ds = generateCrossDataset({ seed, rowCount: rowCount(seed) });
       await loadCSV(ds.csv);
-      const result = await aggregateCross(getConn(), ds.saInput, ds.sa2Input, "");
+      const result = await aggCrossTab(getConn(), ds.saInput, ds.sa2Input, "");
       assertCrossInvariants(result, "SA", ds.sa2Input.codes.length);
     });
   }
 });
 
-describe("PBT - aggregateCross SA×SA 重みあり", () => {
+describe("PBT - aggCrossTab SA×SA 重みあり", () => {
   for (let seed = 1; seed <= SEEDS; seed++) {
     it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
       const ds = generateCrossDataset({ seed, rowCount: rowCount(seed), weighted: true });
       await loadCSV(ds.csv);
-      const result = await aggregateCross(getConn(), ds.saInput, ds.sa2Input, ds.weightCol);
+      const result = await aggCrossTab(getConn(), ds.saInput, ds.sa2Input, ds.weightCol);
       assertCrossInvariants(result, "SA", ds.sa2Input.codes.length);
     });
   }
 });
 
-describe("PBT - aggregateCross MA×SA 重みなし", () => {
+describe("PBT - aggCrossTab MA×SA 重みなし", () => {
   for (let seed = 1; seed <= SEEDS; seed++) {
     it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
       const ds = generateCrossDataset({ seed, rowCount: rowCount(seed) });
       await loadCSV(ds.csv);
-      const result = await aggregateCross(getConn(), ds.maInput, ds.saInput, "");
+      const result = await aggCrossTab(getConn(), ds.maInput, ds.saInput, "");
       assertCrossInvariants(result, "MA", ds.saInput.codes.length);
     });
   }
 });
 
-describe("PBT - aggregateCross MA×SA 重みあり", () => {
+describe("PBT - aggCrossTab MA×SA 重みあり", () => {
   for (let seed = 1; seed <= SEEDS; seed++) {
     it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
       const ds = generateCrossDataset({ seed, rowCount: rowCount(seed), weighted: true });
       await loadCSV(ds.csv);
-      const result = await aggregateCross(getConn(), ds.maInput, ds.saInput, ds.weightCol);
+      const result = await aggCrossTab(getConn(), ds.maInput, ds.saInput, ds.weightCol);
       assertCrossInvariants(result, "MA", ds.saInput.codes.length);
     });
   }
 });
 
-describe("PBT - aggregateCross SA×MA 重みなし", () => {
+describe("PBT - aggCrossTab SA×MA 重みなし", () => {
   for (let seed = 1; seed <= SEEDS; seed++) {
     it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
       const ds = generateCrossDataset({ seed, rowCount: rowCount(seed) });
       await loadCSV(ds.csv);
-      const result = await aggregateCross(getConn(), ds.saInput, ds.maInput, "");
+      const result = await aggCrossTab(getConn(), ds.saInput, ds.maInput, "");
       assertCrossInvariants(result, "SA", ds.maInput.codes.length);
     });
   }
 });
 
-describe("PBT - aggregateCross SA×MA 重みあり", () => {
+describe("PBT - aggCrossTab SA×MA 重みあり", () => {
   for (let seed = 1; seed <= SEEDS; seed++) {
     it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
       const ds = generateCrossDataset({ seed, rowCount: rowCount(seed), weighted: true });
       await loadCSV(ds.csv);
-      const result = await aggregateCross(getConn(), ds.saInput, ds.maInput, ds.weightCol);
+      const result = await aggCrossTab(getConn(), ds.saInput, ds.maInput, ds.weightCol);
       assertCrossInvariants(result, "SA", ds.maInput.codes.length);
     });
   }
 });
 
-describe("PBT - aggregateCross MA×MA 重みなし", () => {
+describe("PBT - aggCrossTab MA×MA 重みなし", () => {
   for (let seed = 1; seed <= SEEDS; seed++) {
     it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
       const ds = generateCrossDataset({ seed, rowCount: rowCount(seed) });
       await loadCSV(ds.csv);
-      const result = await aggregateCross(getConn(), ds.maInput, ds.maInput, "");
+      const result = await aggCrossTab(getConn(), ds.maInput, ds.maInput, "");
       assertCrossInvariants(result, "MA", ds.maInput.codes.length);
     });
   }
 });
 
-describe("PBT - aggregateCross MA×MA 重みあり", () => {
+describe("PBT - aggCrossTab MA×MA 重みあり", () => {
   for (let seed = 1; seed <= SEEDS; seed++) {
     it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
       const ds = generateCrossDataset({ seed, rowCount: rowCount(seed), weighted: true });
       await loadCSV(ds.csv);
-      const result = await aggregateCross(getConn(), ds.maInput, ds.maInput, ds.weightCol);
+      const result = await aggCrossTab(getConn(), ds.maInput, ds.maInput, ds.weightCol);
       assertCrossInvariants(result, "MA", ds.maInput.codes.length);
     });
   }

--- a/tests/aggTotals.test.ts
+++ b/tests/aggTotals.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { aggregateGt } from "../src/lib/agg/aggregateGt";
+import { aggTotals } from "../src/lib/agg/aggTotals";
 import { setupDuckDB, teardownDuckDB, getConn } from "./helpers/duckdb";
 import { getAggInput } from "./helpers/fixtures";
 
@@ -36,10 +36,10 @@ const q3 = getAggInput("q3");
 // 14: id=14, w=1.0, q1=NULL,q2=1,   q3_1=1, q3_2=0, q3_3=1
 // ============================================================
 
-describe("aggregateGt - 重みなし", () => {
+describe("aggTotals - 重みなし", () => {
   describe("SA GT集計", () => {
     it("q1 の GT 集計で各値の count/n/pct が正しい", async () => {
-      const result = await aggregateGt(getConn(), q1, "");
+      const result = await aggTotals(getConn(), q1, "");
 
       expect(result.slices).toHaveLength(1);
 
@@ -65,7 +65,7 @@ describe("aggregateGt - 重みなし", () => {
 
   describe("MA GT集計", () => {
     it("q3 の GT 集計で各サブカラムの count と無回答が正しい", async () => {
-      const result = await aggregateGt(getConn(), q3, "");
+      const result = await aggTotals(getConn(), q3, "");
 
       // MA shown条件: q3_1~q3_3 のいずれかが非NULL
       // 行13: q3_1=NULL,q3_2=NULL,q3_3=NULL → 全部NULLなので除外
@@ -84,10 +84,10 @@ describe("aggregateGt - 重みなし", () => {
   });
 });
 
-describe("aggregateGt - 重み付き", () => {
+describe("aggTotals - 重み付き", () => {
   describe("SA GT集計（重み付き）", () => {
     it("q1 の重み付き GT 集計で weighted count が正しい", async () => {
-      const result = await aggregateGt(getConn(), q1, "weight");
+      const result = await aggTotals(getConn(), q1, "weight");
 
       // q1有効行: 行1-13 (行14=空のみ除外)
       // q1=1: 行1(1.2)+3(1.5)+5(1.1)+7(1.3)+10(1.0)+12(0.8) = 6.9
@@ -111,7 +111,7 @@ describe("aggregateGt - 重み付き", () => {
 
   describe("MA GT集計（重み付き）", () => {
     it("q3 の重み付き GT 集計で weighted count が正しい", async () => {
-      const result = await aggregateGt(getConn(), q3, "weight");
+      const result = await aggTotals(getConn(), q3, "weight");
 
       // shown行: 行1-12,14 = 13行 (行13は全空で除外)
       // q3_1='1': 行1(1.2)+3(1.5)+4(0.8)+6(1.0)+8(0.7)+9(1.4)+14(1.0) = 7.6

--- a/tests/aggTotalsEdge.test.ts
+++ b/tests/aggTotalsEdge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { aggregateGt } from "../src/lib/agg/aggregateGt";
+import { aggTotals } from "../src/lib/agg/aggTotals";
 import { setupDuckDB, teardownDuckDB, getConn, loadCSV } from "./helpers/duckdb";
 import { buildCSV } from "./helpers/csv";
 import type { AggInput } from "../src/lib/agg/types";
@@ -12,7 +12,7 @@ afterAll(async () => {
   await teardownDuckDB();
 });
 
-describe("aggregateGtEdge - SA", () => {
+describe("aggTotalsEdge - SA", () => {
   it("全行同値 → count=5, pct=100", async () => {
     await loadCSV(
       buildCSV(["id", "q1"], [
@@ -20,7 +20,7 @@ describe("aggregateGtEdge - SA", () => {
       ]),
     );
     const input: AggInput = { type: "SA", columns: ["q1"], codes: ["1", "2"] };
-    const result = await aggregateGt(getConn(), input, "");
+    const result = await aggTotals(getConn(), input, "");
 
     const slice = result.slices[0];
     expect(slice.n).toBe(5);
@@ -37,7 +37,7 @@ describe("aggregateGtEdge - SA", () => {
       ]),
     );
     const input: AggInput = { type: "SA", columns: ["q1"], codes: ["1"] };
-    const result = await aggregateGt(getConn(), input, "");
+    const result = await aggTotals(getConn(), input, "");
 
     expect(result.slices[0].n).toBe(0);
   });
@@ -45,7 +45,7 @@ describe("aggregateGtEdge - SA", () => {
   it("1行のみ → n=1, count=1", async () => {
     await loadCSV(buildCSV(["id", "q1"], [[1, 2]]));
     const input: AggInput = { type: "SA", columns: ["q1"], codes: ["1", "2"] };
-    const result = await aggregateGt(getConn(), input, "");
+    const result = await aggTotals(getConn(), input, "");
 
     expect(result.slices[0].n).toBe(1);
     expect(result.slices[0].cells[1].count).toBe(1);
@@ -59,7 +59,7 @@ describe("aggregateGtEdge - SA", () => {
       ]),
     );
     const input: AggInput = { type: "SA", columns: ["q1"], codes: ["1", "2", "3"] };
-    const result = await aggregateGt(getConn(), input, "");
+    const result = await aggTotals(getConn(), input, "");
 
     expect(result.slices[0].cells[0].count).toBe(3);
     expect(result.slices[0].cells[1].count).toBe(0);
@@ -75,7 +75,7 @@ describe("aggregateGtEdge - SA", () => {
       ]),
     );
     const input: AggInput = { type: "SA", columns: ["q1"], codes: ["1", "2"] };
-    const result = await aggregateGt(getConn(), input, "weight");
+    const result = await aggTotals(getConn(), input, "weight");
 
     expect(result.slices[0].n).toBeCloseTo(2.0, 3);
     expect(result.slices[0].cells[0].count).toBeCloseTo(1.0, 3);
@@ -89,8 +89,8 @@ describe("aggregateGtEdge - SA", () => {
       ]),
     );
     const input: AggInput = { type: "SA", columns: ["q1"], codes: ["1", "2", "3"] };
-    const unweighted = await aggregateGt(getConn(), input, "");
-    const weighted = await aggregateGt(getConn(), input, "weight");
+    const unweighted = await aggTotals(getConn(), input, "");
+    const weighted = await aggTotals(getConn(), input, "weight");
 
     const uwCounts = unweighted.slices[0].cells.map((c) => c.count);
     const wCounts = weighted.slices[0].cells.map((c) => c.count);
@@ -98,7 +98,7 @@ describe("aggregateGtEdge - SA", () => {
   });
 });
 
-describe("aggregateGtEdge - MA", () => {
+describe("aggTotalsEdge - MA", () => {
   it("NULL行はshownから除外される → nに寄与しない", async () => {
     // 型推論のため非NULLの行を含む。NULL行のみがshown=falseで除外される
     await loadCSV(
@@ -109,7 +109,7 @@ describe("aggregateGtEdge - MA", () => {
       ]),
     );
     const input: AggInput = { type: "MA", columns: ["q_1", "q_2"], codes: ["1", "2"] };
-    const result = await aggregateGt(getConn(), input, "");
+    const result = await aggTotals(getConn(), input, "");
 
     // shown行は行3のみ → n=1
     expect(result.slices[0].n).toBe(1);
@@ -126,7 +126,7 @@ describe("aggregateGtEdge - MA", () => {
       ]),
     );
     const input: AggInput = { type: "MA", columns: ["q_1", "q_2"], codes: ["1", "2"] };
-    const result = await aggregateGt(getConn(), input, "");
+    const result = await aggTotals(getConn(), input, "");
 
     expect(result.slices[0].n).toBe(3);
     expect(result.slices[0].cells[0].count).toBe(0);

--- a/tests/aggTotalsPbt.test.ts
+++ b/tests/aggTotalsPbt.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, beforeAll, afterAll } from "vitest";
-import { aggregateGt } from "../src/lib/agg/aggregateGt";
+import { aggTotals } from "../src/lib/agg/aggTotals";
 import { setupDuckDB, teardownDuckDB, getConn, loadCSV } from "./helpers/duckdb";
 import { generateSADataset, generateMADataset } from "./helpers/generators";
 import { assertGtInvariants } from "./helpers/invariants";
@@ -19,45 +19,45 @@ function rowCount(seed: number): number {
   return ROW_RANGE.min + ((seed * 17) % (ROW_RANGE.max - ROW_RANGE.min + 1));
 }
 
-describe("PBT - aggregateGt SA 重みなし", () => {
+describe("PBT - aggTotals SA 重みなし", () => {
   for (let seed = 1; seed <= SEEDS; seed++) {
     it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
       const ds = generateSADataset({ seed, rowCount: rowCount(seed) });
       await loadCSV(ds.csv);
-      const result = await aggregateGt(getConn(), ds.aggInput, "");
+      const result = await aggTotals(getConn(), ds.aggInput, "");
       assertGtInvariants(result, "SA");
     });
   }
 });
 
-describe("PBT - aggregateGt SA 重みあり", () => {
+describe("PBT - aggTotals SA 重みあり", () => {
   for (let seed = 1; seed <= SEEDS; seed++) {
     it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
       const ds = generateSADataset({ seed, rowCount: rowCount(seed), weighted: true });
       await loadCSV(ds.csv);
-      const result = await aggregateGt(getConn(), ds.aggInput, ds.weightCol);
+      const result = await aggTotals(getConn(), ds.aggInput, ds.weightCol);
       assertGtInvariants(result, "SA");
     });
   }
 });
 
-describe("PBT - aggregateGt MA 重みなし", () => {
+describe("PBT - aggTotals MA 重みなし", () => {
   for (let seed = 1; seed <= SEEDS; seed++) {
     it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
       const ds = generateMADataset({ seed, rowCount: rowCount(seed) });
       await loadCSV(ds.csv);
-      const result = await aggregateGt(getConn(), ds.aggInput, "");
+      const result = await aggTotals(getConn(), ds.aggInput, "");
       assertGtInvariants(result, "MA");
     });
   }
 });
 
-describe("PBT - aggregateGt MA 重みあり", () => {
+describe("PBT - aggTotals MA 重みあり", () => {
   for (let seed = 1; seed <= SEEDS; seed++) {
     it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
       const ds = generateMADataset({ seed, rowCount: rowCount(seed), weighted: true });
       await loadCSV(ds.csv);
-      const result = await aggregateGt(getConn(), ds.aggInput, ds.weightCol);
+      const result = await aggTotals(getConn(), ds.aggInput, ds.weightCol);
       assertGtInvariants(result, "MA");
     });
   }


### PR DESCRIPTION
## Summary
- `aggregateGt` → `aggTotals` (クラス: `GtAggregator` → `TotalsAggregator`)
- `aggregateCross` → `aggCrossTab` (クラス: `CrossAggregator` → `CrossTabAggregator`)
- ファイル名・テストファイル名も同様にリネーム
- 参照元 (`buildTallies.ts`, `bench/run.ts`) も更新

## Test plan
- [x] `pnpm check` (fmt, lint, tsc) 通過
- [x] `pnpm vitest run --dir tests` 全668テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)