### PR TITLE
refactor: gt/totals → grandTotal にユビキタス言語を統一

### DIFF
--- a/.claude/skills/measure-e2e-perf/SKILL.md
+++ b/.claude/skills/measure-e2e-perf/SKILL.md
@@ -49,7 +49,7 @@ On the ImportScreen:
 
 Click the "Proceed" button. The app transitions to AggregationScreen and auto-runs the first aggregation. Wait for the result table to appear using `wait_for`.
 
-### Step 5: Run GT-only aggregation with Performance tracing
+### Step 5: Run Grand Total-only aggregation with Performance tracing
 
 Measure Grand Total only (no cross-tab):
 
@@ -76,7 +76,7 @@ Measure with cross-tabulation enabled:
 
 Use `performance_analyze_insight` to inspect both trace results. Report a comparison table:
 
-| Metric | GT only | Cross-tab (SA x2) |
+| Metric | Grand Total only | Cross-tab (SA x2) |
 |--------|---------|-------------------|
 | INP | | |
 | Input delay | | |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Aggy is a browser-based survey raw-data aggregation tool (アンケートローデータ集計システム). Users upload a CSV of survey responses and a JSON layout file, then run GT (Grand Total) and cross-tabulation — all client-side using DuckDB Wasm for SQL-based aggregation.
+Aggy is a browser-based survey raw-data aggregation tool (アンケートローデータ集計システム). Users upload a CSV of survey responses and a JSON layout file, then run Grand Total and cross-tabulation — all client-side using DuckDB Wasm for SQL-based aggregation.
 
 Tech: TypeScript (strict), Vite, Preact (JSX), DuckDB Wasm, Tailwind CSS v4.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,4 +34,4 @@ pnpm bench:gen  # generate benchmark data
 - Module-level singleton state for infrastructure (`duckdb`, `i18n`); UI state uses hooks + Context
 - File ordering: `imports → exports (Public API) → internal implementation`. Props interfaces stay with their exported component
 - DuckDB Wasm runs sequentially on a single Web Worker — never use `Promise.all` with `duckdb` methods; call them with sequential `await`
-- Prefer functional style by default. Use classes when multiple functions need shared state to avoid props drilling (e.g. `aggregateGT` — bundle related data into a class and access it via methods)
+- Prefer functional style by default. Use classes when multiple functions need shared state to avoid props drilling (e.g. `aggGrandTotal` — bundle related data into a class and access it via methods)

--- a/bench/run.ts
+++ b/bench/run.ts
@@ -11,7 +11,7 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { performance } from "node:perf_hooks";
 
-import { aggTotals } from "../src/lib/agg/aggTotals";
+import { aggGrandTotal } from "../src/lib/agg/aggGrandTotal";
 import { aggCrossTab } from "../src/lib/agg/aggCrossTab";
 import type { Question } from "../src/lib/agg/types";
 import { parseLayout, filterLayout, buildQuestions } from "../src/lib/layout";
