### PR TITLE
refactor: buildAxis の null ガードを呼び出し側に移動

### DIFF
--- a/src/lib/agg/buildTallies.ts
+++ b/src/lib/agg/buildTallies.ts
@@ -53,13 +53,12 @@ function toTally(question: Question, aggOutput: AggOutput, axisQuestion?: Questi
     label: question.label,
     labels,
     codes: aggOutput.codes,
-    by: buildAxis(aggOutput, axisQuestion),
+    by: axisQuestion ? buildAxis(aggOutput, axisQuestion) : null,
     slices: aggOutput.slices,
   };
 }
 
-function buildAxis(aggOutput: AggOutput, axisQuestion?: Question): Axis | null {
-  if (!axisQuestion) return null;
+function buildAxis(aggOutput: AggOutput, axisQuestion: Question): Axis {
   const axisLabels: Record<string, string> = { ...axisQuestion.labels };
   const hasNoAnswer = aggOutput.slices.some((s) => s.code === NO_ANSWER_VALUE);
   if (hasNoAnswer) {


### PR DESCRIPTION
## 概要
- `buildAxis` 内部の `if (!axisQuestion) return null` ガードを削除
- 呼び出し側の `toTally` で `axisQuestion ? buildAxis(aggOutput, axisQuestion) : null` に変更
- `buildAxis` の引数を `Question`（non-nullable）、戻り値を `Axis`（non-nullable）に変更

## 目的
`buildAxis` の責務を明確にし、nullable なハンドリングを呼び出し側に集約する。
これにより `buildAxis` は「軸を構築する」という単一の責務に専念できる。

## テスト
- `pnpm check` (fmt:check + lint + tsc --noEmit): 全パス
- `pnpm test`: 668 テスト全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)