### PR TITLE
refactor: 集計モジュールの用語を統一

### DIFF
--- a/src/components/AggregationScreen.tsx
+++ b/src/components/AggregationScreen.tsx
@@ -37,10 +37,10 @@ export default function AggregationScreen({ csv, layout, dateWarnings }: Aggrega
     setErrorMsg("");
 
     const wCol = weightEnabled ? weightCol : "";
-    const crossCols = questions.filter((q) => crossSelected[q.code]);
+    const crossQuestions = questions.filter((q) => crossSelected[q.code]);
 
     try {
-      const tallies = await runAggregation(questions, crossCols, wCol);
+      const tallies = await runAggregation(questions, crossQuestions, wCol);
       setAggResult({ tallies, weightCol: wCol });
     } catch (e) {
       setErrorMsg(t("error.aggregation", { msg: (e as Error).message }));

--- a/src/lib/agg/aggCrossTab.ts
+++ b/src/lib/agg/aggCrossTab.ts
@@ -21,12 +21,12 @@ type CrossSliceData = {
 export async function aggCrossTab(
   conn: duckdb.AsyncDuckDBConnection,
   question: AggInput,
-  by: AggInput,
+  axisQuestion: AggInput,
   weightCol: string,
 ): Promise<AggOutput> {
-  const ca = new CrossTabAggregator(conn, weightCol, by);
+  const ca = new CrossTabAggregator(conn, weightCol, axisQuestion);
   const isMainSa = question.type === "SA";
-  const isCrossSa = by.type === "SA";
+  const isCrossSa = axisQuestion.type === "SA";
 
   if (isMainSa && isCrossSa) return ca.saSA(question.columns[0], question.codes);
   if (isMainSa && !isCrossSa) return ca.saMA(question.columns[0], question.codes);
@@ -38,14 +38,14 @@ class CrossTabAggregator {
   constructor(
     private conn: duckdb.AsyncDuckDBConnection,
     private weightCol: string,
-    private crossQ: AggInput,
+    private axisQuestion: AggInput,
   ) {}
 
   // ── SA main × SA cross ──
 
   async saSA(column: string, codes: string[]): Promise<AggOutput> {
-    const crossCol = this.crossQ.columns[0];
-    const crossValues = this.crossQ.codes;
+    const crossCol = this.axisQuestion.columns[0];
+    const crossValues = this.axisQuestion.codes;
     const wExpr = weightExpr(this.weightCol);
 
     const sql = `
@@ -89,7 +89,7 @@ class CrossTabAggregator {
   // ── SA main × MA cross ──
 
   async saMA(column: string, codes: string[]): Promise<AggOutput> {
-    const selectClauses = this.crossQ.columns.map(
+    const selectClauses = this.axisQuestion.columns.map(
       (maCol, i) => `${maWeightedCountExpr(maCol, this.weightCol)} AS c${i}`,
     );
 
@@ -105,18 +105,18 @@ class CrossTabAggregator {
     const result = await this.conn.query(sql);
     const rowData = new Map<string, number[]>();
     for (const r of result.toArray()) {
-      const counts = this.crossQ.columns.map((_, i) => Number(r[`c${i}`] ?? 0));
+      const counts = this.axisQuestion.columns.map((_, i) => Number(r[`c${i}`] ?? 0));
       rowData.set(String(r.mv), counts);
     }
 
     // n for each cross MA column = sum of that column across all main codes
-    const nArr = this.crossQ.columns.map((_, ci) => {
+    const nArr = this.axisQuestion.columns.map((_, ci) => {
       let total = 0;
       for (const counts of rowData.values()) total += counts[ci];
       return total;
     });
 
-    const data: CrossSliceData[] = this.crossQ.codes.map((crossCode, ci) => ({
+    const data: CrossSliceData[] = this.axisQuestion.codes.map((crossCode, ci) => ({
       code: crossCode,
       n: nArr[ci],
       counts: codes.map((code) => rowData.get(code)?.[ci] ?? 0),
@@ -127,8 +127,8 @@ class CrossTabAggregator {
   // ── MA main × SA cross ──
 
   async maSA(columns: string[], codes: string[]): Promise<AggOutput> {
-    const crossCol = this.crossQ.columns[0];
-    const crossValues = this.crossQ.codes;
+    const crossCol = this.axisQuestion.columns[0];
+    const crossValues = this.axisQuestion.codes;
     const wExpr = weightExpr(this.weightCol);
 
     const selectClauses = columns.map(
@@ -195,24 +195,24 @@ class CrossTabAggregator {
 
     const selectClauses: string[] = [];
     for (let r = 0; r < columns.length; r++) {
-      for (let c = 0; c < this.crossQ.columns.length; c++) {
+      for (let c = 0; c < this.axisQuestion.columns.length; c++) {
         const expr = this.weightCol
-          ? `SUM("${esc(columns[r])}" * "${esc(this.crossQ.columns[c])}" * "${esc(this.weightCol)}")`
-          : `SUM("${esc(columns[r])}" * "${esc(this.crossQ.columns[c])}")::DOUBLE`;
+          ? `SUM("${esc(columns[r])}" * "${esc(this.axisQuestion.columns[c])}" * "${esc(this.weightCol)}")`
+          : `SUM("${esc(columns[r])}" * "${esc(this.axisQuestion.columns[c])}")::DOUBLE`;
         selectClauses.push(`${expr} AS r${r}c${c}`);
       }
     }
 
     // No-answer × each cross MA column
     const naBase = `${maNoneSelectedCondition(columns)} AND (${shownCond})`;
-    for (let c = 0; c < this.crossQ.columns.length; c++) {
-      const naCondition = `${naBase} AND "${esc(this.crossQ.columns[c])}" = 1`;
+    for (let c = 0; c < this.axisQuestion.columns.length; c++) {
+      const naCondition = `${naBase} AND "${esc(this.axisQuestion.columns[c])}" = 1`;
       selectClauses.push(`${weightedCountExpr(naCondition, this.weightCol)} AS na_c${c}`);
     }
 
     // n for each cross MA column: cross col = 1 AND main shown
-    for (let c = 0; c < this.crossQ.columns.length; c++) {
-      const nCondition = `(${shownCond}) AND "${esc(this.crossQ.columns[c])}" = 1`;
+    for (let c = 0; c < this.axisQuestion.columns.length; c++) {
+      const nCondition = `(${shownCond}) AND "${esc(this.axisQuestion.columns[c])}" = 1`;
       selectClauses.push(`${weightedCountExpr(nCondition, this.weightCol)} AS n_c${c}`);
     }
 
@@ -220,9 +220,9 @@ class CrossTabAggregator {
     const result = await this.conn.query(sql);
     const row = result.toArray()[0];
 
-    const hasNoAnswer = this.crossQ.codes.some((_, c) => Number(row[`na_c${c}`] ?? 0) > 0);
+    const hasNoAnswer = this.axisQuestion.codes.some((_, c) => Number(row[`na_c${c}`] ?? 0) > 0);
     const resultCodes = hasNoAnswer ? [...codes, NO_ANSWER_VALUE] : codes;
-    const data: CrossSliceData[] = this.crossQ.codes.map((crossCode, c) => {
+    const data: CrossSliceData[] = this.axisQuestion.codes.map((crossCode, c) => {
       const counts = columns.map((_col, r) => Number(row[`r${r}c${c}`] ?? 0));
       if (hasNoAnswer) counts.push(Number(row[`na_c${c}`] ?? 0));
       return { code: crossCode, n: Number(row[`n_c${c}`] ?? 0), counts };

--- a/src/lib/agg/aggCrossTab.ts
+++ b/src/lib/agg/aggCrossTab.ts
@@ -1,7 +1,7 @@
 /** Cross-tabulation aggregation — one cross axis at a time */
 
 import type * as duckdb from "@duckdb/duckdb-wasm";
-import type { AggInput, AggOutput } from "./types";
+import type { Shape, AggOutput } from "./types";
 import {
   esc,
   weightExpr,
@@ -20,32 +20,32 @@ type CrossSliceData = {
 
 export async function aggCrossTab(
   conn: duckdb.AsyncDuckDBConnection,
-  question: AggInput,
-  axisQuestion: AggInput,
+  shape: Shape,
+  axisShape: Shape,
   weightCol: string,
 ): Promise<AggOutput> {
-  const ca = new CrossTabAggregator(conn, weightCol, axisQuestion);
-  const isMainSa = question.type === "SA";
-  const isCrossSa = axisQuestion.type === "SA";
+  const ca = new CrossTabAggregator(conn, weightCol, axisShape);
+  const isMainSa = shape.type === "SA";
+  const isCrossSa = axisShape.type === "SA";
 
-  if (isMainSa && isCrossSa) return ca.saSA(question.columns[0], question.codes);
-  if (isMainSa && !isCrossSa) return ca.saMA(question.columns[0], question.codes);
-  if (!isMainSa && isCrossSa) return ca.maSA(question.columns, question.codes);
-  return ca.maMA(question.columns, question.codes);
+  if (isMainSa && isCrossSa) return ca.saSA(shape.columns[0], shape.codes);
+  if (isMainSa && !isCrossSa) return ca.saMA(shape.columns[0], shape.codes);
+  if (!isMainSa && isCrossSa) return ca.maSA(shape.columns, shape.codes);
+  return ca.maMA(shape.columns, shape.codes);
 }
 
 class CrossTabAggregator {
   constructor(
     private conn: duckdb.AsyncDuckDBConnection,
     private weightCol: string,
-    private axisQuestion: AggInput,
+    private axisShape: Shape,
   ) {}
 
   // ── SA main × SA cross ──
 
   async saSA(column: string, codes: string[]): Promise<AggOutput> {
-    const crossCol = this.axisQuestion.columns[0];
-    const crossValues = this.axisQuestion.codes;
+    const crossCol = this.axisShape.columns[0];
+    const crossValues = this.axisShape.codes;
     const wExpr = weightExpr(this.weightCol);
 
     const sql = `
@@ -89,7 +89,7 @@ class CrossTabAggregator {
   // ── SA main × MA cross ──
 
   async saMA(column: string, codes: string[]): Promise<AggOutput> {
-    const selectClauses = this.axisQuestion.columns.map(
+    const selectClauses = this.axisShape.columns.map(
       (maCol, i) => `${maWeightedCountExpr(maCol, this.weightCol)} AS c${i}`,
     );
 
@@ -105,18 +105,18 @@ class CrossTabAggregator {
     const result = await this.conn.query(sql);
     const rowData = new Map<string, number[]>();
     for (const r of result.toArray()) {
-      const counts = this.axisQuestion.columns.map((_, i) => Number(r[`c${i}`] ?? 0));
+      const counts = this.axisShape.columns.map((_, i) => Number(r[`c${i}`] ?? 0));
       rowData.set(String(r.mv), counts);
     }
 
     // n for each cross MA column = sum of that column across all main codes
-    const nArr = this.axisQuestion.columns.map((_, ci) => {
+    const nArr = this.axisShape.columns.map((_, ci) => {
       let total = 0;
       for (const counts of rowData.values()) total += counts[ci];
       return total;
     });
 
-    const data: CrossSliceData[] = this.axisQuestion.codes.map((crossCode, ci) => ({
+    const data: CrossSliceData[] = this.axisShape.codes.map((crossCode, ci) => ({
       code: crossCode,
       n: nArr[ci],
       counts: codes.map((code) => rowData.get(code)?.[ci] ?? 0),
@@ -127,8 +127,8 @@ class CrossTabAggregator {
   // ── MA main × SA cross ──
 
   async maSA(columns: string[], codes: string[]): Promise<AggOutput> {
-    const crossCol = this.axisQuestion.columns[0];
-    const crossValues = this.axisQuestion.codes;
+    const crossCol = this.axisShape.columns[0];
+    const crossValues = this.axisShape.codes;
     const wExpr = weightExpr(this.weightCol);
 
     const selectClauses = columns.map(
@@ -195,24 +195,24 @@ class CrossTabAggregator {
 
     const selectClauses: string[] = [];
     for (let r = 0; r < columns.length; r++) {
-      for (let c = 0; c < this.axisQuestion.columns.length; c++) {
+      for (let c = 0; c < this.axisShape.columns.length; c++) {
         const expr = this.weightCol
-          ? `SUM("${esc(columns[r])}" * "${esc(this.axisQuestion.columns[c])}" * "${esc(this.weightCol)}")`
-          : `SUM("${esc(columns[r])}" * "${esc(this.axisQuestion.columns[c])}")::DOUBLE`;
+          ? `SUM("${esc(columns[r])}" * "${esc(this.axisShape.columns[c])}" * "${esc(this.weightCol)}")`
+          : `SUM("${esc(columns[r])}" * "${esc(this.axisShape.columns[c])}")::DOUBLE`;
         selectClauses.push(`${expr} AS r${r}c${c}`);
       }
     }
 
     // No-answer × each cross MA column
     const naBase = `${maNoneSelectedCondition(columns)} AND (${shownCond})`;
-    for (let c = 0; c < this.axisQuestion.columns.length; c++) {
-      const naCondition = `${naBase} AND "${esc(this.axisQuestion.columns[c])}" = 1`;
+    for (let c = 0; c < this.axisShape.columns.length; c++) {
+      const naCondition = `${naBase} AND "${esc(this.axisShape.columns[c])}" = 1`;
       selectClauses.push(`${weightedCountExpr(naCondition, this.weightCol)} AS na_c${c}`);
     }
 
     // n for each cross MA column: cross col = 1 AND main shown
-    for (let c = 0; c < this.axisQuestion.columns.length; c++) {
-      const nCondition = `(${shownCond}) AND "${esc(this.axisQuestion.columns[c])}" = 1`;
+    for (let c = 0; c < this.axisShape.columns.length; c++) {
+      const nCondition = `(${shownCond}) AND "${esc(this.axisShape.columns[c])}" = 1`;
       selectClauses.push(`${weightedCountExpr(nCondition, this.weightCol)} AS n_c${c}`);
     }
 
@@ -220,9 +220,9 @@ class CrossTabAggregator {
     const result = await this.conn.query(sql);
     const row = result.toArray()[0];
 
-    const hasNoAnswer = this.axisQuestion.codes.some((_, c) => Number(row[`na_c${c}`] ?? 0) > 0);
+    const hasNoAnswer = this.axisShape.codes.some((_, c) => Number(row[`na_c${c}`] ?? 0) > 0);
     const resultCodes = hasNoAnswer ? [...codes, NO_ANSWER_VALUE] : codes;
-    const data: CrossSliceData[] = this.axisQuestion.codes.map((crossCode, c) => {
+    const data: CrossSliceData[] = this.axisShape.codes.map((crossCode, c) => {
       const counts = columns.map((_col, r) => Number(row[`r${r}c${c}`] ?? 0));
       if (hasNoAnswer) counts.push(Number(row[`na_c${c}`] ?? 0));
       return { code: crossCode, n: Number(row[`n_c${c}`] ?? 0), counts };

--- a/src/lib/agg/aggNa.ts
+++ b/src/lib/agg/aggNa.ts
@@ -31,13 +31,13 @@ export async function aggNaTotals(
 export async function aggNaCrossTab(
   conn: duckdb.AsyncDuckDBConnection,
   naColumn: string,
-  crossQ: AggInput,
+  axisQuestion: AggInput,
   weightCol: string,
 ): Promise<AggOutput> {
-  if (crossQ.type === "SA") {
-    return crossSA(conn, naColumn, crossQ.columns[0], crossQ.codes, weightCol);
+  if (axisQuestion.type === "SA") {
+    return crossSA(conn, naColumn, axisQuestion.columns[0], axisQuestion.codes, weightCol);
   }
-  return crossMA(conn, naColumn, crossQ.columns, crossQ.codes, weightCol);
+  return crossMA(conn, naColumn, axisQuestion.columns, axisQuestion.codes, weightCol);
 }
 
 // ── Helpers ──

--- a/src/lib/agg/aggNa.ts
+++ b/src/lib/agg/aggNa.ts
@@ -1,7 +1,7 @@
 /** NA (Numerical Answer) aggregation — GT and Cross */
 
 import type * as duckdb from "@duckdb/duckdb-wasm";
-import type { AggInput, AggOutput, NaStats, Slice } from "./types";
+import type { Shape, AggOutput, NaStats, Slice } from "./types";
 import { esc, maShownCondition } from "./sqlHelpers";
 
 interface ValueCount {
@@ -31,13 +31,13 @@ export async function aggNaTotals(
 export async function aggNaCrossTab(
   conn: duckdb.AsyncDuckDBConnection,
   naColumn: string,
-  axisQuestion: AggInput,
+  axisShape: Shape,
   weightCol: string,
 ): Promise<AggOutput> {
-  if (axisQuestion.type === "SA") {
-    return crossSA(conn, naColumn, axisQuestion.columns[0], axisQuestion.codes, weightCol);
+  if (axisShape.type === "SA") {
+    return crossSA(conn, naColumn, axisShape.columns[0], axisShape.codes, weightCol);
   }
-  return crossMA(conn, naColumn, axisQuestion.columns, axisQuestion.codes, weightCol);
+  return crossMA(conn, naColumn, axisShape.columns, axisShape.codes, weightCol);
 }
 
 // ── Helpers ──

--- a/src/lib/agg/aggNa.ts
+++ b/src/lib/agg/aggNa.ts
@@ -35,9 +35,9 @@ export async function aggNaCrossTab(
   weightCol: string,
 ): Promise<AggOutput> {
   if (axisShape.type === "SA") {
-    return crossSA(conn, naColumn, axisShape.columns[0], axisShape.codes, weightCol);
+    return naCrossSA(conn, naColumn, axisShape.columns[0], axisShape.codes, weightCol);
   }
-  return crossMA(conn, naColumn, axisShape.columns, axisShape.codes, weightCol);
+  return naCrossMA(conn, naColumn, axisShape.columns, axisShape.codes, weightCol);
 }
 
 // ── Helpers ──
@@ -234,7 +234,7 @@ function toStats(row: Record<string, unknown>): NaStats {
 
 // ── NA × SA cross ──
 
-async function crossSA(
+async function naCrossSA(
   conn: duckdb.AsyncDuckDBConnection,
   naColumn: string,
   crossCol: string,
@@ -259,7 +259,7 @@ async function crossSA(
 
 // ── NA × MA cross ──
 
-async function crossMA(
+async function naCrossMA(
   conn: duckdb.AsyncDuckDBConnection,
   naColumn: string,
   maCols: string[],

--- a/src/lib/agg/aggNa.ts
+++ b/src/lib/agg/aggNa.ts
@@ -11,7 +11,7 @@ interface ValueCount {
 
 // ── GT ──
 
-export async function aggregateNaGt(
+export async function aggNaTotals(
   conn: duckdb.AsyncDuckDBConnection,
   column: string,
   weightCol: string,
@@ -28,7 +28,7 @@ export async function aggregateNaGt(
 
 // ── Cross (NA × SA or NA × MA) ──
 
-export async function aggregateNaCross(
+export async function aggNaCrossTab(
   conn: duckdb.AsyncDuckDBConnection,
   naColumn: string,
   crossQ: AggInput,

--- a/src/lib/agg/aggTotals.ts
+++ b/src/lib/agg/aggTotals.ts
@@ -17,10 +17,10 @@ export async function aggTotals(
   question: AggInput,
   weightCol: string,
 ): Promise<AggOutput> {
-  const gt = new TotalsAggregator(conn, weightCol);
+  const totals = new TotalsAggregator(conn, weightCol);
   return question.type === "SA"
-    ? gt.aggregateSA(question.columns[0], question.codes)
-    : gt.aggregateMA(question.columns, question.codes);
+    ? totals.aggregateSA(question.columns[0], question.codes)
+    : totals.aggregateMA(question.columns, question.codes);
 }
 
 class TotalsAggregator {

--- a/src/lib/agg/aggTotals.ts
+++ b/src/lib/agg/aggTotals.ts
@@ -1,7 +1,7 @@
 /** Totals aggregation — SA and MA */
 
 import type * as duckdb from "@duckdb/duckdb-wasm";
-import type { AggInput, AggOutput } from "./types";
+import type { Shape, AggOutput } from "./types";
 import {
   esc,
   weightExpr,
@@ -14,13 +14,13 @@ import {
 
 export async function aggTotals(
   conn: duckdb.AsyncDuckDBConnection,
-  question: AggInput,
+  shape: Shape,
   weightCol: string,
 ): Promise<AggOutput> {
   const totals = new TotalsAggregator(conn, weightCol);
-  return question.type === "SA"
-    ? totals.aggregateSA(question.columns[0], question.codes)
-    : totals.aggregateMA(question.columns, question.codes);
+  return shape.type === "SA"
+    ? totals.aggregateSA(shape.columns[0], shape.codes)
+    : totals.aggregateMA(shape.columns, shape.codes);
 }
 
 class TotalsAggregator {

--- a/src/lib/agg/buildTallies.ts
+++ b/src/lib/agg/buildTallies.ts
@@ -2,7 +2,7 @@ import type * as duckdb from "@duckdb/duckdb-wasm";
 import type { Question, AggOutput, Tally } from "./types";
 import { aggTotals } from "./aggTotals";
 import { aggCrossTab } from "./aggCrossTab";
-import { aggregateNaGt, aggregateNaCross } from "./aggregateNa";
+import { aggNaTotals, aggNaCrossTab } from "./aggNa";
 import { NO_ANSWER_VALUE } from "./sqlHelpers";
 import { t } from "../i18n";
 
@@ -15,10 +15,10 @@ export async function buildTallies(
   const tallies: Tally[] = [];
   for (const q of questions) {
     if (q.type === "NA") {
-      const gtResult = await aggregateNaGt(conn, q.columns[0], weightCol);
+      const gtResult = await aggNaTotals(conn, q.columns[0], weightCol);
       tallies.push(toTally(q, gtResult));
       for (const cross of crossCols) {
-        const crossResult = await aggregateNaCross(conn, q.columns[0], cross, weightCol);
+        const crossResult = await aggNaCrossTab(conn, q.columns[0], cross, weightCol);
         tallies.push(toTally(q, crossResult, cross));
       }
     } else {

--- a/src/lib/agg/buildTallies.ts
+++ b/src/lib/agg/buildTallies.ts
@@ -9,7 +9,7 @@ import { t } from "../i18n";
 export async function buildTallies(
   conn: duckdb.AsyncDuckDBConnection,
   questions: Question[],
-  crossCols: Question[],
+  crossQuestions: Question[],
   weightCol: string,
 ): Promise<Tally[]> {
   const tallies: Tally[] = [];
@@ -17,14 +17,14 @@ export async function buildTallies(
     if (q.type === "NA") {
       const gtResult = await aggNaTotals(conn, q.columns[0], weightCol);
       tallies.push(toTally(q, gtResult));
-      for (const cross of crossCols) {
+      for (const cross of crossQuestions) {
         const crossResult = await aggNaCrossTab(conn, q.columns[0], cross, weightCol);
         tallies.push(toTally(q, crossResult, cross));
       }
     } else {
       const gtResult = await aggTotals(conn, q, weightCol);
       tallies.push(toTally(q, gtResult));
-      for (const cross of crossCols) {
+      for (const cross of crossQuestions) {
         const crossResult = await aggCrossTab(conn, q, cross, weightCol);
         tallies.push(toTally(q, crossResult, cross));
       }

--- a/src/lib/agg/buildTallies.ts
+++ b/src/lib/agg/buildTallies.ts
@@ -17,23 +17,23 @@ export async function buildTallies(
     if (q.type === "NA") {
       const gtOutput = await aggNaTotals(conn, q.columns[0], weightCol);
       tallies.push(toTally(q, gtOutput));
-      for (const cross of crossQuestions) {
-        const crossOutput = await aggNaCrossTab(conn, q.columns[0], cross, weightCol);
-        tallies.push(toTally(q, crossOutput, cross));
+      for (const axisQuestion of crossQuestions) {
+        const crossOutput = await aggNaCrossTab(conn, q.columns[0], axisQuestion, weightCol);
+        tallies.push(toTally(q, crossOutput, axisQuestion));
       }
     } else {
       const gtOutput = await aggTotals(conn, q, weightCol);
       tallies.push(toTally(q, gtOutput));
-      for (const cross of crossQuestions) {
-        const crossOutput = await aggCrossTab(conn, q, cross, weightCol);
-        tallies.push(toTally(q, crossOutput, cross));
+      for (const axisQuestion of crossQuestions) {
+        const crossOutput = await aggCrossTab(conn, q, axisQuestion, weightCol);
+        tallies.push(toTally(q, crossOutput, axisQuestion));
       }
     }
   }
   return tallies;
 }
 
-function toTally(question: Question, aggOutput: AggOutput, byQuestion?: Question): Tally {
+function toTally(question: Question, aggOutput: AggOutput, axisQuestion?: Question): Tally {
   const labels: Record<string, string> = { ...question.labels };
 
   if (question.type === "NA") {
@@ -53,17 +53,17 @@ function toTally(question: Question, aggOutput: AggOutput, byQuestion?: Question
     label: question.label,
     labels,
     codes: aggOutput.codes,
-    by: buildAxis(aggOutput, byQuestion),
+    by: buildAxis(aggOutput, axisQuestion),
     slices: aggOutput.slices,
   };
 }
 
-function buildAxis(aggOutput: AggOutput, byQuestion?: Question): Tally["by"] {
-  if (!byQuestion) return null;
-  const axisLabels: Record<string, string> = { ...byQuestion.labels };
+function buildAxis(aggOutput: AggOutput, axisQuestion?: Question): Tally["by"] {
+  if (!axisQuestion) return null;
+  const axisLabels: Record<string, string> = { ...axisQuestion.labels };
   const hasNoAnswer = aggOutput.slices.some((s) => s.code === NO_ANSWER_VALUE);
   if (hasNoAnswer) {
     axisLabels[NO_ANSWER_VALUE] = t("label.noAnswer");
   }
-  return { code: byQuestion.code, label: byQuestion.label, labels: axisLabels };
+  return { code: axisQuestion.code, label: axisQuestion.label, labels: axisLabels };
 }

--- a/src/lib/agg/buildTallies.ts
+++ b/src/lib/agg/buildTallies.ts
@@ -1,5 +1,5 @@
 import type * as duckdb from "@duckdb/duckdb-wasm";
-import type { Question, AggOutput, Tally } from "./types";
+import type { Question, AggOutput, Axis, Tally } from "./types";
 import { aggTotals } from "./aggTotals";
 import { aggCrossTab } from "./aggCrossTab";
 import { aggNaTotals, aggNaCrossTab } from "./aggNa";
@@ -58,7 +58,7 @@ function toTally(question: Question, aggOutput: AggOutput, axisQuestion?: Questi
   };
 }
 
-function buildAxis(aggOutput: AggOutput, axisQuestion?: Question): Tally["by"] {
+function buildAxis(aggOutput: AggOutput, axisQuestion?: Question): Axis | null {
   if (!axisQuestion) return null;
   const axisLabels: Record<string, string> = { ...axisQuestion.labels };
   const hasNoAnswer = aggOutput.slices.some((s) => s.code === NO_ANSWER_VALUE);

--- a/src/lib/agg/buildTallies.ts
+++ b/src/lib/agg/buildTallies.ts
@@ -15,35 +15,35 @@ export async function buildTallies(
   const tallies: Tally[] = [];
   for (const q of questions) {
     if (q.type === "NA") {
-      const gtResult = await aggNaTotals(conn, q.columns[0], weightCol);
-      tallies.push(toTally(q, gtResult));
+      const gtOutput = await aggNaTotals(conn, q.columns[0], weightCol);
+      tallies.push(toTally(q, gtOutput));
       for (const cross of crossQuestions) {
-        const crossResult = await aggNaCrossTab(conn, q.columns[0], cross, weightCol);
-        tallies.push(toTally(q, crossResult, cross));
+        const crossOutput = await aggNaCrossTab(conn, q.columns[0], cross, weightCol);
+        tallies.push(toTally(q, crossOutput, cross));
       }
     } else {
-      const gtResult = await aggTotals(conn, q, weightCol);
-      tallies.push(toTally(q, gtResult));
+      const gtOutput = await aggTotals(conn, q, weightCol);
+      tallies.push(toTally(q, gtOutput));
       for (const cross of crossQuestions) {
-        const crossResult = await aggCrossTab(conn, q, cross, weightCol);
-        tallies.push(toTally(q, crossResult, cross));
+        const crossOutput = await aggCrossTab(conn, q, cross, weightCol);
+        tallies.push(toTally(q, crossOutput, cross));
       }
     }
   }
   return tallies;
 }
 
-function toTally(question: Question, aggResult: AggOutput, byQuestion?: Question): Tally {
+function toTally(question: Question, aggOutput: AggOutput, byQuestion?: Question): Tally {
   const labels: Record<string, string> = { ...question.labels };
 
   if (question.type === "NA") {
     // NA: self-labeling (value string as label)
-    for (const code of aggResult.codes) {
+    for (const code of aggOutput.codes) {
       labels[code] = code;
     }
   }
 
-  if (aggResult.codes.includes(NO_ANSWER_VALUE)) {
+  if (aggOutput.codes.includes(NO_ANSWER_VALUE)) {
     labels[NO_ANSWER_VALUE] = t("label.noAnswer");
   }
 
@@ -52,16 +52,16 @@ function toTally(question: Question, aggResult: AggOutput, byQuestion?: Question
     type: question.type,
     label: question.label,
     labels,
-    codes: aggResult.codes,
-    by: buildAxis(aggResult, byQuestion),
-    slices: aggResult.slices,
+    codes: aggOutput.codes,
+    by: buildAxis(aggOutput, byQuestion),
+    slices: aggOutput.slices,
   };
 }
 
-function buildAxis(aggResult: AggOutput, byQuestion?: Question): Tally["by"] {
+function buildAxis(aggOutput: AggOutput, byQuestion?: Question): Tally["by"] {
   if (!byQuestion) return null;
   const axisLabels: Record<string, string> = { ...byQuestion.labels };
-  const hasNoAnswer = aggResult.slices.some((s) => s.code === NO_ANSWER_VALUE);
+  const hasNoAnswer = aggOutput.slices.some((s) => s.code === NO_ANSWER_VALUE);
   if (hasNoAnswer) {
     axisLabels[NO_ANSWER_VALUE] = t("label.noAnswer");
   }

--- a/src/lib/agg/types.ts
+++ b/src/lib/agg/types.ts
@@ -13,6 +13,8 @@ export interface Question {
 
 export type AggInput = Pick<Question, "type" | "columns" | "codes">;
 
+export type Axis = Pick<Question, "code" | "label" | "labels">;
+
 export interface Cell {
   count: number;
   pct: number;
@@ -45,7 +47,7 @@ export interface Tally {
   type: QuestionType;
   questionCode: string;
   label: string;
-  by: { code: string; label: string; labels: Record<string, string> } | null;
+  by: Axis | null;
   codes: string[];
   labels: Record<string, string>;
   slices: Slice[];

--- a/src/lib/agg/types.ts
+++ b/src/lib/agg/types.ts
@@ -11,7 +11,7 @@ export interface Question {
   labels: Record<string, string>;
 }
 
-export type AggInput = Pick<Question, "type" | "columns" | "codes">;
+export type Shape = Pick<Question, "type" | "columns" | "codes">;
 
 export type Axis = Pick<Question, "code" | "label" | "labels">;
 

--- a/src/lib/duckdbBridge.ts
+++ b/src/lib/duckdbBridge.ts
@@ -76,11 +76,11 @@ export async function runValidation(headers: string[], layout: Layout): Promise<
 /** Execute aggregation for all question × axis combinations */
 export async function runAggregation(
   questions: Question[],
-  crossCols: Question[],
+  crossQuestions: Question[],
   weightCol: string,
 ): Promise<Tally[]> {
   const c = await getConnection();
-  return buildTallies(c, questions, crossCols, weightCol);
+  return buildTallies(c, questions, crossQuestions, weightCol);
 }
 
 /** Prepare DATE columns in layout (convert to SA with auto-generated items) */

--- a/tests/aggCrossTab.test.ts
+++ b/tests/aggCrossTab.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { aggCrossTab } from "../src/lib/agg/aggCrossTab";
 import { setupDuckDB, teardownDuckDB, getConn } from "./helpers/duckdb";
-import { getAggInput } from "./helpers/fixtures";
+import { getShape } from "./helpers/fixtures";
 
 beforeAll(async () => {
   await setupDuckDB();
@@ -11,9 +11,9 @@ afterAll(async () => {
   await teardownDuckDB();
 });
 
-const q1 = getAggInput("q1");
-const q2 = getAggInput("q2");
-const q3 = getAggInput("q3");
+const q1 = getShape("q1");
+const q2 = getShape("q2");
+const q3 = getShape("q3");
 
 /** スライスのcounts配列を取得 */
 function sliceCounts(result: { codes: string[]; slices: { code: string | null; cells: { count: number }[] }[] }, sliceCode: string): number[] {

--- a/tests/aggCrossTabEdge.test.ts
+++ b/tests/aggCrossTabEdge.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { aggCrossTab } from "../src/lib/agg/aggCrossTab";
 import { setupDuckDB, teardownDuckDB, getConn, loadCSV } from "./helpers/duckdb";
-import { getAggInput, weightColumn } from "./helpers/fixtures";
+import { getShape, weightColumn } from "./helpers/fixtures";
 import { buildCSV } from "./helpers/csv";
-import type { AggInput } from "../src/lib/agg/types";
+import type { Shape } from "../src/lib/agg/types";
 
 beforeAll(async () => {
   await setupDuckDB();
@@ -13,9 +13,9 @@ afterAll(async () => {
   await teardownDuckDB();
 });
 
-const q1 = getAggInput("q1");
-const q2 = getAggInput("q2");
-const q3 = getAggInput("q3");
+const q1 = getShape("q1");
+const q2 = getShape("q2");
+const q3 = getShape("q3");
 
 function sliceCounts(
   result: { slices: { code: string | null; cells: { count: number }[] }[] },
@@ -189,8 +189,8 @@ describe("aggCrossTabEdge - エッジケース", () => {
         [3, 1, 5],
       ]),
     );
-    const mainInput: AggInput = { type: "SA", columns: ["main"], codes: ["1", "2"] };
-    const crossInput: AggInput = { type: "SA", columns: ["cross"], codes: ["5"] };
+    const mainInput: Shape = { type: "SA", columns: ["main"], codes: ["1", "2"] };
+    const crossInput: Shape = { type: "SA", columns: ["cross"], codes: ["5"] };
     const result = await aggCrossTab(getConn(), mainInput, crossInput, "");
 
     expect(result.slices).toHaveLength(1);
@@ -206,8 +206,8 @@ describe("aggCrossTabEdge - エッジケース", () => {
         [3, null, 1],
       ]),
     );
-    const mainInput: AggInput = { type: "SA", columns: ["main"], codes: ["1"] };
-    const crossInput: AggInput = { type: "SA", columns: ["cross"], codes: ["1", "2"] };
+    const mainInput: Shape = { type: "SA", columns: ["main"], codes: ["1"] };
+    const crossInput: Shape = { type: "SA", columns: ["cross"], codes: ["1", "2"] };
     const result = await aggCrossTab(getConn(), mainInput, crossInput, "");
 
     for (const slice of result.slices) {
@@ -217,8 +217,8 @@ describe("aggCrossTabEdge - エッジケース", () => {
 
   it("1行のみのクロス", async () => {
     await loadCSV(buildCSV(["id", "main", "cross"], [[1, 2, 3]]));
-    const mainInput: AggInput = { type: "SA", columns: ["main"], codes: ["1", "2"] };
-    const crossInput: AggInput = { type: "SA", columns: ["cross"], codes: ["3", "4"] };
+    const mainInput: Shape = { type: "SA", columns: ["main"], codes: ["1", "2"] };
+    const crossInput: Shape = { type: "SA", columns: ["cross"], codes: ["3", "4"] };
     const result = await aggCrossTab(getConn(), mainInput, crossInput, "");
 
     expect(sliceCounts(result, "3")).toEqual([0, 1]);

--- a/tests/aggNa.test.ts
+++ b/tests/aggNa.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { aggregateNaGt, aggregateNaCross } from "../src/lib/agg/aggregateNa";
+import { aggNaTotals, aggNaCrossTab } from "../src/lib/agg/aggNa";
 import { setupDuckDB, teardownDuckDB, getConn, loadCSV } from "./helpers/duckdb";
 import type { Shape } from "../src/lib/agg/types";
 
@@ -28,9 +28,9 @@ afterAll(async () => {
   await teardownDuckDB();
 });
 
-describe("aggregateNaGt - unweighted", () => {
+describe("aggNaTotals - unweighted", () => {
   it("returns correct stats for score column", async () => {
-    const result = await aggregateNaGt(getConn(), "score", "");
+    const result = await aggNaTotals(getConn(), "score", "");
 
     expect(result.slices).toHaveLength(1);
     const slice = result.slices[0];
@@ -47,7 +47,7 @@ describe("aggregateNaGt - unweighted", () => {
   });
 
   it("returns correct frequency distribution as codes/cells", async () => {
-    const result = await aggregateNaGt(getConn(), "score", "");
+    const result = await aggNaTotals(getConn(), "score", "");
 
     // Unique values: 3,4,5,6,7,8,9,10
     expect(result.codes).toEqual(["3", "4", "5", "6", "7", "8", "9", "10"]);
@@ -65,9 +65,9 @@ describe("aggregateNaGt - unweighted", () => {
   });
 });
 
-describe("aggregateNaGt - weighted", () => {
+describe("aggNaTotals - weighted", () => {
   it("returns weighted stats", async () => {
-    const result = await aggregateNaGt(getConn(), "score", "weight");
+    const result = await aggNaTotals(getConn(), "score", "weight");
 
     const slice = result.slices[0];
     // Weighted n = sum of weights for valid score rows
@@ -81,9 +81,9 @@ describe("aggregateNaGt - weighted", () => {
   });
 });
 
-describe("aggregateNaCross - NA × SA", () => {
+describe("aggNaCrossTab - NA × SA", () => {
   it("returns slices grouped by cross column", async () => {
-    const result = await aggregateNaCross(getConn(), "score", crossSA, "");
+    const result = await aggNaCrossTab(getConn(), "score", crossSA, "");
 
     expect(result.slices).toHaveLength(2);
     expect(result.slices[0].code).toBe("1");
@@ -100,7 +100,7 @@ describe("aggregateNaCross - NA × SA", () => {
   });
 
   it("returns aligned codes and cells per cross segment", async () => {
-    const result = await aggregateNaCross(getConn(), "score", crossSA, "");
+    const result = await aggNaCrossTab(getConn(), "score", crossSA, "");
 
     // All unique values across both segments: 3,4,5,6,7,8,9,10
     expect(result.codes).toEqual(["3", "4", "5", "6", "7", "8", "9", "10"]);

--- a/tests/aggTotals.test.ts
+++ b/tests/aggTotals.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { aggTotals } from "../src/lib/agg/aggTotals";
 import { setupDuckDB, teardownDuckDB, getConn } from "./helpers/duckdb";
-import { getAggInput } from "./helpers/fixtures";
+import { getShape } from "./helpers/fixtures";
 
 beforeAll(async () => {
   await setupDuckDB();
@@ -11,8 +11,8 @@ afterAll(async () => {
   await teardownDuckDB();
 });
 
-const q1 = getAggInput("q1");
-const q3 = getAggInput("q3");
+const q1 = getShape("q1");
+const q3 = getShape("q3");
 
 // ============================================================
 // テストデータ (testdata/test_data.csv) 14行

--- a/tests/aggTotalsEdge.test.ts
+++ b/tests/aggTotalsEdge.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { aggTotals } from "../src/lib/agg/aggTotals";
 import { setupDuckDB, teardownDuckDB, getConn, loadCSV } from "./helpers/duckdb";
 import { buildCSV } from "./helpers/csv";
-import type { AggInput } from "../src/lib/agg/types";
+import type { Shape } from "../src/lib/agg/types";
 
 beforeAll(async () => {
   await setupDuckDB();
@@ -19,7 +19,7 @@ describe("aggTotalsEdge - SA", () => {
         [1, 1], [2, 1], [3, 1], [4, 1], [5, 1],
       ]),
     );
-    const input: AggInput = { type: "SA", columns: ["q1"], codes: ["1", "2"] };
+    const input: Shape = { type: "SA", columns: ["q1"], codes: ["1", "2"] };
     const result = await aggTotals(getConn(), input, "");
 
     const slice = result.slices[0];
@@ -36,7 +36,7 @@ describe("aggTotalsEdge - SA", () => {
         [1, null], [2, null], [3, null],
       ]),
     );
-    const input: AggInput = { type: "SA", columns: ["q1"], codes: ["1"] };
+    const input: Shape = { type: "SA", columns: ["q1"], codes: ["1"] };
     const result = await aggTotals(getConn(), input, "");
 
     expect(result.slices[0].n).toBe(0);
@@ -44,7 +44,7 @@ describe("aggTotalsEdge - SA", () => {
 
   it("1行のみ → n=1, count=1", async () => {
     await loadCSV(buildCSV(["id", "q1"], [[1, 2]]));
-    const input: AggInput = { type: "SA", columns: ["q1"], codes: ["1", "2"] };
+    const input: Shape = { type: "SA", columns: ["q1"], codes: ["1", "2"] };
     const result = await aggTotals(getConn(), input, "");
 
     expect(result.slices[0].n).toBe(1);
@@ -58,7 +58,7 @@ describe("aggTotalsEdge - SA", () => {
         [1, 1], [2, 1], [3, 1],
       ]),
     );
-    const input: AggInput = { type: "SA", columns: ["q1"], codes: ["1", "2", "3"] };
+    const input: Shape = { type: "SA", columns: ["q1"], codes: ["1", "2", "3"] };
     const result = await aggTotals(getConn(), input, "");
 
     expect(result.slices[0].cells[0].count).toBe(3);
@@ -74,7 +74,7 @@ describe("aggTotalsEdge - SA", () => {
         [3, 1.0, 2],
       ]),
     );
-    const input: AggInput = { type: "SA", columns: ["q1"], codes: ["1", "2"] };
+    const input: Shape = { type: "SA", columns: ["q1"], codes: ["1", "2"] };
     const result = await aggTotals(getConn(), input, "weight");
 
     expect(result.slices[0].n).toBeCloseTo(2.0, 3);
@@ -88,7 +88,7 @@ describe("aggTotalsEdge - SA", () => {
         [1, 1, 1], [2, 1, 2], [3, 1, 1], [4, 1, 3], [5, 1, 2],
       ]),
     );
-    const input: AggInput = { type: "SA", columns: ["q1"], codes: ["1", "2", "3"] };
+    const input: Shape = { type: "SA", columns: ["q1"], codes: ["1", "2", "3"] };
     const unweighted = await aggTotals(getConn(), input, "");
     const weighted = await aggTotals(getConn(), input, "weight");
 
@@ -108,7 +108,7 @@ describe("aggTotalsEdge - MA", () => {
         [3, 1, 0],
       ]),
     );
-    const input: AggInput = { type: "MA", columns: ["q_1", "q_2"], codes: ["1", "2"] };
+    const input: Shape = { type: "MA", columns: ["q_1", "q_2"], codes: ["1", "2"] };
     const result = await aggTotals(getConn(), input, "");
 
     // shown行は行3のみ → n=1
@@ -125,7 +125,7 @@ describe("aggTotalsEdge - MA", () => {
         [3, 0, 0],
       ]),
     );
-    const input: AggInput = { type: "MA", columns: ["q_1", "q_2"], codes: ["1", "2"] };
+    const input: Shape = { type: "MA", columns: ["q_1", "q_2"], codes: ["1", "2"] };
     const result = await aggTotals(getConn(), input, "");
 
     expect(result.slices[0].n).toBe(3);

--- a/tests/aggTotalsPbt.test.ts
+++ b/tests/aggTotalsPbt.test.ts
@@ -24,7 +24,7 @@ describe("PBT - aggTotals SA 重みなし", () => {
     it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
       const ds = generateSADataset({ seed, rowCount: rowCount(seed) });
       await loadCSV(ds.csv);
-      const result = await aggTotals(getConn(), ds.aggInput, "");
+      const result = await aggTotals(getConn(), ds.shape, "");
       assertGtInvariants(result, "SA");
     });
   }
@@ -35,7 +35,7 @@ describe("PBT - aggTotals SA 重みあり", () => {
     it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
       const ds = generateSADataset({ seed, rowCount: rowCount(seed), weighted: true });
       await loadCSV(ds.csv);
-      const result = await aggTotals(getConn(), ds.aggInput, ds.weightCol);
+      const result = await aggTotals(getConn(), ds.shape, ds.weightCol);
       assertGtInvariants(result, "SA");
     });
   }
@@ -46,7 +46,7 @@ describe("PBT - aggTotals MA 重みなし", () => {
     it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
       const ds = generateMADataset({ seed, rowCount: rowCount(seed) });
       await loadCSV(ds.csv);
-      const result = await aggTotals(getConn(), ds.aggInput, "");
+      const result = await aggTotals(getConn(), ds.shape, "");
       assertGtInvariants(result, "MA");
     });
   }
@@ -57,7 +57,7 @@ describe("PBT - aggTotals MA 重みあり", () => {
     it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
       const ds = generateMADataset({ seed, rowCount: rowCount(seed), weighted: true });
       await loadCSV(ds.csv);
-      const result = await aggTotals(getConn(), ds.aggInput, ds.weightCol);
+      const result = await aggTotals(getConn(), ds.shape, ds.weightCol);
       assertGtInvariants(result, "MA");
     });
   }

--- a/tests/aggregateNa.test.ts
+++ b/tests/aggregateNa.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { aggregateNaGt, aggregateNaCross } from "../src/lib/agg/aggregateNa";
 import { setupDuckDB, teardownDuckDB, getConn, loadCSV } from "./helpers/duckdb";
-import type { AggInput } from "../src/lib/agg/types";
+import type { Shape } from "../src/lib/agg/types";
 
 // Test CSV with a numeric column (score: 0-10 NPS-like)
 const CSV = `id,weight,q1,score
@@ -17,7 +17,7 @@ const CSV = `id,weight,q1,score
 10,1.0,2,
 `;
 
-const crossSA: AggInput = { type: "SA", columns: ["q1"], codes: ["1", "2"] };
+const crossSA: Shape = { type: "SA", columns: ["q1"], codes: ["1", "2"] };
 
 beforeAll(async () => {
   await setupDuckDB();

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -1,13 +1,13 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { parseLayout, buildQuestions, findWeightColumn } from "../../src/lib/layout";
-import type { AggInput, Question } from "../../src/lib/agg/types";
+import type { Shape, Question } from "../../src/lib/agg/types";
 
 const layoutPath = resolve(import.meta.dirname!, "../../testdata/test_layout.json");
 const layout = parseLayout(readFileSync(layoutPath, "utf-8"));
 const questions = buildQuestions(layout);
 
-export function getAggInput(code: string): AggInput {
+export function getShape(code: string): Shape {
   const q = questions.find((q) => q.code === code);
   if (!q) throw new Error(`Question "${code}" not found in test_layout.json`);
   const { type, columns, codes } = q;

--- a/tests/helpers/generators.ts
+++ b/tests/helpers/generators.ts
@@ -1,4 +1,4 @@
-import type { AggInput } from "../../src/lib/agg/types";
+import type { Shape } from "../../src/lib/agg/types";
 import { buildCSV } from "./csv";
 
 export class Rng {
@@ -35,21 +35,21 @@ interface DatasetOpts {
 
 interface SADataset {
   csv: string;
-  aggInput: AggInput;
+  shape: Shape;
   weightCol: string;
 }
 
 interface MADataset {
   csv: string;
-  aggInput: AggInput;
+  shape: Shape;
   weightCol: string;
 }
 
 interface CrossDataset {
   csv: string;
-  saInput: AggInput;
-  sa2Input: AggInput;
-  maInput: AggInput;
+  saInput: Shape;
+  sa2Input: Shape;
+  maInput: Shape;
   weightCol: string;
 }
 
@@ -73,7 +73,7 @@ export function generateSADataset(opts: DatasetOpts): SADataset {
 
   return {
     csv: buildCSV(headers, rows),
-    aggInput: { type: "SA", columns: ["q_sa"], codes },
+    shape: { type: "SA", columns: ["q_sa"], codes },
     weightCol: weighted ? "weight" : "",
   };
 }
@@ -107,7 +107,7 @@ export function generateMADataset(opts: DatasetOpts): MADataset {
 
   return {
     csv: buildCSV(headers, rows),
-    aggInput: { type: "MA", columns, codes },
+    shape: { type: "MA", columns, codes },
     weightCol: weighted ? "weight" : "",
   };
 }


### PR DESCRIPTION
## Summary
- `aggregateNa` → `aggNa` にリネーム（SA/MA用の `aggTotals`/`aggCrossTab` と命名規則を統一）
- `crossCols` → `crossQuestions` にリネーム（`Question[]` 型であることを明示）
- `gtResult`/`crossResult` → `gtOutput`/`crossOutput` にリネーム（`AggOutput` 型名と一致）
- `gt` → `totals` にリネーム（`TotalsAggregator` クラス名と一致）
- `AggInput` → `Shape` にリネーム、`Axis` 型を導入しクロス軸の変数名を整理
- テストファイルのインポートパス・関数名・ファイル名も追従

## Test plan
- [ ] `pnpm test` で全テストがパスすることを確認
- [ ] `pnpm build` でビルドが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)