### PR TITLE
refactor: NO_ANSWER_VALUE を sqlHelpers から constants.ts に移動

### DIFF
--- a/src/lib/agg/aggCrossTab.ts
+++ b/src/lib/agg/aggCrossTab.ts
@@ -9,8 +9,8 @@ import {
   maWeightedCountExpr,
   maShownCondition,
   maNoneSelectedCondition,
-  NO_ANSWER_VALUE,
 } from "./sqlHelpers";
+import { NO_ANSWER_VALUE } from "./constants";
 
 type CrossSliceData = {
   code: string;

--- a/src/lib/agg/aggGrandTotal.ts
+++ b/src/lib/agg/aggGrandTotal.ts
@@ -9,8 +9,8 @@ import {
   maWeightedCountExpr,
   maShownCondition,
   maNoneSelectedCondition,
-  NO_ANSWER_VALUE,
 } from "./sqlHelpers";
+import { NO_ANSWER_VALUE } from "./constants";
 
 export async function aggGrandTotal(
   conn: duckdb.AsyncDuckDBConnection,

--- a/src/lib/agg/buildTallies.ts
+++ b/src/lib/agg/buildTallies.ts
@@ -3,7 +3,7 @@ import type { Question, AggOutput, Axis, Tally } from "./types";
 import { aggGrandTotal } from "./aggGrandTotal";
 import { aggCrossTab } from "./aggCrossTab";
 import { aggNaGrandTotal, aggNaCrossTab } from "./aggNa";
-import { NO_ANSWER_VALUE } from "./sqlHelpers";
+import { NO_ANSWER_VALUE } from "./constants";
 import { t } from "../i18n";
 
 export async function buildTallies(

--- a/src/lib/agg/constants.ts
+++ b/src/lib/agg/constants.ts
@@ -1,0 +1,2 @@
+/** No-answer marker */
+export const NO_ANSWER_VALUE = "N/A";

--- a/src/lib/agg/sqlHelpers.ts
+++ b/src/lib/agg/sqlHelpers.ts
@@ -28,5 +28,3 @@ export function weightedCountExpr(condition: string, weightCol: string): string 
 export function maNoneSelectedCondition(cols: string[]): string {
   return cols.map((c) => `"${esc(c)}" != 1`).join(" AND ");
 }
-/** No-answer marker */
-export const NO_ANSWER_VALUE = "N/A";


### PR DESCRIPTION
## Summary
- `NO_ANSWER_VALUE` を `sqlHelpers.ts` から新規作成した `src/lib/agg/constants.ts` に移動
- SQL生成ヘルパーとドメイン定数の責務を分離
- `aggGrandTotal.ts`, `aggCrossTab.ts`, `buildTallies.ts` のインポート元を更新

## Test plan
- [x] `pnpm check` パス確認済み
- [x] `pnpm test` 全668テストパス確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)