@@ -85,7 +85,7 @@ async function benchPattern(
   for (let i = 0; i < RUNS; i++) {
     const start = performance.now();
     for (const q of questions) {
-      await aggTotals(conn, q, weightCol);
+      await aggGrandTotal(conn, q, weightCol);
       for (const cross of crossCols) {
         await aggCrossTab(conn, q, cross, weightCol);
       }

--- a/e2e/aggregation.spec.ts
+++ b/e2e/aggregation.spec.ts
@@ -26,7 +26,7 @@ test("GT集計結果の自動表示", async ({ page }) => {
   await uploadFiles(page);
   await proceedToAggregation(page);
 
-  // 自動実行による GT テーブルが表示される
+  // 自動実行による Grand Total テーブルが表示される
   // テーブル caption でラベルを確認（getByText だと複数要素にマッチするため）
   await expect(page.getByText("性別 の集計結果")).toBeAttached({
     timeout: 30_000,
@@ -45,7 +45,7 @@ test("クロス集計", async ({ page }) => {
   await uploadFiles(page);
   await proceedToAggregation(page);
 
-  // GT テーブル表示を待つ
+  // Grand Total テーブル表示を待つ
   await expect(page.getByText("性別 の集計結果")).toBeAttached({
     timeout: 30_000,
   });

--- a/src/components/aggregation/ChartCardBody.tsx
+++ b/src/components/aggregation/ChartCardBody.tsx
@@ -6,16 +6,16 @@ import type { ChartType } from "./viewTypes";
 import type { ChartConfiguration } from "chart.js";
 
 interface ChartCardBodyProps {
-  gtTally: Tally;
+  grandTotalTally: Tally;
   crossTallies: Tally[];
-  gtChartType: ChartType;
+  grandTotalChartType: ChartType;
   paletteId: PaletteId;
 }
 
 export function ChartCardBody({
-  gtTally,
+  grandTotalTally,
   crossTallies,
-  gtChartType,
+  grandTotalChartType,
   paletteId,
 }: ChartCardBodyProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -33,21 +33,27 @@ export function ChartCardBody({
     if (isCross) {
       chartRef.current = buildCrossChart(
         canvas,
-        gtTally,
+        grandTotalTally,
         crossTallies,
-        gtChartType,
+        grandTotalChartType,
         theme,
         paletteId,
       );
     } else {
-      chartRef.current = buildGtChart(canvas, gtTally, gtChartType, theme, paletteId);
+      chartRef.current = buildGrandTotalChart(
+        canvas,
+        grandTotalTally,
+        grandTotalChartType,
+        theme,
+        paletteId,
+      );
     }
 
     return () => {
       chartRef.current?.destroy();
       chartRef.current = null;
     };
-  }, [gtTally, crossTallies, gtChartType, paletteId]);
+  }, [grandTotalTally, crossTallies, grandTotalChartType, paletteId]);
 
   return (
     <div class={`p-4 ${isCross ? "h-[400px]" : "h-80"}`}>
@@ -60,7 +66,7 @@ function resolveLabel(code: string, tally: Tally): string {
   return tally.labels[code];
 }
 
-function buildGtChart(
+function buildGrandTotalChart(
   canvas: HTMLCanvasElement,
   tally: Tally,
   chartType: ChartType,
@@ -152,9 +158,9 @@ function buildGtChart(
 
 function buildCrossChart(
   canvas: HTMLCanvasElement,
-  gtTally: Tally,
+  grandTotalTally: Tally,
   crossTallies: Tally[],
-  gtChartType: ChartType,
+  grandTotalChartType: ChartType,
   theme: ReturnType<typeof getThemeColors>,
   paletteId: PaletteId,
 ): Chart {
@@ -167,10 +173,10 @@ function buildCrossChart(
     }));
   });
 
-  if (gtChartType === "obi") {
+  if (grandTotalChartType === "obi") {
     const subLabels = allSlices.map((s) => s.label);
-    const datasets = gtTally.codes.map((code, i) => ({
-      label: resolveLabel(code, gtTally),
+    const datasets = grandTotalTally.codes.map((code, i) => ({
+      label: resolveLabel(code, grandTotalTally),
       data: allSlices.map((s) => s.slice.cells[i]?.pct ?? 0),
       backgroundColor: getSeriesColor(i, paletteId),
       maxBarThickness: 48,
@@ -204,12 +210,12 @@ function buildCrossChart(
     } as ChartConfiguration);
   }
 
-  const isHorizontal = gtChartType === "bar-h";
-  const labels = gtTally.codes.map((code) => resolveLabel(code, gtTally));
+  const isHorizontal = grandTotalChartType === "bar-h";
+  const labels = grandTotalTally.codes.map((code) => resolveLabel(code, grandTotalTally));
 
   const datasets = allSlices.map((s, i) => ({
     label: s.label,
-    data: gtTally.codes.map((_, ci) => s.slice.cells[ci]?.pct ?? 0),
+    data: grandTotalTally.codes.map((_, ci) => s.slice.cells[ci]?.pct ?? 0),
     backgroundColor: getSeriesColor(i, paletteId),
     borderRadius: 3,
     maxBarThickness: 40,

--- a/src/components/aggregation/CrossTable.tsx
+++ b/src/components/aggregation/CrossTable.tsx
@@ -5,34 +5,42 @@ import { formatN } from "../../lib/format";
 import { Th, Td } from "./TableCells";
 
 interface CrossTableProps {
-  gtTally: Tally;
+  grandTotalTally: Tally;
   crossTallies: Tally[];
   pctDir: PctDirection;
 }
 
-export function CrossTable({ gtTally, crossTallies, pctDir }: CrossTableProps) {
+export function CrossTable({ grandTotalTally, crossTallies, pctDir }: CrossTableProps) {
   if (pctDir === "horizontal") {
-    return <TransposedCrossTable gtTally={gtTally} crossTallies={crossTallies} />;
+    return <TransposedCrossTable grandTotalTally={grandTotalTally} crossTallies={crossTallies} />;
   }
-  return <VerticalCrossTable gtTally={gtTally} crossTallies={crossTallies} />;
+  return <VerticalCrossTable grandTotalTally={grandTotalTally} crossTallies={crossTallies} />;
 }
 
 const TH_BASE = "py-3 px-4 text-xs font-bold tracking-wide border-b-2 border-border-strong";
 const TD_BASE = "py-3 px-4 border-b border-row-border leading-[1.2]";
 const MONO = "text-right tabular-nums font-mono";
 
-function VerticalCrossTable({ gtTally, crossTallies }: { gtTally: Tally; crossTallies: Tally[] }) {
-  const gtSlice = gtTally.slices[0];
-  const codes = gtTally.codes;
+function VerticalCrossTable({
+  grandTotalTally,
+  crossTallies,
+}: {
+  grandTotalTally: Tally;
+  crossTallies: Tally[];
+}) {
+  const grandTotalSlice = grandTotalTally.slices[0];
+  const codes = grandTotalTally.codes;
   const hasMultipleAxes = crossTallies.length > 1;
 
   return (
     <table class="w-full border-collapse text-sm tabular-nums min-w-[400px]">
-      <caption class="sr-only">{t("table.caption.cross", { question: gtTally.label })}</caption>
+      <caption class="sr-only">
+        {t("table.caption.cross", { question: grandTotalTally.label })}
+      </caption>
       <thead>
         <tr>
           <th rowSpan={2} class="py-3 px-4" />
-          <th colSpan={2} class={`${TH_BASE} text-center bg-gt-bg text-accent`}>
+          <th colSpan={2} class={`${TH_BASE} text-center bg-grandTotal-bg text-accent`}>
             {t("table.total")}
           </th>
           {crossTallies.map((ct) => (
@@ -64,15 +72,15 @@ function VerticalCrossTable({ gtTally, crossTallies }: { gtTally: Tally; crossTa
       </thead>
       <tbody class="[&_tr:hover_td]:bg-row-hover [&_tr:last-child_td]:border-b-0">
         {codes.map((code, i) => {
-          const gtCell = gtSlice.cells[i];
+          const grandTotalCell = grandTotalSlice.cells[i];
           return (
             <tr key={code}>
-              <Td>{gtTally.labels[code]}</Td>
+              <Td>{grandTotalTally.labels[code]}</Td>
               <Td right mono>
-                {formatN(gtCell.count)}
+                {formatN(grandTotalCell.count)}
               </Td>
               <Td right mono class="text-muted">
-                {gtCell.pct.toFixed(1)}%
+                {grandTotalCell.pct.toFixed(1)}%
               </Td>
               {crossTallies.map((ct, gi) =>
                 ct.slices.map((slice, si) => {
@@ -96,18 +104,20 @@ function VerticalCrossTable({ gtTally, crossTallies }: { gtTally: Tally; crossTa
 }
 
 function TransposedCrossTable({
-  gtTally,
+  grandTotalTally,
   crossTallies,
 }: {
-  gtTally: Tally;
+  grandTotalTally: Tally;
   crossTallies: Tally[];
 }) {
-  const gtSlice = gtTally.slices[0];
-  const codes = gtTally.codes;
+  const grandTotalSlice = grandTotalTally.slices[0];
+  const codes = grandTotalTally.codes;
 
   return (
     <table class="w-full border-collapse text-sm tabular-nums min-w-[400px]">
-      <caption class="sr-only">{t("table.caption.cross", { question: gtTally.label })}</caption>
+      <caption class="sr-only">
+        {t("table.caption.cross", { question: grandTotalTally.label })}
+      </caption>
       <thead>
         <tr>
           <th class="py-3 px-4" />
@@ -116,23 +126,23 @@ function TransposedCrossTable({
               key={code}
               class={`${TH_BASE} text-right text-xs whitespace-nowrap border-l border-row-border bg-surface2`}
             >
-              {gtTally.labels[code]}
+              {grandTotalTally.labels[code]}
             </th>
           ))}
         </tr>
       </thead>
       <tbody>
-        {/* GT row */}
+        {/* Grand Total row */}
         <tr class="[&_td]:border-b-2 [&_td]:border-border-strong">
           <td
-            class={`${TD_BASE} text-left text-xs font-bold whitespace-nowrap border-r-2 border-r-border-strong bg-gt-bg text-accent`}
+            class={`${TD_BASE} text-left text-xs font-bold whitespace-nowrap border-r-2 border-r-border-strong bg-grandTotal-bg text-accent`}
           >
             {t("table.total")}
           </td>
           {codes.map((code, i) => {
-            const cell = gtSlice.cells[i];
+            const cell = grandTotalSlice.cells[i];
             return (
-              <td key={code} class={`${TD_BASE} ${MONO} text-accent bg-gt-bg`}>
+              <td key={code} class={`${TD_BASE} ${MONO} text-accent bg-grandTotal-bg`}>
                 {cell ? cell.pct.toFixed(1) + "%" : "-"}
               </td>
             );

--- a/src/components/aggregation/GrandTotalTable.tsx
+++ b/src/components/aggregation/GrandTotalTable.tsx
@@ -2,17 +2,17 @@ import type { Tally } from "../../lib/agg/types";
 import { formatN } from "../../lib/format";
 import { t } from "../../lib/i18n";
 import { Th, Td } from "./TableCells";
-interface GtTableProps {
+interface GrandTotalTableProps {
   tally: Tally;
   maxPct: number;
 }
 
-export function GtTable({ tally, maxPct }: GtTableProps) {
+export function GrandTotalTable({ tally, maxPct }: GrandTotalTableProps) {
   const slice = tally.slices[0];
 
   return (
     <table class="w-full border-collapse text-sm tabular-nums">
-      <caption class="sr-only">{t("table.caption.gt", { question: tally.label })}</caption>
+      <caption class="sr-only">{t("table.caption.grandTotal", { question: tally.label })}</caption>
       <thead>
         <tr>
           <Th>{t("table.option")}</Th>

--- a/src/components/aggregation/NaChartCardBody.tsx
+++ b/src/components/aggregation/NaChartCardBody.tsx
@@ -5,12 +5,16 @@ import { t } from "../../lib/i18n";
 import type { ChartConfiguration } from "chart.js";
 
 interface NaChartCardBodyProps {
-  gtTally: Tally;
+  grandTotalTally: Tally;
   crossTallies: Tally[];
   paletteId: PaletteId;
 }
 
-export function NaChartCardBody({ gtTally, crossTallies, paletteId }: NaChartCardBodyProps) {
+export function NaChartCardBody({
+  grandTotalTally,
+  crossTallies,
+  paletteId,
+}: NaChartCardBodyProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const chartRef = useRef<Chart | null>(null);
   const isCross = crossTallies.length > 0;
@@ -23,16 +27,22 @@ export function NaChartCardBody({ gtTally, crossTallies, paletteId }: NaChartCar
     const theme = getThemeColors();
 
     if (isCross) {
-      chartRef.current = buildMeanComparisonChart(canvas, gtTally, crossTallies, theme, paletteId);
+      chartRef.current = buildMeanComparisonChart(
+        canvas,
+        grandTotalTally,
+        crossTallies,
+        theme,
+        paletteId,
+      );
     } else {
-      chartRef.current = buildFreqChart(canvas, gtTally, theme, paletteId);
+      chartRef.current = buildFreqChart(canvas, grandTotalTally, theme, paletteId);
     }
 
     return () => {
       chartRef.current?.destroy();
       chartRef.current = null;
     };
-  }, [gtTally, crossTallies, paletteId]);
+  }, [grandTotalTally, crossTallies, paletteId]);
 
   return (
     <div class={`p-4 ${isCross ? "h-[400px]" : "h-80"}`}>
@@ -99,7 +109,7 @@ function buildFreqChart(
 
 function buildMeanComparisonChart(
   canvas: HTMLCanvasElement,
-  _gtTally: Tally,
+  _grandTotalTally: Tally,
   crossTallies: Tally[],
   theme: ReturnType<typeof getThemeColors>,
   paletteId: PaletteId,

--- a/src/components/aggregation/NaCrossTable.tsx
+++ b/src/components/aggregation/NaCrossTable.tsx
@@ -3,7 +3,7 @@ import { formatN } from "../../lib/format";
 import { t } from "../../lib/i18n";
 
 interface NaCrossTableProps {
-  gtTally: Tally;
+  grandTotalTally: Tally;
   crossTallies: Tally[];
 }
 
@@ -13,8 +13,8 @@ const TH_BASE = "py-3 px-4 text-xs font-bold tracking-wide border-b-2 border-bor
 const TD_BASE = "py-3 px-4 border-b border-row-border leading-[1.2]";
 const MONO = "text-right tabular-nums font-mono";
 
-export function NaCrossTable({ gtTally, crossTallies }: NaCrossTableProps) {
-  const gtStats = gtTally.slices[0].stats!;
+export function NaCrossTable({ grandTotalTally, crossTallies }: NaCrossTableProps) {
+  const grandTotalStats = grandTotalTally.slices[0].stats!;
 
   const crossGroups = crossTallies.map((ct) => ({
     axis: ct.by!,
@@ -25,11 +25,13 @@ export function NaCrossTable({ gtTally, crossTallies }: NaCrossTableProps) {
 
   return (
     <table class="w-full border-collapse text-sm tabular-nums min-w-[400px]">
-      <caption class="sr-only">{t("table.caption.cross", { question: gtTally.label })}</caption>
+      <caption class="sr-only">
+        {t("table.caption.cross", { question: grandTotalTally.label })}
+      </caption>
       <thead>
         <tr>
           <th rowSpan={2} class="py-3 px-4" />
-          <th class={`${TH_BASE} text-center bg-gt-bg text-accent`}>{t("table.total")}</th>
+          <th class={`${TH_BASE} text-center bg-grandTotal-bg text-accent`}>{t("table.total")}</th>
           {crossGroups.map((group) => (
             <th
               key={group.axis.code}
@@ -60,7 +62,9 @@ export function NaCrossTable({ gtTally, crossTallies }: NaCrossTableProps) {
         {STAT_KEYS.map((key) => (
           <tr key={key}>
             <td class={`${TD_BASE} text-left text-sm`}>{t(`na.stat.${key}`)}</td>
-            <td class={`${TD_BASE} ${MONO} text-accent`}>{formatStat(key, gtStats[key])}</td>
+            <td class={`${TD_BASE} ${MONO} text-accent`}>
+              {formatStat(key, grandTotalStats[key])}
+            </td>
             {crossGroups.map((group, gi) =>
               group.tally.slices.map((slice, si) => (
                 <td

--- a/src/components/aggregation/NaGrandTotalTable.tsx
+++ b/src/components/aggregation/NaGrandTotalTable.tsx
@@ -2,18 +2,18 @@ import type { Tally } from "../../lib/agg/types";
 import { t } from "../../lib/i18n";
 import { Th, Td } from "./TableCells";
 
-interface NaGtTableProps {
+interface NaGrandTotalTableProps {
   tally: Tally;
 }
 
 const STAT_KEYS = ["n", "mean", "median", "sd", "min", "max"] as const;
 
-export function NaGtTable({ tally }: NaGtTableProps) {
+export function NaGrandTotalTable({ tally }: NaGrandTotalTableProps) {
   const stats = tally.slices[0].stats!;
 
   return (
     <table class="w-full border-collapse text-sm tabular-nums">
-      <caption class="sr-only">{t("table.caption.gt", { question: tally.label })}</caption>
+      <caption class="sr-only">{t("table.caption.grandTotal", { question: tally.label })}</caption>
       <thead>
         <tr>
           <Th>{t("table.option")}</Th>

--- a/src/components/aggregation/ResultPanel.tsx
+++ b/src/components/aggregation/ResultPanel.tsx
@@ -95,7 +95,7 @@ function ResultContent({ tallies, weightCol }: { tallies: Tally[]; weightCol: st
         {questionCodes.map((q) => (
           <TallyCard
             key={q}
-            gtTally={tallies.find((t) => t.questionCode === q && t.by === null)!}
+            grandTotalTally={tallies.find((t) => t.questionCode === q && t.by === null)!}
             crossTallies={tallies.filter((t) => t.questionCode === q && t.by !== null)}
             viewMode={viewMode}
             tableOpts={tableOpts}

--- a/src/components/aggregation/TallyCard.tsx
+++ b/src/components/aggregation/TallyCard.tsx
@@ -1,15 +1,15 @@
 import type { Tally } from "../../lib/agg/types";
 import { ChartCardBody } from "./ChartCardBody";
 import { CrossTable } from "./CrossTable";
-import { GtTable } from "./GtTable";
+import { GrandTotalTable } from "./GrandTotalTable";
 import { NaChartCardBody } from "./NaChartCardBody";
 import { NaCrossTable } from "./NaCrossTable";
-import { NaGtTable } from "./NaGtTable";
+import { NaGrandTotalTable } from "./NaGrandTotalTable";
 import type { ChartOpts, TableOpts, ViewMode } from "./viewTypes";
 import { formatN } from "../../lib/format";
 
 interface TallyCardProps {
-  gtTally: Tally;
+  grandTotalTally: Tally;
   crossTallies: Tally[];
   viewMode: ViewMode;
   tableOpts: TableOpts;
@@ -17,7 +17,7 @@ interface TallyCardProps {
 }
 
 export function TallyCard({
-  gtTally,
+  grandTotalTally,
   crossTallies,
   viewMode,
   tableOpts,
@@ -25,7 +25,7 @@ export function TallyCard({
 }: TallyCardProps) {
   const hasCross = crossTallies.length > 0;
 
-  const gtN = gtTally.slices[0]?.n ?? 0;
+  const grandTotalN = grandTotalTally.slices[0]?.n ?? 0;
 
   return (
     <div
@@ -33,14 +33,14 @@ export function TallyCard({
     >
       <div class="flex items-baseline gap-3 border-b border-border p-4">
         <div class="flex min-w-0 flex-col gap-0.5">
-          <span class="text-sm font-bold text-accent">{gtTally.label}</span>
-          <span class="text-xs tracking-wide text-muted">{gtTally.questionCode}</span>
+          <span class="text-sm font-bold text-accent">{grandTotalTally.label}</span>
+          <span class="text-xs tracking-wide text-muted">{grandTotalTally.questionCode}</span>
         </div>
-        <span class="text-xs tracking-wide text-muted">{gtTally.type}</span>
-        <span class="ml-auto text-xs text-muted">n={formatN(gtN)}</span>
+        <span class="text-xs tracking-wide text-muted">{grandTotalTally.type}</span>
+        <span class="ml-auto text-xs text-muted">n={formatN(grandTotalN)}</span>
       </div>
       <CardBody
-        gtTally={gtTally}
+        grandTotalTally={grandTotalTally}
         crossTallies={crossTallies}
         viewMode={viewMode}
         tableOpts={tableOpts}
@@ -50,21 +50,27 @@ export function TallyCard({
   );
 }
 
-function CardBody({ gtTally, crossTallies, viewMode, tableOpts, chartOpts }: TallyCardProps) {
-  if (gtTally.type === "NA") {
+function CardBody({
+  grandTotalTally,
+  crossTallies,
+  viewMode,
+  tableOpts,
+  chartOpts,
+}: TallyCardProps) {
+  if (grandTotalTally.type === "NA") {
     if (viewMode === "chart") {
       return (
         <NaChartCardBody
-          gtTally={gtTally}
+          grandTotalTally={grandTotalTally}
           crossTallies={crossTallies}
           paletteId={chartOpts.paletteId}
         />
       );
     }
     if (crossTallies.length > 0) {
-      return <NaCrossTable gtTally={gtTally} crossTallies={crossTallies} />;
+      return <NaCrossTable grandTotalTally={grandTotalTally} crossTallies={crossTallies} />;
     }
-    return <NaGtTable tally={gtTally} />;
+    return <NaGrandTotalTable tally={grandTotalTally} />;
   }
 
   // SA | MA
@@ -72,17 +78,21 @@ function CardBody({ gtTally, crossTallies, viewMode, tableOpts, chartOpts }: Tal
     const { saChartType, maChartType, paletteId } = chartOpts;
     return (
       <ChartCardBody
-        gtTally={gtTally}
+        grandTotalTally={grandTotalTally}
         crossTallies={crossTallies}
-        gtChartType={gtTally.type === "SA" ? saChartType : maChartType}
+        grandTotalChartType={grandTotalTally.type === "SA" ? saChartType : maChartType}
         paletteId={paletteId}
       />
     );
   }
   if (crossTallies.length > 0) {
     return (
-      <CrossTable gtTally={gtTally} crossTallies={crossTallies} pctDir={tableOpts.pctDirection} />
+      <CrossTable
+        grandTotalTally={grandTotalTally}
+        crossTallies={crossTallies}
+        pctDir={tableOpts.pctDirection}
+      />
     );
   }
-  return <GtTable tally={gtTally} maxPct={tableOpts.maxPct} />;
+  return <GrandTotalTable tally={grandTotalTally} maxPct={tableOpts.maxPct} />;
 }

--- a/src/components/aggregation/Toolbar.tsx
+++ b/src/components/aggregation/Toolbar.tsx
@@ -30,7 +30,7 @@ export function Toolbar({ tallies, weightCol, currentViewMode, callbacks }: Tool
 
   return (
     <div class="mb-6 flex items-center gap-4">
-      <h2 class="text-xl font-bold">{t("result.title.gt")}</h2>
+      <h2 class="text-xl font-bold">{t("result.title.grandTotal")}</h2>
       <span class="text-xs text-muted">
         {t("result.meta", { count: questionCount, weight: weightText })}
       </span>

--- a/src/lib/agg/aggGrandTotal.ts
+++ b/src/lib/agg/aggGrandTotal.ts
@@ -1,4 +1,4 @@
-/** Totals aggregation — SA and MA */
+/** Grand Total aggregation — SA and MA */
 
 import type * as duckdb from "@duckdb/duckdb-wasm";
 import type { Shape, AggOutput } from "./types";
@@ -12,18 +12,18 @@ import {
   NO_ANSWER_VALUE,
 } from "./sqlHelpers";
 
-export async function aggTotals(
+export async function aggGrandTotal(
   conn: duckdb.AsyncDuckDBConnection,
   shape: Shape,
   weightCol: string,
 ): Promise<AggOutput> {
-  const totals = new TotalsAggregator(conn, weightCol);
+  const grandTotal = new GrandTotalAggregator(conn, weightCol);
   return shape.type === "SA"
-    ? totals.aggregateSA(shape.columns[0], shape.codes)
-    : totals.aggregateMA(shape.columns, shape.codes);
+    ? grandTotal.aggregateSA(shape.columns[0], shape.codes)
+    : grandTotal.aggregateMA(shape.columns, shape.codes);
 }
 
-class TotalsAggregator {
+class GrandTotalAggregator {
   constructor(
     private conn: duckdb.AsyncDuckDBConnection,
     private weightCol: string,

--- a/src/lib/agg/aggNa.ts
+++ b/src/lib/agg/aggNa.ts
@@ -1,4 +1,4 @@
-/** NA (Numerical Answer) aggregation — GT and Cross */
+/** NA (Numerical Answer) aggregation — Grand Total and Cross */
 
 import type * as duckdb from "@duckdb/duckdb-wasm";
 import type { Shape, AggOutput, NaStats, Slice } from "./types";
@@ -9,9 +9,9 @@ interface ValueCount {
   count: number;
 }
 
-// ── GT ──
+// ── Grand Total ──
 
-export async function aggNaTotals(
+export async function aggNaGrandTotal(
   conn: duckdb.AsyncDuckDBConnection,
   column: string,
   weightCol: string,

--- a/src/lib/agg/buildTallies.ts
+++ b/src/lib/agg/buildTallies.ts
@@ -1,8 +1,8 @@
 import type * as duckdb from "@duckdb/duckdb-wasm";
 import type { Question, AggOutput, Axis, Tally } from "./types";
-import { aggTotals } from "./aggTotals";
+import { aggGrandTotal } from "./aggGrandTotal";
 import { aggCrossTab } from "./aggCrossTab";
-import { aggNaTotals, aggNaCrossTab } from "./aggNa";
+import { aggNaGrandTotal, aggNaCrossTab } from "./aggNa";
 import { NO_ANSWER_VALUE } from "./sqlHelpers";
 import { t } from "../i18n";
 
@@ -15,15 +15,15 @@ export async function buildTallies(
   const tallies: Tally[] = [];
   for (const q of questions) {
     if (q.type === "NA") {
-      const gtOutput = await aggNaTotals(conn, q.columns[0], weightCol);
-      tallies.push(toTally(q, gtOutput));
+      const grandTotalOutput = await aggNaGrandTotal(conn, q.columns[0], weightCol);
+      tallies.push(toTally(q, grandTotalOutput));
       for (const axisQuestion of crossQuestions) {
         const crossOutput = await aggNaCrossTab(conn, q.columns[0], axisQuestion, weightCol);
         tallies.push(toTally(q, crossOutput, axisQuestion));
       }
     } else {
-      const gtOutput = await aggTotals(conn, q, weightCol);
-      tallies.push(toTally(q, gtOutput));
+      const grandTotalOutput = await aggGrandTotal(conn, q, weightCol);
+      tallies.push(toTally(q, grandTotalOutput));
       for (const axisQuestion of crossQuestions) {
         const crossOutput = await aggCrossTab(conn, q, axisQuestion, weightCol);
         tallies.push(toTally(q, crossOutput, axisQuestion));

--- a/src/lib/aiComment.ts
+++ b/src/lib/aiComment.ts
@@ -68,10 +68,10 @@ function summarizeResults(tallies: Tally[], weightCol: string, topN: number): st
     lines.push(t("ai.weight", { col: weightCol }));
   }
 
-  // Only use GT tallies
-  const gtTallies = tallies.filter((t) => t.by === null);
+  // Only use Grand Total tallies
+  const grandTotalTallies = tallies.filter((t) => t.by === null);
 
-  for (const tally of gtTallies) {
+  for (const tally of grandTotalTallies) {
     if (tally.type === "NA") {
       const stats = tally.slices[0].stats!;
       lines.push(`${tally.questionCode}: ${tally.label} (NA, n=${stats.n})`);

--- a/src/lib/export/formatters/grid.ts
+++ b/src/lib/export/formatters/grid.ts
@@ -15,7 +15,7 @@ export function buildExportGrids(tallies: Tally[]): ExportGrid[] {
   if (hasCross) {
     return buildCrossGrids(tallies);
   }
-  return tallies.filter((t) => t.by === null).map((tally) => buildGtGrid(tally));
+  return tallies.filter((t) => t.by === null).map((tally) => buildGrandTotalGrid(tally));
 }
 
 // ─── Internal ───────────────────────────────────────────────
@@ -24,12 +24,12 @@ function resolveLabel(code: string, tally: Tally): string {
   return tally.labels[code];
 }
 
-function buildGtGrid(tally: Tally): ExportGrid {
-  if (tally.type === "NA") return buildNaGtGrid(tally);
-  return buildCategoricalGtGrid(tally);
+function buildGrandTotalGrid(tally: Tally): ExportGrid {
+  if (tally.type === "NA") return buildNaGrandTotalGrid(tally);
+  return buildCategoricalGrandTotalGrid(tally);
 }
 
-function buildCategoricalGtGrid(tally: Tally): ExportGrid {
+function buildCategoricalGrandTotalGrid(tally: Tally): ExportGrid {
   const slice = tally.slices[0];
   const headers = [
     [
@@ -58,7 +58,7 @@ function buildCategoricalGtGrid(tally: Tally): ExportGrid {
   return { questionCode: tally.questionCode, type: tally.type, headers, rows };
 }
 
-function buildNaGtGrid(tally: Tally): ExportGrid {
+function buildNaGrandTotalGrid(tally: Tally): ExportGrid {
   const stats = tally.slices[0].stats!;
   const headers = [[t("export.header.variable"), t("export.header.type"), t("table.option"), ""]];
   const rows: string[][] = NA_STAT_KEYS.map((key) => [
@@ -73,15 +73,15 @@ function buildNaGtGrid(tally: Tally): ExportGrid {
 function buildCrossGrids(tallies: Tally[]): ExportGrid[] {
   const firstCross = tallies.find((t) => t.by !== null);
   if (!firstCross) {
-    return tallies.filter((t) => t.by === null).map((tally) => buildGtGrid(tally));
+    return tallies.filter((t) => t.by === null).map((tally) => buildGrandTotalGrid(tally));
   }
 
   const questionCodes = [...new Set(tallies.map((t) => t.questionCode))];
 
   // Find first categorical question for shared headers
   const firstCatQCode = questionCodes.find((qc) => {
-    const gt = tallies.find((t) => t.questionCode === qc && t.by === null);
-    return gt && gt.type !== "NA";
+    const grandTotal = tallies.find((t) => t.questionCode === qc && t.by === null);
+    return grandTotal && grandTotal.type !== "NA";
   });
 
   const crossTalliesForFirst = firstCatQCode
@@ -110,25 +110,25 @@ function buildCrossGrids(tallies: Tally[]): ExportGrid[] {
   const sharedHeaders = [headerRow1, headerRow2];
 
   return questionCodes.map((qCode) => {
-    const gtTally = tallies.find((t) => t.questionCode === qCode && t.by === null)!;
+    const grandTotalTally = tallies.find((t) => t.questionCode === qCode && t.by === null)!;
     const qCrossTallies = tallies.filter((t) => t.questionCode === qCode && t.by !== null);
 
-    if (gtTally.type === "NA") {
-      return buildNaCrossGrid(gtTally, qCrossTallies);
+    if (grandTotalTally.type === "NA") {
+      return buildNaGrandTotalCrossGrid(grandTotalTally, qCrossTallies);
     }
 
-    const gtSlice = gtTally.slices[0];
+    const grandTotalSlice = grandTotalTally.slices[0];
     const rows: string[][] = [];
 
-    for (let i = 0; i < gtTally.codes.length; i++) {
-      const code = gtTally.codes[i];
-      const gtCell = gtSlice.cells[i];
+    for (let i = 0; i < grandTotalTally.codes.length; i++) {
+      const code = grandTotalTally.codes[i];
+      const grandTotalCell = grandTotalSlice.cells[i];
       const dataRow = [
-        gtTally.questionCode,
-        gtTally.type,
-        resolveLabel(code, gtTally),
-        gtCell.count.toFixed(1),
-        gtCell.pct.toFixed(1),
+        grandTotalTally.questionCode,
+        grandTotalTally.type,
+        resolveLabel(code, grandTotalTally),
+        grandTotalCell.count.toFixed(1),
+        grandTotalCell.pct.toFixed(1),
       ];
       for (const crossTally of qCrossTallies) {
         if (crossTally.type === "NA") continue;
@@ -140,7 +140,13 @@ function buildCrossGrids(tallies: Tally[]): ExportGrid[] {
       rows.push(dataRow);
     }
 
-    const nRow = [gtTally.questionCode, gtTally.type, "n", gtSlice.n.toFixed(1), ""];
+    const nRow = [
+      grandTotalTally.questionCode,
+      grandTotalTally.type,
+      "n",
+      grandTotalSlice.n.toFixed(1),
+      "",
+    ];
     for (const crossTally of qCrossTallies) {
       if (crossTally.type === "NA") continue;
       for (const slice of crossTally.slices) {
@@ -149,12 +155,17 @@ function buildCrossGrids(tallies: Tally[]): ExportGrid[] {
     }
     rows.push(nRow);
 
-    return { questionCode: gtTally.questionCode, type: gtTally.type, headers: sharedHeaders, rows };
+    return {
+      questionCode: grandTotalTally.questionCode,
+      type: grandTotalTally.type,
+      headers: sharedHeaders,
+      rows,
+    };
   });
 }
 
-function buildNaCrossGrid(gtTally: Tally, crossTallies: Tally[]): ExportGrid {
-  const gtStats = gtTally.slices[0].stats!;
+function buildNaGrandTotalCrossGrid(grandTotalTally: Tally, crossTallies: Tally[]): ExportGrid {
+  const grandTotalStats = grandTotalTally.slices[0].stats!;
 
   const headerRow1 = [
     t("export.header.variable"),
@@ -174,10 +185,10 @@ function buildNaCrossGrid(gtTally: Tally, crossTallies: Tally[]): ExportGrid {
 
   const rows: string[][] = NA_STAT_KEYS.map((key) => {
     const row = [
-      gtTally.questionCode,
+      grandTotalTally.questionCode,
       "NA",
       t(`na.stat.${key}`),
-      key === "n" ? gtStats.n.toFixed(1) : gtStats[key].toFixed(2),
+      key === "n" ? grandTotalStats.n.toFixed(1) : grandTotalStats[key].toFixed(2),
     ];
     for (const ct of crossTallies) {
       for (const slice of ct.slices) {
@@ -188,7 +199,7 @@ function buildNaCrossGrid(gtTally: Tally, crossTallies: Tally[]): ExportGrid {
   });
 
   return {
-    questionCode: gtTally.questionCode,
+    questionCode: grandTotalTally.questionCode,
     type: "NA",
     headers: [headerRow1, headerRow2],
     rows,

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -54,7 +54,7 @@ const en: Record<string, string> = {
   "empty.text": "Select cross-tabulation axes and run the aggregation",
 
   // Results
-  "result.title.gt": "Aggregation Results",
+  "result.title.grandTotal": "Aggregation Results",
   "result.meta": "{count} questions  /  {weight}",
   "result.weight.applied": "Weighted: {col}",
   "result.weight.none": "Unweighted",
@@ -100,7 +100,7 @@ const en: Record<string, string> = {
   "table.option": "Option",
   "table.graph": "Graph",
   "table.total": "Total",
-  "table.caption.gt": "Aggregation results for {question}",
+  "table.caption.grandTotal": "Aggregation results for {question}",
   "table.caption.cross": "Cross-tabulation results for {question}",
 
   // AI Bubble

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -54,7 +54,7 @@ const ja: Record<string, string> = {
   "empty.text": "クロス集計軸を選んで集計を実行してください",
 
   // Results
-  "result.title.gt": "集計結果",
+  "result.title.grandTotal": "集計結果",
   "result.meta": "{count} 問  ／  {weight}",
   "result.weight.applied": "ウェイトバック適用: {col}",
   "result.weight.none": "実数集計",
@@ -100,7 +100,7 @@ const ja: Record<string, string> = {
   "table.option": "選択肢",
   "table.graph": "グラフ",
   "table.total": "全体",
-  "table.caption.gt": "{question} の集計結果",
+  "table.caption.grandTotal": "{question} の集計結果",
   "table.caption.cross": "{question} のクロス集計結果",
 
   // AI Bubble

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -24,7 +24,7 @@
   --color-row-border: var(--row-border);
   --color-row-hover: var(--row-hover);
   --color-cross-bg: var(--cross-bg);
-  --color-gt-bg: var(--gt-bg);
+  --color-grandTotal-bg: var(--grandTotal-bg);
   --color-error-bg: var(--error-bg);
   --color-error-border: var(--error-border);
   --color-warning: var(--warning);
@@ -101,7 +101,7 @@
     --row-border: var(--color-gray-200);
     --row-hover: var(--color-primary-50);
     --cross-bg: var(--color-secondary-100);
-    --gt-bg: var(--color-primary-50);
+    --grandTotal-bg: var(--color-primary-50);
     --error-bg: var(--color-error-50);
     --error-border: var(--color-error-100);
     --warning: var(--color-warning-700);

--- a/tests/aggGrandTotal.test.ts
+++ b/tests/aggGrandTotal.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { aggTotals } from "../src/lib/agg/aggTotals";
+import { aggGrandTotal } from "../src/lib/agg/aggGrandTotal";
 import { setupDuckDB, teardownDuckDB, getConn } from "./helpers/duckdb";
 import { getShape } from "./helpers/fixtures";
 
@@ -36,10 +36,10 @@ const q3 = getShape("q3");
 // 14: id=14, w=1.0, q1=NULL,q2=1,   q3_1=1, q3_2=0, q3_3=1
 // ============================================================
 
-describe("aggTotals - 重みなし", () => {
+describe("aggGrandTotal - 重みなし", () => {
   describe("SA GT集計", () => {
     it("q1 の GT 集計で各値の count/n/pct が正しい", async () => {
-      const result = await aggTotals(getConn(), q1, "");
+      const result = await aggGrandTotal(getConn(), q1, "");
 
       expect(result.slices).toHaveLength(1);
 
@@ -65,7 +65,7 @@ describe("aggTotals - 重みなし", () => {
 
   describe("MA GT集計", () => {
     it("q3 の GT 集計で各サブカラムの count と無回答が正しい", async () => {
-      const result = await aggTotals(getConn(), q3, "");
+      const result = await aggGrandTotal(getConn(), q3, "");
 
       // MA shown条件: q3_1~q3_3 のいずれかが非NULL
       // 行13: q3_1=NULL,q3_2=NULL,q3_3=NULL → 全部NULLなので除外
@@ -84,10 +84,10 @@ describe("aggTotals - 重みなし", () => {
   });
 });
 
-describe("aggTotals - 重み付き", () => {
+describe("aggGrandTotal - 重み付き", () => {
   describe("SA GT集計（重み付き）", () => {
     it("q1 の重み付き GT 集計で weighted count が正しい", async () => {
-      const result = await aggTotals(getConn(), q1, "weight");
+      const result = await aggGrandTotal(getConn(), q1, "weight");
 
       // q1有効行: 行1-13 (行14=空のみ除外)
       // q1=1: 行1(1.2)+3(1.5)+5(1.1)+7(1.3)+10(1.0)+12(0.8) = 6.9
@@ -111,7 +111,7 @@ describe("aggTotals - 重み付き", () => {
 
   describe("MA GT集計（重み付き）", () => {
     it("q3 の重み付き GT 集計で weighted count が正しい", async () => {
-      const result = await aggTotals(getConn(), q3, "weight");
+      const result = await aggGrandTotal(getConn(), q3, "weight");
 
       // shown行: 行1-12,14 = 13行 (行13は全空で除外)
       // q3_1='1': 行1(1.2)+3(1.5)+4(0.8)+6(1.0)+8(0.7)+9(1.4)+14(1.0) = 7.6

--- a/tests/aggGrandTotalEdge.test.ts
+++ b/tests/aggGrandTotalEdge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { aggTotals } from "../src/lib/agg/aggTotals";
+import { aggGrandTotal } from "../src/lib/agg/aggGrandTotal";
 import { setupDuckDB, teardownDuckDB, getConn, loadCSV } from "./helpers/duckdb";
 import { buildCSV } from "./helpers/csv";
 import type { Shape } from "../src/lib/agg/types";
@@ -12,7 +12,7 @@ afterAll(async () => {
   await teardownDuckDB();
 });
 
-describe("aggTotalsEdge - SA", () => {
+describe("aggGrandTotalEdge - SA", () => {
   it("全行同値 → count=5, pct=100", async () => {
     await loadCSV(
       buildCSV(["id", "q1"], [
@@ -20,7 +20,7 @@ describe("aggTotalsEdge - SA", () => {
       ]),
     );
     const input: Shape = { type: "SA", columns: ["q1"], codes: ["1", "2"] };
-    const result = await aggTotals(getConn(), input, "");
+    const result = await aggGrandTotal(getConn(), input, "");
 
     const slice = result.slices[0];
     expect(slice.n).toBe(5);
@@ -37,7 +37,7 @@ describe("aggTotalsEdge - SA", () => {
       ]),
     );
     const input: Shape = { type: "SA", columns: ["q1"], codes: ["1"] };
-    const result = await aggTotals(getConn(), input, "");
+    const result = await aggGrandTotal(getConn(), input, "");
 
     expect(result.slices[0].n).toBe(0);
   });
@@ -45,7 +45,7 @@ describe("aggTotalsEdge - SA", () => {
   it("1行のみ → n=1, count=1", async () => {
     await loadCSV(buildCSV(["id", "q1"], [[1, 2]]));
     const input: Shape = { type: "SA", columns: ["q1"], codes: ["1", "2"] };
-    const result = await aggTotals(getConn(), input, "");
+    const result = await aggGrandTotal(getConn(), input, "");
 
     expect(result.slices[0].n).toBe(1);
     expect(result.slices[0].cells[1].count).toBe(1);
@@ -59,7 +59,7 @@ describe("aggTotalsEdge - SA", () => {
       ]),
     );
     const input: Shape = { type: "SA", columns: ["q1"], codes: ["1", "2", "3"] };
-    const result = await aggTotals(getConn(), input, "");
+    const result = await aggGrandTotal(getConn(), input, "");
 
     expect(result.slices[0].cells[0].count).toBe(3);
     expect(result.slices[0].cells[1].count).toBe(0);
@@ -75,7 +75,7 @@ describe("aggTotalsEdge - SA", () => {
       ]),
     );
     const input: Shape = { type: "SA", columns: ["q1"], codes: ["1", "2"] };
-    const result = await aggTotals(getConn(), input, "weight");
+    const result = await aggGrandTotal(getConn(), input, "weight");
 
     expect(result.slices[0].n).toBeCloseTo(2.0, 3);
     expect(result.slices[0].cells[0].count).toBeCloseTo(1.0, 3);
@@ -89,8 +89,8 @@ describe("aggTotalsEdge - SA", () => {
       ]),
     );
     const input: Shape = { type: "SA", columns: ["q1"], codes: ["1", "2", "3"] };
-    const unweighted = await aggTotals(getConn(), input, "");
-    const weighted = await aggTotals(getConn(), input, "weight");
+    const unweighted = await aggGrandTotal(getConn(), input, "");
+    const weighted = await aggGrandTotal(getConn(), input, "weight");
 
     const uwCounts = unweighted.slices[0].cells.map((c) => c.count);
     const wCounts = weighted.slices[0].cells.map((c) => c.count);
@@ -98,7 +98,7 @@ describe("aggTotalsEdge - SA", () => {
   });
 });
 
-describe("aggTotalsEdge - MA", () => {
+describe("aggGrandTotalEdge - MA", () => {
   it("NULL行はshownから除外される → nに寄与しない", async () => {
     // 型推論のため非NULLの行を含む。NULL行のみがshown=falseで除外される
     await loadCSV(
@@ -109,7 +109,7 @@ describe("aggTotalsEdge - MA", () => {
       ]),
     );
     const input: Shape = { type: "MA", columns: ["q_1", "q_2"], codes: ["1", "2"] };
-    const result = await aggTotals(getConn(), input, "");
+    const result = await aggGrandTotal(getConn(), input, "");
 
     // shown行は行3のみ → n=1
     expect(result.slices[0].n).toBe(1);
@@ -126,7 +126,7 @@ describe("aggTotalsEdge - MA", () => {
       ]),
     );
     const input: Shape = { type: "MA", columns: ["q_1", "q_2"], codes: ["1", "2"] };
-    const result = await aggTotals(getConn(), input, "");
+    const result = await aggGrandTotal(getConn(), input, "");
 
     expect(result.slices[0].n).toBe(3);
     expect(result.slices[0].cells[0].count).toBe(0);

--- a/tests/aggGrandTotalPbt.test.ts
+++ b/tests/aggGrandTotalPbt.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, beforeAll, afterAll } from "vitest";
-import { aggTotals } from "../src/lib/agg/aggTotals";
+import { aggGrandTotal } from "../src/lib/agg/aggGrandTotal";
 import { setupDuckDB, teardownDuckDB, getConn, loadCSV } from "./helpers/duckdb";
 import { generateSADataset, generateMADataset } from "./helpers/generators";
-import { assertGtInvariants } from "./helpers/invariants";
+import { assertGrandTotalInvariants } from "./helpers/invariants";
 
 beforeAll(async () => {
   await setupDuckDB();
@@ -19,46 +19,46 @@ function rowCount(seed: number): number {
   return ROW_RANGE.min + ((seed * 17) % (ROW_RANGE.max - ROW_RANGE.min + 1));
 }
 
-describe("PBT - aggTotals SA 重みなし", () => {
+describe("PBT - aggGrandTotal SA 重みなし", () => {
   for (let seed = 1; seed <= SEEDS; seed++) {
     it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
       const ds = generateSADataset({ seed, rowCount: rowCount(seed) });
       await loadCSV(ds.csv);
-      const result = await aggTotals(getConn(), ds.shape, "");
-      assertGtInvariants(result, "SA");
+      const result = await aggGrandTotal(getConn(), ds.shape, "");
+      assertGrandTotalInvariants(result, "SA");
     });
   }
 });
 
-describe("PBT - aggTotals SA 重みあり", () => {
+describe("PBT - aggGrandTotal SA 重みあり", () => {
   for (let seed = 1; seed <= SEEDS; seed++) {
     it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
       const ds = generateSADataset({ seed, rowCount: rowCount(seed), weighted: true });
       await loadCSV(ds.csv);
-      const result = await aggTotals(getConn(), ds.shape, ds.weightCol);
-      assertGtInvariants(result, "SA");
+      const result = await aggGrandTotal(getConn(), ds.shape, ds.weightCol);
+      assertGrandTotalInvariants(result, "SA");
     });
   }
 });
 
-describe("PBT - aggTotals MA 重みなし", () => {
+describe("PBT - aggGrandTotal MA 重みなし", () => {
   for (let seed = 1; seed <= SEEDS; seed++) {
     it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
       const ds = generateMADataset({ seed, rowCount: rowCount(seed) });
       await loadCSV(ds.csv);
-      const result = await aggTotals(getConn(), ds.shape, "");
-      assertGtInvariants(result, "MA");
+      const result = await aggGrandTotal(getConn(), ds.shape, "");
+      assertGrandTotalInvariants(result, "MA");
     });
   }
 });
 
-describe("PBT - aggTotals MA 重みあり", () => {
+describe("PBT - aggGrandTotal MA 重みあり", () => {
   for (let seed = 1; seed <= SEEDS; seed++) {
     it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
       const ds = generateMADataset({ seed, rowCount: rowCount(seed), weighted: true });
       await loadCSV(ds.csv);
-      const result = await aggTotals(getConn(), ds.shape, ds.weightCol);
-      assertGtInvariants(result, "MA");
+      const result = await aggGrandTotal(getConn(), ds.shape, ds.weightCol);
+      assertGrandTotalInvariants(result, "MA");
     });
   }
 });

--- a/tests/aggNa.test.ts
+++ b/tests/aggNa.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { aggNaTotals, aggNaCrossTab } from "../src/lib/agg/aggNa";
+import { aggNaGrandTotal, aggNaCrossTab } from "../src/lib/agg/aggNa";
 import { setupDuckDB, teardownDuckDB, getConn, loadCSV } from "./helpers/duckdb";
 import type { Shape } from "../src/lib/agg/types";
 
@@ -28,9 +28,9 @@ afterAll(async () => {
   await teardownDuckDB();
 });
 
-describe("aggNaTotals - unweighted", () => {
+describe("aggNaGrandTotal - unweighted", () => {
   it("returns correct stats for score column", async () => {
-    const result = await aggNaTotals(getConn(), "score", "");
+    const result = await aggNaGrandTotal(getConn(), "score", "");
 
     expect(result.slices).toHaveLength(1);
     const slice = result.slices[0];
@@ -47,7 +47,7 @@ describe("aggNaTotals - unweighted", () => {
   });
 
   it("returns correct frequency distribution as codes/cells", async () => {
-    const result = await aggNaTotals(getConn(), "score", "");
+    const result = await aggNaGrandTotal(getConn(), "score", "");
 
     // Unique values: 3,4,5,6,7,8,9,10
     expect(result.codes).toEqual(["3", "4", "5", "6", "7", "8", "9", "10"]);
@@ -65,9 +65,9 @@ describe("aggNaTotals - unweighted", () => {
   });
 });
 
-describe("aggNaTotals - weighted", () => {
+describe("aggNaGrandTotal - weighted", () => {
   it("returns weighted stats", async () => {
-    const result = await aggNaTotals(getConn(), "score", "weight");
+    const result = await aggNaGrandTotal(getConn(), "score", "weight");
 
     const slice = result.slices[0];
     // Weighted n = sum of weights for valid score rows

--- a/tests/aiComment.test.ts
+++ b/tests/aiComment.test.ts
@@ -89,14 +89,14 @@ describe("buildPromptPayload", () => {
   });
 
   it("GT集計のみがプロンプトに含まれ、クロス集計は除外される", () => {
-    const gt = makeTally({ questionCode: "q1", label: "性別" });
+    const grandTotal = makeTally({ questionCode: "q1", label: "性別" });
     const cross = makeTally({
       questionCode: "q2",
       label: "年代",
       by: { code: "q1", label: "性別", labels: { "1": "男性" } },
     });
 
-    const payload = buildPromptPayload([gt, cross], "");
+    const payload = buildPromptPayload([grandTotal, cross], "");
 
     expect(payload).toContain("q1");
     expect(payload).not.toContain("q2");

--- a/tests/export.test.ts
+++ b/tests/export.test.ts
@@ -13,13 +13,13 @@ import { formatJSON } from "../src/lib/export/formatters/json";
 const q1 = getQuestion("q1");
 const q2 = getQuestion("q2");
 const q3 = getQuestion("q3");
-let gtTallies: Tally[];
+let grandTotalTallies: Tally[];
 let crossTallies: Tally[];
 
 beforeAll(async () => {
   await setupDuckDB();
 
-  gtTallies = await buildTallies(getConn(), [q1, q3], [], "");
+  grandTotalTallies = await buildTallies(getConn(), [q1, q3], [], "");
   crossTallies = await buildTallies(getConn(), [q2], [q1], "");
 }, 30_000);
 
@@ -31,7 +31,7 @@ afterAll(async () => {
 
 describe("buildExportGrids", () => {
   it("GT結果から正しいグリッド構造を生成する", () => {
-    const grids = buildExportGrids(gtTallies);
+    const grids = buildExportGrids(grandTotalTallies);
     expect(grids).toHaveLength(2);
 
     const grid = grids[0];
@@ -61,22 +61,22 @@ describe("buildExportGrids", () => {
 
 describe("talliesToLongRows", () => {
   it("GT結果からロングフォーマット行を生成する", () => {
-    const rows = talliesToLongRows(gtTallies);
+    const rows = talliesToLongRows(grandTotalTallies);
     // ヘッダー行（i18n: ja）
     expect(rows[0]).toEqual(["変数名", "種別", "選択肢", "クロス軸", "クロス値", "n", "度数", "%"]);
     // GT行のcross_axis/cross_valueは(全体)
     expect(rows[1][3]).toBe("(全体)");
     expect(rows[1][4]).toBe("(全体)");
     // データ行数: ヘッダー1行 + 各tallyのcodes数の合計
-    const expectedDataRows = gtTallies.reduce((sum, t) => sum + t.codes.length, 0);
+    const expectedDataRows = grandTotalTallies.reduce((sum, t) => sum + t.codes.length, 0);
     expect(rows).toHaveLength(1 + expectedDataRows);
   });
 
   it("クロス結果でcross_axis/cross_valueが設定される", () => {
     const rows = talliesToLongRows(crossTallies);
     // GT行(by===null)は(全体)
-    const gtRows = rows.filter((r) => r[3] === "(全体)");
-    expect(gtRows.length).toBeGreaterThan(0);
+    const grandTotalRows = rows.filter((r) => r[3] === "(全体)");
+    expect(grandTotalRows.length).toBeGreaterThan(0);
     // クロス行(by!==null)はcross_axisが軸ラベル
     const crossRows = rows.filter((r, i) => i > 0 && r[3] !== "(全体)");
     expect(crossRows.length).toBeGreaterThan(0);
@@ -102,7 +102,7 @@ describe("talliesToLongRows", () => {
 
 describe("formatCSV", () => {
   it("ロングフォーマットのCSVを出力する", () => {
-    const csv = formatCSV(gtTallies);
+    const csv = formatCSV(grandTotalTallies);
     const lines = csv.split("\r\n");
 
     // ヘッダー行
@@ -131,7 +131,7 @@ describe("formatCSV", () => {
 
 describe("formatTSV", () => {
   it("タブ区切りのロングフォーマットで出力される", () => {
-    const tsv = formatTSV(gtTallies);
+    const tsv = formatTSV(grandTotalTallies);
     const lines = tsv.split("\n");
 
     expect(lines[0]).toContain("\t");
@@ -144,7 +144,7 @@ describe("formatTSV", () => {
 
 describe("formatMarkdown", () => {
   it("パイプ区切りのテーブルを生成する", () => {
-    const md = formatMarkdown(gtTallies);
+    const md = formatMarkdown(grandTotalTallies);
 
     expect(md).toContain("### q1 (SA)");
     expect(md).toContain("| --- |");
@@ -163,12 +163,12 @@ describe("formatMarkdown", () => {
 
 describe("formatJSON", () => {
   it("パース可能なJSONを出力し、Tally[]がそのまま含まれる", () => {
-    const json = formatJSON(gtTallies, "");
+    const json = formatJSON(grandTotalTallies, "");
     const parsed = JSON.parse(json);
 
     expect(parsed.weightColumn).toBeNull();
     expect(Array.isArray(parsed.results)).toBe(true);
-    expect(parsed.results).toHaveLength(gtTallies.length);
+    expect(parsed.results).toHaveLength(grandTotalTallies.length);
     expect(parsed.results[0].questionCode).toBe("q1");
     expect(parsed.results[0].type).toBe("SA");
     expect(Array.isArray(parsed.results[0].slices)).toBe(true);
@@ -176,14 +176,14 @@ describe("formatJSON", () => {
   });
 
   it("weightCol指定時にweightColumnが含まれる", () => {
-    const json = formatJSON(gtTallies, "weight");
+    const json = formatJSON(grandTotalTallies, "weight");
     const parsed = JSON.parse(json);
 
     expect(parsed.weightColumn).toBe("weight");
   });
 
   it("各sliceのcellsにcount/pctが数値で含まれる", () => {
-    const json = formatJSON(gtTallies, "");
+    const json = formatJSON(grandTotalTallies, "");
     const parsed = JSON.parse(json);
     const cell = parsed.results[0].slices[0].cells[0];
 

--- a/tests/helpers/invariants.ts
+++ b/tests/helpers/invariants.ts
@@ -1,7 +1,7 @@
 import { expect } from "vitest";
 import type { AggOutput } from "../../src/lib/agg/types";
 
-export function assertGtInvariants(
+export function assertGrandTotalInvariants(
   result: AggOutput,
   type: "SA" | "MA",
 ): void {


### PR DESCRIPTION
## Summary
- ドメイン用語「Grand Total（全体集計）」を略語 `gt` や曖昧な `totals` ではなく `grandTotal` として明示的に使用するよう統一
- ファイル名・識別子・i18nキー・CSS変数・コメントを一括リネーム（28ファイル）
- `pnpm check` (format + lint + tsc) パス、テスト 668件全パス

## Test plan
- [x] `pnpm check` パス
- [x] `pnpm test` 全668テスト パス
- [ ] `pnpm dev` で画面表示に問題がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)