### PR TITLE
refactor: aggResult から weightCol を除去し親の状態から導出

### DIFF
--- a/src/components/AggregationScreen.tsx
+++ b/src/components/AggregationScreen.tsx
@@ -40,8 +40,8 @@ export default function AggregationScreen({ csv, layout, dateWarnings }: Aggrega
     const crossQuestions = questions.filter((q) => crossSelected[q.code]);
 
     try {
-      const result = await runAggregation(questions, crossQuestions, wCol);
-      setTallies(result);
+      const tallies = await runAggregation(questions, crossQuestions, wCol);
+      setTallies(tallies);
     } catch (e) {
       setErrorMsg(t("error.aggregation", { msg: (e as Error).message }));
     }


### PR DESCRIPTION
## Summary
- `aggResult: { tallies, weightCol }` を `tallies: Tally[] | null` に簡素化
- `ResultPanel` の `weightCol` は親の `weightEnabled` と `weightCol` から直接導出するように変更
- `runAggregation` の受け変数を `result` → `tallies` にリネーム

## Test plan
- [x] `pnpm check` パス
- [x] `pnpm test` 全668テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)