### PR TITLE
fix: StatusListener コールバックの不要な省略可能パラメータを削除

### DIFF
--- a/src/lib/duckdb.ts
+++ b/src/lib/duckdb.ts
@@ -6,7 +6,7 @@ import { prepareDateColumns, type DatePreparationResult } from "./datePreparatio
 import { validateData, type ValidationResult } from "./validateData";
 
 export type DuckStatus = "loading" | "ready" | "error";
-export type StatusListener = (s: DuckStatus, label?: string) => void;
+export type StatusListener = (s: DuckStatus, label: string) => void;
 
 let statusListener: StatusListener | null = null;
 


### PR DESCRIPTION
## Summary
- `StatusListener` 型の `label` パラメータから `?` を除去し、TypeScript [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html) の「コールバック型に省略可能パラメータを使わない」ルールに準拠
- 全呼び出し箇所で常に `label` を渡しているため、実行時の影響なし

## Test plan
- [x] `pnpm check` パス確認済み（fmt, lint, tsc）

🤖 Generated with [Claude Code](https://claude.com/claude-code)