### PR TITLE
refactor: PctDirection → Basis にリネームし wCol → activeWeightCol に統一

### DIFF
--- a/src/components/AggregationScreen.tsx
+++ b/src/components/AggregationScreen.tsx
@@ -36,12 +36,12 @@ export default function AggregationScreen({ csv, layout, dateWarnings }: Aggrega
   async function handleRunAggregation(): Promise<void> {
     setErrorMsg("");
 
-    const wCol = weightEnabled ? weightCol : "";
+    const activeWeightCol = weightEnabled ? weightCol : "";
     const crossQuestions = questions.filter((q) => crossSelected[q.code]);
 
     try {
-      const tallies = await runAggregation(questions, crossQuestions, wCol);
-      setAggResult({ tallies, weightCol: wCol });
+      const tallies = await runAggregation(questions, crossQuestions, activeWeightCol);
+      setAggResult({ tallies, weightCol: activeWeightCol });
     } catch (e) {
       setErrorMsg(t("error.aggregation", { msg: (e as Error).message }));
     }

--- a/src/components/aggregation/CrossTable.tsx
+++ b/src/components/aggregation/CrossTable.tsx
@@ -1,17 +1,17 @@
 import type { Tally, Slice } from "../../lib/agg/types";
 import { t } from "../../lib/i18n";
-import type { PctDirection } from "./viewTypes";
+import type { Basis } from "./viewTypes";
 import { formatN } from "../../lib/format";
 import { Th, Td } from "./TableCells";
 
 interface CrossTableProps {
   grandTotalTally: Tally;
   crossTallies: Tally[];
-  pctDir: PctDirection;
+  basis: Basis;
 }
 
-export function CrossTable({ grandTotalTally, crossTallies, pctDir }: CrossTableProps) {
-  if (pctDir === "horizontal") {
+export function CrossTable({ grandTotalTally, crossTallies, basis }: CrossTableProps) {
+  if (basis === "row") {
     return <TransposedCrossTable grandTotalTally={grandTotalTally} crossTallies={crossTallies} />;
   }
   return <VerticalCrossTable grandTotalTally={grandTotalTally} crossTallies={crossTallies} />;

--- a/src/components/aggregation/ResultPanel.tsx
+++ b/src/components/aggregation/ResultPanel.tsx
@@ -4,7 +4,7 @@ import { Toolbar, ViewOpts } from "./Toolbar";
 import { TallyCard } from "./TallyCard";
 import { AIBubble } from "./AIBubble";
 import { t } from "../../lib/i18n";
-import type { ChartType, PctDirection, ViewMode } from "./viewTypes";
+import type { Basis, ChartType, ViewMode } from "./viewTypes";
 import type { PaletteId } from "../../lib/chartConfig";
 
 interface ResultPanelProps {
@@ -35,7 +35,7 @@ function ResultContent({ tallies, weightCol }: { tallies: Tally[]; weightCol: st
   const [viewMode, setViewMode] = useState<ViewMode>("table");
   const [saChartType, setSaChartType] = useState<ChartType>("bar-h");
   const [maChartType, setMaChartType] = useState<ChartType>("bar-h");
-  const [pctDirection, setPctDirection] = useState<PctDirection>("vertical");
+  const [basis, setBasis] = useState<Basis>("column");
   const [paletteId, setPaletteId] = useState<PaletteId>("default");
   const [, setThemeTick] = useState(0);
 
@@ -55,7 +55,7 @@ function ResultContent({ tallies, weightCol }: { tallies: Tally[]; weightCol: st
     onViewModeChange: setViewMode,
     onSaChartTypeChange: setSaChartType,
     onMaChartTypeChange: setMaChartType,
-    onPctDirectionChange: setPctDirection,
+    onBasisChange: setBasis,
     onPaletteChange: setPaletteId,
   };
 
@@ -68,7 +68,7 @@ function ResultContent({ tallies, weightCol }: { tallies: Tally[]; weightCol: st
       .flatMap((t) => t.slices[0]?.cells.map((c) => c.pct) ?? []),
     0,
   );
-  const tableOpts = { pctDirection, maxPct };
+  const tableOpts = { basis, maxPct };
   const chartOpts = { saChartType, maChartType, paletteId };
 
   const minWidth = viewMode === "chart" ? "400px" : "360px";
@@ -86,7 +86,7 @@ function ResultContent({ tallies, weightCol }: { tallies: Tally[]; weightCol: st
       />
       <ViewOpts
         currentViewMode={viewMode}
-        currentPctDirection={pctDirection}
+        currentBasis={basis}
         hasCross={hasCross}
         chartOpts={chartOpts}
         callbacks={callbacks}

--- a/src/components/aggregation/TallyCard.tsx
+++ b/src/components/aggregation/TallyCard.tsx
@@ -90,7 +90,7 @@ function CardBody({
       <CrossTable
         grandTotalTally={grandTotalTally}
         crossTallies={crossTallies}
-        pctDir={tableOpts.pctDirection}
+        basis={tableOpts.basis}
       />
     );
   }

--- a/src/components/aggregation/Toolbar.tsx
+++ b/src/components/aggregation/Toolbar.tsx
@@ -4,13 +4,13 @@ import { PALETTE_BASES, PALETTE_IDS, type PaletteId } from "../../lib/chartConfi
 import { ToggleButton, ToggleGroup } from "../shared/ToggleButton";
 import { ExportMenu } from "./ExportMenu";
 import { executeExport, type ExportAction } from "../../lib/export/export";
-import type { ChartOpts, ChartType, PctDirection, ViewMode } from "./viewTypes";
+import type { Basis, ChartOpts, ChartType, ViewMode } from "./viewTypes";
 
 export interface ToolbarCallbacks {
   onViewModeChange: (mode: ViewMode) => void;
   onSaChartTypeChange: (type: ChartType) => void;
   onMaChartTypeChange: (type: ChartType) => void;
-  onPctDirectionChange: (dir: PctDirection) => void;
+  onBasisChange: (basis: Basis) => void;
   onPaletteChange: (id: PaletteId) => void;
 }
 
@@ -58,18 +58,18 @@ export function Toolbar({ tallies, weightCol, currentViewMode, callbacks }: Tool
 
 interface ViewOptsProps {
   currentViewMode: ViewMode;
-  currentPctDirection: PctDirection;
+  currentBasis: Basis;
   hasCross: boolean;
   chartOpts: ChartOpts;
   callbacks: Pick<
     ToolbarCallbacks,
-    "onSaChartTypeChange" | "onMaChartTypeChange" | "onPctDirectionChange" | "onPaletteChange"
+    "onSaChartTypeChange" | "onMaChartTypeChange" | "onBasisChange" | "onPaletteChange"
   >;
 }
 
 export function ViewOpts({
   currentViewMode,
-  currentPctDirection,
+  currentBasis,
   hasCross,
   chartOpts,
   callbacks,
@@ -101,20 +101,16 @@ export function ViewOpts({
       {showPctToggle && (
         <ToggleGroup class="ml-auto">
           <ToggleButton
-            active={currentPctDirection === "vertical"}
-            onClick={() =>
-              currentPctDirection !== "vertical" && callbacks.onPctDirectionChange("vertical")
-            }
+            active={currentBasis === "column"}
+            onClick={() => currentBasis !== "column" && callbacks.onBasisChange("column")}
           >
-            {t("result.pct.vertical")}
+            {t("result.pct.column")}
           </ToggleButton>
           <ToggleButton
-            active={currentPctDirection === "horizontal"}
-            onClick={() =>
-              currentPctDirection !== "horizontal" && callbacks.onPctDirectionChange("horizontal")
-            }
+            active={currentBasis === "row"}
+            onClick={() => currentBasis !== "row" && callbacks.onBasisChange("row")}
           >
-            {t("result.pct.horizontal")}
+            {t("result.pct.row")}
           </ToggleButton>
         </ToggleGroup>
       )}

--- a/src/components/aggregation/viewTypes.ts
+++ b/src/components/aggregation/viewTypes.ts
@@ -2,10 +2,10 @@ import type { PaletteId } from "../../lib/chartConfig";
 
 export type ChartType = "bar-h" | "bar-v" | "obi";
 export type ViewMode = "table" | "chart";
-export type PctDirection = "vertical" | "horizontal";
+export type Basis = "column" | "row";
 
 export interface TableOpts {
-  pctDirection: PctDirection;
+  basis: Basis;
   maxPct: number;
 }
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -60,8 +60,8 @@ const en: Record<string, string> = {
   "result.weight.none": "Unweighted",
   "result.view.table": "Table",
   "result.view.chart": "Chart",
-  "result.pct.vertical": "Col %",
-  "result.pct.horizontal": "Row %",
+  "result.pct.column": "Col %",
+  "result.pct.row": "Row %",
   "result.csv.export": "Export All CSV",
 
   // Export menu

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -60,8 +60,8 @@ const ja: Record<string, string> = {
   "result.weight.none": "実数集計",
   "result.view.table": "テーブル",
   "result.view.chart": "チャート",
-  "result.pct.vertical": "縦%",
-  "result.pct.horizontal": "横%",
+  "result.pct.column": "縦%",
+  "result.pct.row": "横%",
   "result.csv.export": "全件CSV出力",
 
   // Export menu


### PR DESCRIPTION
## Summary
- `PctDirection` 型（`"vertical" | "horizontal"`）を `Basis`（`"column" | "row"`）にリネーム — %算出基準の意図をより明確に表現
- 関連する props / state / callback / i18nキーをすべて統一
- `AggregationScreen` のローカル変数 `wCol` を `activeWeightCol` にリネームし、親スコープの `weightCol` との混同を防止

## Test plan
- [x] `pnpm check` (fmt, lint, tsc) 通過
- [x] `pnpm test` 全668テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)