### PR TITLE
refactor: LayoutEntry を Discriminated Union に変更

### DIFF
--- a/.claude/skills/aggy-import/references/layout.schema.json
+++ b/.claude/skills/aggy-import/references/layout.schema.json
@@ -5,7 +5,7 @@
   "description": "アンケートローデータのレイアウト定義。CSV列の種別（SA/MA/WEIGHT）と選択肢ラベルを指定する。",
   "type": "array",
   "items": {
-    "$ref": "#/definitions/LayoutEntry"
+    "$ref": "#/definitions/LayoutQuestion"
   },
   "definitions": {
     "LayoutItem": {
@@ -24,7 +24,7 @@
       "required": ["code", "label"],
       "additionalProperties": false
     },
-    "LayoutEntry": {
+    "LayoutQuestion": {
       "type": "object",
       "properties": {
         "key": {
@@ -49,7 +49,7 @@
           "description": "選択肢リスト（SA/MAで使用）"
         }
       },
-      "required": ["key", "type"],
+      "required": ["key", "label", "type"],
       "additionalProperties": false,
       "allOf": [
         {

--- a/bench/generate.ts
+++ b/bench/generate.ts
@@ -8,7 +8,7 @@
 
 import { mkdirSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
-import type { LayoutEntry, LayoutItem } from "../src/lib/layout";
+import type { LayoutQuestion, LayoutItem } from "../src/lib/layout";
 
 // ---------------------------------------------------------------------------
 // Seeded PRNG (mulberry32) — deterministic across runs
@@ -95,9 +95,9 @@ function generateItems(count: number, prefix: string): LayoutItem[] {
   }));
 }
 
-function generateLayout(pattern: PatternDef): LayoutEntry[] {
+function generateLayout(pattern: PatternDef): LayoutQuestion[] {
   const { saCount, maCount, maSubCount } = pattern;
-  const layout: LayoutEntry[] = [{ key: "weight", label: "ウェイト", type: "WEIGHT" }];
+  const layout: LayoutQuestion[] = [{ key: "weight", label: "ウェイト", type: "WEIGHT" }];
 
   for (let i = 1; i <= saCount; i++) {
     layout.push({

--- a/bench/generate.ts
+++ b/bench/generate.ts
@@ -8,6 +8,7 @@
 
 import { mkdirSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
+import type { LayoutEntry, LayoutItem } from "../src/lib/layout";
 
 // ---------------------------------------------------------------------------
 // Seeded PRNG (mulberry32) — deterministic across runs
@@ -87,29 +88,23 @@ function generateCSV(pattern: PatternDef, rand: () => number): string {
 // Layout JSON generation
 // ---------------------------------------------------------------------------
 
-interface LayoutEntry {
-  key: string;
-  type: string;
-  label?: string;
-  items?: { code: string; label: string }[];
+function generateItems(count: number, prefix: string): LayoutItem[] {
+  return Array.from({ length: count }, (_, j) => ({
+    code: String(j + 1),
+    label: `${prefix}${j + 1}`,
+  }));
 }
 
 function generateLayout(pattern: PatternDef): LayoutEntry[] {
   const { saCount, maCount, maSubCount } = pattern;
-  const layout: LayoutEntry[] = [
-    { key: "id", type: "ID" },
-    { key: "weight", type: "WEIGHT" },
-  ];
+  const layout: LayoutEntry[] = [{ key: "weight", label: "ウェイト", type: "WEIGHT" }];
 
   for (let i = 1; i <= saCount; i++) {
     layout.push({
       key: `sa${i}`,
       label: `SA設問${i}`,
       type: "SA",
-      items: Array.from({ length: 5 }, (_, j) => ({
-        code: String(j + 1),
-        label: `選択肢${j + 1}`,
-      })),
+      items: generateItems(5, "選択肢"),
     });
   }
 
@@ -118,10 +113,7 @@ function generateLayout(pattern: PatternDef): LayoutEntry[] {
       key: `ma${i}`,
       label: `MA設問${i}`,
       type: "MA",
-      items: Array.from({ length: maSubCount }, (_, j) => ({
-        code: String(j + 1),
-        label: `項目${j + 1}`,
-      })),
+      items: generateItems(maSubCount, "項目"),
     });
   }
 

--- a/public/schemas/layout.schema.json
+++ b/public/schemas/layout.schema.json
@@ -5,7 +5,7 @@
   "description": "アンケートローデータのレイアウト定義。CSV列の種別（SA/MA/WEIGHT/DATE）と選択肢ラベルを指定する。",
   "type": "array",
   "items": {
-    "$ref": "#/definitions/LayoutEntry"
+    "$ref": "#/definitions/LayoutQuestion"
   },
   "definitions": {
     "LayoutItem": {
@@ -24,7 +24,7 @@
       "required": ["code", "label"],
       "additionalProperties": false
     },
-    "LayoutEntry": {
+    "LayoutQuestion": {
       "type": "object",
       "properties": {
         "key": {
@@ -54,7 +54,7 @@
           "description": "選択肢リスト（SA/MAで使用）"
         }
       },
-      "required": ["key", "type"],
+      "required": ["key", "label", "type"],
       "additionalProperties": false,
       "allOf": [
         {

--- a/src/lib/datePreparation.ts
+++ b/src/lib/datePreparation.ts
@@ -27,7 +27,7 @@ export async function prepareDateColumns(
       continue;
     }
 
-    const granularity = entry.granularity ?? "month";
+    const granularity = entry.granularity;
     const fmt = FORMAT_MAP[granularity];
     const col = esc(entry.key);
     const fmtCol = esc(`${entry.key}__${granularity}`);
@@ -42,7 +42,7 @@ export async function prepareDateColumns(
     );
     const failCount = Number(failResult.toArray()[0].n);
     if (failCount > 0) {
-      warnings.push(`${entry.label ?? entry.key}:${failCount}`);
+      warnings.push(`${entry.label}:${failCount}`);
     }
 
     const distinct = await conn.query(
@@ -52,7 +52,7 @@ export async function prepareDateColumns(
 
     result.push({
       key: `${entry.key}__${granularity}`,
-      label: entry.label ?? entry.key,
+      label: entry.label,
       type: "SA",
       items: values.map((v) => ({ code: v, label: v })),
     });

--- a/src/lib/datePreparation.ts
+++ b/src/lib/datePreparation.ts
@@ -21,16 +21,16 @@ export async function prepareDateColumns(
   const result: Layout = [];
   const warnings: string[] = [];
 
-  for (const entry of layout) {
-    if (entry.type !== "DATE") {
-      result.push(entry);
+  for (const q of layout) {
+    if (q.type !== "DATE") {
+      result.push(q);
       continue;
     }
 
-    const granularity = entry.granularity;
+    const granularity = q.granularity;
     const fmt = FORMAT_MAP[granularity];
-    const col = esc(entry.key);
-    const fmtCol = esc(`${entry.key}__${granularity}`);
+    const col = esc(q.key);
+    const fmtCol = esc(`${q.key}__${granularity}`);
 
     await conn.query(`ALTER TABLE survey ADD COLUMN "${fmtCol}" VARCHAR`);
     await conn.query(
@@ -42,7 +42,7 @@ export async function prepareDateColumns(
     );
     const failCount = Number(failResult.toArray()[0].n);
     if (failCount > 0) {
-      warnings.push(`${entry.label}:${failCount}`);
+      warnings.push(`${q.label}:${failCount}`);
     }
 
     const distinct = await conn.query(
@@ -51,8 +51,8 @@ export async function prepareDateColumns(
     const values = distinct.toArray().map((r) => String(r.v));
 
     result.push({
-      key: `${entry.key}__${granularity}`,
-      label: entry.label,
+      key: `${q.key}__${granularity}`,
+      label: q.label,
       type: "SA",
       items: values.map((v) => ({ code: v, label: v })),
     });

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -18,9 +18,9 @@ type DateLayout = {
   granularity: DateGranularity;
 };
 
-export type LayoutEntry = SALayout | MALayout | NALayout | WeightLayout | DateLayout;
+export type LayoutQuestion = SALayout | MALayout | NALayout | WeightLayout | DateLayout;
 
-export type Layout = LayoutEntry[];
+export type Layout = LayoutQuestion[];
 
 const VALID_TYPES = new Set(["SA", "MA", "NA", "WEIGHT", "DATE"]);
 const VALID_GRANULARITIES = new Set(["year", "month", "week", "day"]);

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -73,18 +73,13 @@ export function filterLayout(headers: string[], layout: Layout): Layout {
   const headerSet = new Set(headers);
   const filtered: Layout = [];
 
-  for (const entry of layout) {
-    if (
-      entry.type === "SA" ||
-      entry.type === "NA" ||
-      entry.type === "WEIGHT" ||
-      entry.type === "DATE"
-    ) {
-      if (headerSet.has(entry.key)) filtered.push(entry);
-    } else if (entry.type === "MA") {
-      const matchedItems = entry.items.filter((item) => headerSet.has(`${entry.key}_${item.code}`));
+  for (const q of layout) {
+    if (q.type === "SA" || q.type === "NA" || q.type === "WEIGHT" || q.type === "DATE") {
+      if (headerSet.has(q.key)) filtered.push(q);
+    } else if (q.type === "MA") {
+      const matchedItems = q.items.filter((item) => headerSet.has(`${q.key}_${item.code}`));
       if (matchedItems.length > 0) {
-        filtered.push({ ...entry, items: matchedItems });
+        filtered.push({ ...q, items: matchedItems });
       }
     }
   }

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -1,21 +1,29 @@
-import type { Question, QuestionType } from "./agg/types";
+import type { Question } from "./agg/types";
 
-interface LayoutItem {
+export interface LayoutItem {
   code: string;
   label: string;
 }
 
 export type DateGranularity = "year" | "month" | "week" | "day";
 
-interface LayoutEntry {
+type SALayout = { type: "SA"; key: string; label: string; items: LayoutItem[] };
+type MALayout = { type: "MA"; key: string; label: string; items: LayoutItem[] };
+type NALayout = { type: "NA"; key: string; label: string };
+type WeightLayout = { type: "WEIGHT"; key: string; label: string };
+type DateLayout = {
+  type: "DATE";
   key: string;
-  label?: string;
-  type: QuestionType | "WEIGHT" | "DATE";
-  items?: LayoutItem[];
-  granularity?: DateGranularity;
-}
+  label: string;
+  granularity: DateGranularity;
+};
+
+export type LayoutEntry = SALayout | MALayout | NALayout | WeightLayout | DateLayout;
 
 export type Layout = LayoutEntry[];
+
+const VALID_TYPES = new Set(["SA", "MA", "NA", "WEIGHT", "DATE"]);
+const VALID_GRANULARITIES = new Set(["year", "month", "week", "day"]);
 
 export function parseLayout(jsonText: string): Layout {
   let parsed: unknown;
@@ -35,8 +43,26 @@ export function parseLayout(jsonText: string): Layout {
     if (typeof e["key"] !== "string") {
       throw new Error('各エントリに "key"（文字列）が必要です。');
     }
-    if (typeof e["type"] !== "string") {
-      throw new Error('各エントリに "type"（文字列）が必要です。');
+    if (typeof e["type"] !== "string" || !VALID_TYPES.has(e["type"])) {
+      throw new Error(
+        `"${e["key"]}": "type" は ${[...VALID_TYPES].join(", ")} のいずれかである必要があります。`,
+      );
+    }
+    if (typeof e["label"] !== "string") {
+      throw new Error(`"${e["key"]}": "label"（文字列）が必要です。`);
+    }
+    const type = e["type"] as string;
+    if (type === "SA" || type === "MA") {
+      if (!Array.isArray(e["items"]) || e["items"].length === 0) {
+        throw new Error(`"${e["key"]}": ${type} には "items"（1件以上の配列）が必要です。`);
+      }
+    }
+    if (type === "DATE") {
+      if (typeof e["granularity"] !== "string" || !VALID_GRANULARITIES.has(e["granularity"])) {
+        throw new Error(
+          `"${e["key"]}": DATE には "granularity"（${[...VALID_GRANULARITIES].join(", ")}）が必要です。`,
+        );
+      }
     }
   }
   return parsed as Layout;
@@ -55,7 +81,7 @@ export function filterLayout(headers: string[], layout: Layout): Layout {
       entry.type === "DATE"
     ) {
       if (headerSet.has(entry.key)) filtered.push(entry);
-    } else if (entry.type === "MA" && entry.items) {
+    } else if (entry.type === "MA") {
       const matchedItems = entry.items.filter((item) => headerSet.has(`${entry.key}_${item.code}`));
       if (matchedItems.length > 0) {
         filtered.push({ ...entry, items: matchedItems });
@@ -71,25 +97,31 @@ export function buildQuestions(layout: Layout): Question[] {
   return layout
     .filter((e) => e.type === "SA" || e.type === "MA" || e.type === "NA")
     .map((e) => {
-      if (e.type === "NA") {
-        return {
-          type: "NA" as const,
-          code: e.key,
-          columns: [e.key],
-          codes: [],
-          label: e.label ?? e.key,
-          labels: {},
-        };
-      }
-      return {
-        type: e.type as "SA" | "MA",
-        code: e.key,
-        columns: e.type === "SA" ? [e.key] : (e.items ?? []).map((i) => `${e.key}_${i.code}`),
-        codes: (e.items ?? []).map((i) => i.code),
-        label: e.label ?? e.key,
-        labels: Object.fromEntries((e.items ?? []).map((i) => [i.code, i.label])),
-      };
+      if (e.type === "NA") return buildNAQuestion(e);
+      return buildChoiceQuestion(e);
     });
+}
+
+function buildNAQuestion(e: NALayout): Question {
+  return {
+    type: "NA",
+    code: e.key,
+    columns: [e.key],
+    codes: [],
+    label: e.label,
+    labels: {},
+  };
+}
+
+function buildChoiceQuestion(e: SALayout | MALayout): Question {
+  return {
+    type: e.type,
+    code: e.key,
+    columns: e.type === "SA" ? [e.key] : e.items.map((i) => `${e.key}_${i.code}`),
+    codes: e.items.map((i) => i.code),
+    label: e.label,
+    labels: Object.fromEntries(e.items.map((i) => [i.code, i.label])),
+  };
 }
 
 /** Find weight column name from layout, or empty string if none */
@@ -99,5 +131,5 @@ export function findWeightColumn(layout: Layout): string {
 
 /** Count total layout-defined columns (SA: 1 each, MA: items count, WEIGHT: 1) */
 export function countLayoutColumns(layout: Layout): number {
-  return layout.reduce((acc, e) => acc + (e.type === "MA" ? (e.items?.length ?? 0) : 1), 0);
+  return layout.reduce((acc, e) => acc + (e.type === "MA" ? e.items.length : 1), 0);
 }

--- a/src/lib/validateData.ts
+++ b/src/lib/validateData.ts
@@ -28,12 +28,12 @@ export async function validateData(
   for (const entry of layout) {
     if (entry.type === "SA" || entry.type === "NA" || entry.type === "WEIGHT") {
       if (!headerSet.has(entry.key)) {
-        droppedEntries.push({ key: entry.key, label: entry.label ?? entry.key, type: entry.type });
+        droppedEntries.push({ key: entry.key, label: entry.label, type: entry.type });
       }
-    } else if (entry.type === "MA" && entry.items) {
+    } else if (entry.type === "MA") {
       const hasAny = entry.items.some((item) => headerSet.has(`${entry.key}_${item.code}`));
       if (!hasAny) {
-        droppedEntries.push({ key: entry.key, label: entry.label ?? entry.key, type: entry.type });
+        droppedEntries.push({ key: entry.key, label: entry.label, type: entry.type });
       }
     }
   }
@@ -41,7 +41,7 @@ export async function validateData(
   // Check SA columns for undefined codes
   const unknownCodeErrors: UnknownCodeError[] = [];
   for (const entry of layout) {
-    if (entry.type !== "SA" || !entry.items || entry.items.length === 0) continue;
+    if (entry.type !== "SA") continue;
     if (!headerSet.has(entry.key)) continue; // column not in CSV, already reported as dropped
 
     const definedCodes = new Set(entry.items.map((i) => i.code));
@@ -61,7 +61,7 @@ export async function validateData(
     if (unknownCodes.length > 0) {
       unknownCodeErrors.push({
         key: entry.key,
-        label: entry.label ?? entry.key,
+        label: entry.label,
         unknownCodes: unknownCodes.sort(),
       });
     }

--- a/src/lib/validateData.ts
+++ b/src/lib/validateData.ts
@@ -25,29 +25,29 @@ export async function validateData(
 
   // Detect layout entries whose columns are missing from CSV
   const droppedEntries: ValidationResult["droppedEntries"] = [];
-  for (const entry of layout) {
-    if (entry.type === "SA" || entry.type === "NA" || entry.type === "WEIGHT") {
-      if (!headerSet.has(entry.key)) {
-        droppedEntries.push({ key: entry.key, label: entry.label, type: entry.type });
+  for (const q of layout) {
+    if (q.type === "SA" || q.type === "NA" || q.type === "WEIGHT") {
+      if (!headerSet.has(q.key)) {
+        droppedEntries.push({ key: q.key, label: q.label, type: q.type });
       }
-    } else if (entry.type === "MA") {
-      const hasAny = entry.items.some((item) => headerSet.has(`${entry.key}_${item.code}`));
+    } else if (q.type === "MA") {
+      const hasAny = q.items.some((item) => headerSet.has(`${q.key}_${item.code}`));
       if (!hasAny) {
-        droppedEntries.push({ key: entry.key, label: entry.label, type: entry.type });
+        droppedEntries.push({ key: q.key, label: q.label, type: q.type });
       }
     }
   }
 
   // Check SA columns for undefined codes
   const unknownCodeErrors: UnknownCodeError[] = [];
-  for (const entry of layout) {
-    if (entry.type !== "SA") continue;
-    if (!headerSet.has(entry.key)) continue; // column not in CSV, already reported as dropped
+  for (const q of layout) {
+    if (q.type !== "SA") continue;
+    if (!headerSet.has(q.key)) continue; // column not in CSV, already reported as dropped
 
-    const definedCodes = new Set(entry.items.map((i) => i.code));
+    const definedCodes = new Set(q.items.map((i) => i.code));
 
     const result = await conn.query(
-      `SELECT DISTINCT "${esc(entry.key)}" AS v FROM survey WHERE "${esc(entry.key)}" IS NOT NULL`,
+      `SELECT DISTINCT "${esc(q.key)}" AS v FROM survey WHERE "${esc(q.key)}" IS NOT NULL`,
     );
 
     const unknownCodes: string[] = [];
@@ -60,8 +60,8 @@ export async function validateData(
 
     if (unknownCodes.length > 0) {
       unknownCodeErrors.push({
-        key: entry.key,
-        label: entry.label,
+        key: q.key,
+        label: q.label,
         unknownCodes: unknownCodes.sort(),
       });
     }

--- a/testdata/test_layout.json
+++ b/testdata/test_layout.json
@@ -1,6 +1,7 @@
 [
   {
     "key": "weight",
+    "label": "ウェイト",
     "type": "WEIGHT"
   },
   {

--- a/tests/layout.test.ts
+++ b/tests/layout.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { filterLayout, buildQuestions } from "../src/lib/layout";
+import { parseLayout, filterLayout, buildQuestions } from "../src/lib/layout";
 import type { Layout } from "../src/lib/layout";
 
 const layout: Layout = [
@@ -22,7 +22,7 @@ const layout: Layout = [
       { code: "3", label: "Reading" },
     ],
   },
-  { key: "weight", type: "WEIGHT" },
+  { key: "weight", label: "ウェイト", type: "WEIGHT" },
   { key: "answer_date", label: "回答日", type: "DATE", granularity: "month" as const },
   { key: "score", label: "NPS", type: "NA" as const },
 ];
@@ -130,5 +130,42 @@ describe("buildQuestions", () => {
       label: "NPS",
       labels: {},
     });
+  });
+});
+
+describe("parseLayout validation", () => {
+  it("rejects entry without label", () => {
+    const json = JSON.stringify([{ key: "q1", type: "SA", items: [{ code: "1", label: "A" }] }]);
+    expect(() => parseLayout(json)).toThrow('"q1": "label"（文字列）が必要です。');
+  });
+
+  it("rejects SA entry without items", () => {
+    const json = JSON.stringify([{ key: "q1", label: "Q1", type: "SA" }]);
+    expect(() => parseLayout(json)).toThrow('"q1": SA には "items"（1件以上の配列）が必要です。');
+  });
+
+  it("rejects MA entry with empty items", () => {
+    const json = JSON.stringify([{ key: "q1", label: "Q1", type: "MA", items: [] }]);
+    expect(() => parseLayout(json)).toThrow('"q1": MA には "items"（1件以上の配列）が必要です。');
+  });
+
+  it("rejects DATE entry without granularity", () => {
+    const json = JSON.stringify([{ key: "d1", label: "Date", type: "DATE" }]);
+    expect(() => parseLayout(json)).toThrow('"d1": DATE には "granularity"');
+  });
+
+  it("rejects invalid type", () => {
+    const json = JSON.stringify([{ key: "q1", label: "Q1", type: "UNKNOWN" }]);
+    expect(() => parseLayout(json)).toThrow('"q1": "type" は');
+  });
+
+  it("accepts valid layout", () => {
+    const json = JSON.stringify([
+      { key: "q1", label: "Q1", type: "SA", items: [{ code: "1", label: "A" }] },
+      { key: "q2", label: "Q2", type: "NA" },
+      { key: "w", label: "Weight", type: "WEIGHT" },
+      { key: "d", label: "Date", type: "DATE", granularity: "month" },
+    ]);
+    expect(parseLayout(json)).toHaveLength(4);
   });
 });


### PR DESCRIPTION
## Summary
- `LayoutEntry` を Discriminated Union に変更し `LayoutQuestion` にリネーム（`SALayout | MALayout | NALayout | WeightLayout | DateLayout`）
- 各 type ごとに必要なフィールドを型レベルで強制（`label` 全型必須、SA/MA の `items` 必須、DATE の `granularity` 必須）
- `parseLayout` のバリデーションを厳格化（type 値チェック含む）
- `buildQuestions` を `buildNAQuestion` / `buildChoiceQuestion` ヘルパーに分割し、フォールバック（`?? e.key`, `?? []`）を全削除
- `validateData`, `datePreparation` の optional フォールバックも削除
- layout ループ変数を `entry` → `q` に統一

## Test plan
- [x] `pnpm check` パス（型チェック + lint + format）
- [x] `pnpm test` 全 1342 テストパス
- [x] parseLayout バリデーションテスト 6 件追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)