### PR TITLE
refactor: formatLoadedInfo の null ガードを呼び出し側に移動

### DIFF
--- a/src/components/ImportScreen.tsx
+++ b/src/components/ImportScreen.tsx
@@ -14,8 +14,7 @@ const GettingStartedModal = lazy(() =>
   import("./import/GettingStarted").then((m) => ({ default: m.GettingStartedModal })),
 );
 
-function formatLoadedInfo(csv: CsvData | null): string | null {
-  if (!csv) return null;
+function formatLoadedInfo(csv: CsvData): string {
   return t("summary.rows", {
     rows: csv.rowCount.toLocaleString(),
     cols: csv.headers.length,
@@ -115,7 +114,7 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
   const { entries, deleteEntry } = useSavedFiles();
 
   const bothLoaded = csv !== null && layout !== null;
-  const loadedInfo = formatLoadedInfo(csv);
+  const loadedInfo = csv ? formatLoadedInfo(csv) : null;
 
   const handleCsvFile = useCallback(async (file: File) => {
     try {


### PR DESCRIPTION
## Summary
- `formatLoadedInfo` 関数内の null ガード (`if (!csv) return null`) を除去し、シグネチャを `(csv: CsvData) => string` に変更
- null チェックは呼び出し側で三項演算子 (`csv ? formatLoadedInfo(csv) : null`) として処理するように移動
- これにより `formatLoadedInfo` は常に `string` を返す純粋な変換関数となり、責務が明確化

## Test plan
- [x] `pnpm check` (fmt:check, lint, tsc --noEmit) 通過
- [x] `pnpm test` 全 668 テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)