### PR TITLE
refactor: duckdbBridge → duckdb リネーム＆依存方向修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ pnpm bench:gen  # generate benchmark data
 
 - Data format conventions: see `.claude/skills/aggy-import/references/data-preparation-guide.md`
 - Component files: PascalCase `.tsx`; lib files: camelCase `.ts`
-- Module-level singleton state for infrastructure (`duckdbBridge`, `i18n`); UI state uses hooks + Context
+- Module-level singleton state for infrastructure (`duckdb`, `i18n`); UI state uses hooks + Context
 - File ordering: `imports → exports (Public API) → internal implementation`. Props interfaces stay with their exported component
-- DuckDB Wasm runs sequentially on a single Web Worker — never use `Promise.all` with `duckdbBridge` methods; call them with sequential `await`
+- DuckDB Wasm runs sequentially on a single Web Worker — never use `Promise.all` with `duckdb` methods; call them with sequential `await`
 - Prefer functional style by default. Use classes when multiple functions need shared state to avoid props drilling (e.g. `aggregateGT` — bundle related data into a class and access it via methods)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "preact/hooks";
-import { initDuckDB } from "./lib/duckdbBridge";
+import { initDuckDB } from "./lib/duckdb";
 import { initTheme } from "./components/header/SettingsModal";
 import Header from "./components/Header";
 import ImportScreen from "./components/ImportScreen";

--- a/src/components/AggregationScreen.tsx
+++ b/src/components/AggregationScreen.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "preact/hooks";
 import type { Tally } from "../lib/agg/types";
 import ResultPanel from "./aggregation/ResultPanel";
 import SettingsPanel from "./aggregation/SettingsPanel";
-import { runAggregation } from "../lib/duckdbBridge";
+import { runAggregation } from "../lib/duckdb";
 import { buildQuestions, findWeightColumn } from "../lib/layout";
 import { t } from "../lib/i18n";
 import type { CsvData, LayoutData } from "../lib/types";

--- a/src/components/ImportScreen.tsx
+++ b/src/components/ImportScreen.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense } from "preact/compat";
 import { useCallback, useRef, useState } from "preact/hooks";
 import { parseLayout, filterLayout } from "../lib/layout";
-import { loadCSV, prepareDateLayout } from "../lib/duckdbBridge";
+import { loadCSV, prepareDateLayout } from "../lib/duckdb";
 import { saveData, loadSaved } from "../lib/opfs";
 import { t } from "../lib/i18n";
 

--- a/src/components/header/WasmStatus.tsx
+++ b/src/components/header/WasmStatus.tsx
@@ -1,18 +1,17 @@
-import { useState } from "preact/hooks";
+import { useEffect, useState } from "preact/hooks";
+import { setStatusListener, type DuckStatus } from "../../lib/duckdb";
 import { t } from "../../lib/i18n";
 
-export function setWasmStatus(s: DotStatus, label?: string): void {
-  rerender?.(s, label);
-}
-
 export default function WasmStatus() {
-  const [status, setStatus] = useState<DotStatus>("loading");
+  const [status, setStatus] = useState<DuckStatus>("loading");
   const [label, setLabel] = useState<string>(t("wasm.loading"));
 
-  rerender = (s, l) => {
-    setStatus(s);
-    if (l !== undefined) setLabel(l);
-  };
+  useEffect(() => {
+    setStatusListener((s, l) => {
+      setStatus(s);
+      if (l !== undefined) setLabel(l);
+    });
+  }, []);
 
   return (
     <div
@@ -31,12 +30,8 @@ export default function WasmStatus() {
 
 // ─── Internal ───────────────────────────────────────────────
 
-type DotStatus = "loading" | "ready" | "error";
-
-const STATUS_CLASSES: Record<DotStatus, string> = {
+const STATUS_CLASSES: Record<DuckStatus, string> = {
   loading: "bg-[var(--color-warning-700)] animate-[pulse_1s_infinite]",
   ready: "bg-[var(--color-success-700)]",
   error: "bg-danger",
 };
-
-let rerender: ((s: DotStatus, label?: string) => void) | null = null;

--- a/src/components/import/ValidationStep.tsx
+++ b/src/components/import/ValidationStep.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "preact/hooks";
 import { t } from "../../lib/i18n";
-import { runValidation } from "../../lib/duckdbBridge";
+import { runValidation } from "../../lib/duckdb";
 import type { ValidationResult } from "../../lib/validateData";
 import type { CsvData, LayoutData } from "../../lib/types";
 

--- a/src/lib/duckdb.ts
+++ b/src/lib/duckdb.ts
@@ -3,15 +3,23 @@ import type { Question, Tally } from "./agg/types";
 import type { Layout } from "./layout";
 import { buildTallies } from "./agg/buildTallies";
 import { prepareDateColumns, type DatePreparationResult } from "./datePreparation";
-import { setWasmStatus } from "../components/header/WasmStatus";
 import { validateData, type ValidationResult } from "./validateData";
+
+export type DuckStatus = "loading" | "ready" | "error";
+export type StatusListener = (s: DuckStatus, label?: string) => void;
+
+let statusListener: StatusListener | null = null;
+
+export function setStatusListener(listener: StatusListener): void {
+  statusListener = listener;
+}
 
 export async function initDuckDB(): Promise<void> {
   if (initPromise) return initPromise;
 
   initPromise = (async () => {
     try {
-      updateStatusUI("loading", "DuckDB 読み込み中...");
+      statusListener?.("loading", "DuckDB 読み込み中...");
 
       const BUNDLES: duckdb.DuckDBBundles = {
         mvp: {
@@ -34,10 +42,10 @@ export async function initDuckDB(): Promise<void> {
       await db.instantiate(bundle.mainModule, bundle.pthreadWorker);
 
       status = "ready";
-      updateStatusUI("ready", "DuckDB Ready");
+      statusListener?.("ready", "DuckDB Ready");
     } catch (err) {
       status = "error";
-      updateStatusUI("error", `DuckDB エラー: ${(err as Error).message}`);
+      statusListener?.("error", `DuckDB エラー: ${(err as Error).message}`);
       throw err;
     }
   })();
@@ -93,16 +101,10 @@ export async function prepareDateLayout(layout: Layout): Promise<DatePreparation
 
 const DUCKDB_CDN = "https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.33.1-dev18.0/dist";
 
-type DuckStatus = "loading" | "ready" | "error";
-
 let db: duckdb.AsyncDuckDB | null = null;
 let conn: duckdb.AsyncDuckDBConnection | null = null;
 let status: DuckStatus = "loading";
 let initPromise: Promise<void> | null = null;
-
-function updateStatusUI(s: DuckStatus, label?: string): void {
-  setWasmStatus(s, label);
-}
 
 async function getConnection(): Promise<duckdb.AsyncDuckDBConnection> {
   if (!db || status !== "ready") throw new Error("DuckDB is not ready");


### PR DESCRIPTION
## Summary
- `duckdbBridge.ts` → `duckdb.ts` にリネーム（より簡潔な命名）
- lib → components の依存（`setWasmStatus` import）を解消し、コールバック注入パターン（`setStatusListener`）で components → lib の一方向依存に統一
- 全 import パスと CLAUDE.md の参照を更新

## Test plan
- [x] `pnpm check` パス（fmt, lint, tsc）
- [x] `pnpm test` 全668テストパス
- [ ] ブラウザで DuckDB ステータスインジケータが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)