### PR TITLE
refactor: CardBody を viewMode × isNA の 2×2 構造に整理

### DIFF
--- a/src/components/aggregation/TallyCard.tsx
+++ b/src/components/aggregation/TallyCard.tsx
@@ -57,34 +57,47 @@ function CardBody({
   tableOpts,
   chartOpts,
 }: TallyCardProps) {
-  if (grandTotalTally.type === "NA") {
-    if (viewMode === "chart") {
-      return (
-        <NaChartCardBody
-          grandTotalTally={grandTotalTally}
-          crossTallies={crossTallies}
-          paletteId={chartOpts.paletteId}
-        />
-      );
-    }
-    if (crossTallies.length > 0) {
-      return <NaCrossTable grandTotalTally={grandTotalTally} crossTallies={crossTallies} />;
-    }
-    return <NaGrandTotalTable tally={grandTotalTally} />;
-  }
+  const isNA = grandTotalTally.type === "NA";
 
-  // SA | MA
   if (viewMode === "chart") {
-    const { saChartType, maChartType, paletteId } = chartOpts;
-    return (
+    return isNA ? (
+      <NaChartCardBody
+        grandTotalTally={grandTotalTally}
+        crossTallies={crossTallies}
+        paletteId={chartOpts.paletteId}
+      />
+    ) : (
       <ChartCardBody
         grandTotalTally={grandTotalTally}
         crossTallies={crossTallies}
-        grandTotalChartType={grandTotalTally.type === "SA" ? saChartType : maChartType}
-        paletteId={paletteId}
+        grandTotalChartType={
+          grandTotalTally.type === "SA" ? chartOpts.saChartType : chartOpts.maChartType
+        }
+        paletteId={chartOpts.paletteId}
       />
     );
   }
+
+  return isNA ? (
+    <NaTableCardBody grandTotalTally={grandTotalTally} crossTallies={crossTallies} />
+  ) : (
+    <TableCardBody
+      grandTotalTally={grandTotalTally}
+      crossTallies={crossTallies}
+      tableOpts={tableOpts}
+    />
+  );
+}
+
+function TableCardBody({
+  grandTotalTally,
+  crossTallies,
+  tableOpts,
+}: {
+  grandTotalTally: Tally;
+  crossTallies: Tally[];
+  tableOpts: TableOpts;
+}) {
   if (crossTallies.length > 0) {
     return (
       <CrossTable
@@ -95,4 +108,17 @@ function CardBody({
     );
   }
   return <GrandTotalTable tally={grandTotalTally} maxPct={tableOpts.maxPct} />;
+}
+
+function NaTableCardBody({
+  grandTotalTally,
+  crossTallies,
+}: {
+  grandTotalTally: Tally;
+  crossTallies: Tally[];
+}) {
+  if (crossTallies.length > 0) {
+    return <NaCrossTable grandTotalTally={grandTotalTally} crossTallies={crossTallies} />;
+  }
+  return <NaGrandTotalTable tally={grandTotalTally} />;
 }


### PR DESCRIPTION
## Summary
- `CardBody` のネストした分岐を `viewMode`(chart / table)× `isNA`(NA / SA・MA)の 2×2 マトリクスに整理
- `TableCardBody` / `NaTableCardBody` を導入し、`hasCross` 判定を内部に押し込み
- `CardBody` が2軸だけに集中できるようになり、対称構造が一目でわかるように

## Test plan
- [ ] `pnpm check` パス済み
- [ ] SA/MA の GT テーブル・クロステーブル・チャートが正常に表示されること
- [ ] NA の GT テーブル・クロステーブル・チャートが正常に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)