### PR TITLE
test: aggNaGrandTotal の PBT テストを追加

### DIFF
--- a/tests/aggNaGrandTotalPbt.test.ts
+++ b/tests/aggNaGrandTotalPbt.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, beforeAll, afterAll } from "vitest";
+import { aggNaGrandTotal } from "../src/lib/agg/aggNa";
+import { setupDuckDB, teardownDuckDB, getConn, loadCSV } from "./helpers/duckdb";
+import { generateNADataset } from "./helpers/generators";
+import { assertNaGrandTotalInvariants } from "./helpers/invariants";
+
+beforeAll(async () => {
+  await setupDuckDB();
+}, 30_000);
+
+afterAll(async () => {
+  await teardownDuckDB();
+});
+
+const SEEDS = 50;
+const ROW_RANGE = { min: 50, max: 200 };
+
+function rowCount(seed: number): number {
+  return ROW_RANGE.min + ((seed * 17) % (ROW_RANGE.max - ROW_RANGE.min + 1));
+}
+
+describe("PBT - aggNaGrandTotal 重みなし", () => {
+  for (let seed = 1; seed <= SEEDS; seed++) {
+    it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
+      const ds = generateNADataset({ seed, rowCount: rowCount(seed) });
+      await loadCSV(ds.csv);
+      const result = await aggNaGrandTotal(getConn(), ds.column, "");
+      assertNaGrandTotalInvariants(result);
+    });
+  }
+});
+
+describe("PBT - aggNaGrandTotal 重みあり", () => {
+  for (let seed = 1; seed <= SEEDS; seed++) {
+    it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
+      const ds = generateNADataset({ seed, rowCount: rowCount(seed), weighted: true });
+      await loadCSV(ds.csv);
+      const result = await aggNaGrandTotal(getConn(), ds.column, ds.weightCol);
+      assertNaGrandTotalInvariants(result);
+    });
+  }
+});

--- a/tests/helpers/generators.ts
+++ b/tests/helpers/generators.ts
@@ -112,6 +112,36 @@ export function generateMADataset(opts: DatasetOpts): MADataset {
   };
 }
 
+interface NADataset {
+  csv: string;
+  column: string;
+  weightCol: string;
+}
+
+export function generateNADataset(opts: DatasetOpts): NADataset {
+  const rng = new Rng(opts.seed);
+  const nullRate = opts.nullRate ?? 0.1;
+  const weighted = opts.weighted ?? false;
+
+  const headers = ["id", ...(weighted ? ["weight"] : []), "q_na"];
+  const rows: (string | number | null)[][] = [];
+
+  for (let i = 1; i <= opts.rowCount; i++) {
+    const row: (string | number | null)[] = [i];
+    if (weighted) {
+      row.push(Math.round((0.5 + rng.next() * 1.5) * 10) / 10);
+    }
+    row.push(rng.next() < nullRate ? null : rng.int(0, 10));
+    rows.push(row);
+  }
+
+  return {
+    csv: buildCSV(headers, rows),
+    column: "q_na",
+    weightCol: weighted ? "weight" : "",
+  };
+}
+
 export function generateCrossDataset(opts: DatasetOpts): CrossDataset {
   const rng = new Rng(opts.seed);
   const saCodes = ["1", "2", "3"];

--- a/tests/helpers/invariants.ts
+++ b/tests/helpers/invariants.ts
@@ -33,6 +33,61 @@ export function assertGrandTotalInvariants(
   }
 }
 
+export function assertNaGrandTotalInvariants(result: AggOutput): void {
+  // 1. Single slice with code === null
+  expect(result.slices).toHaveLength(1);
+  const slice = result.slices[0];
+  expect(slice.code).toBeNull();
+
+  // 2. stats exists
+  expect(slice.stats).toBeDefined();
+  const stats = slice.stats!;
+
+  // 3. codes.length === cells.length
+  expect(result.codes.length).toBe(slice.cells.length);
+
+  // 4. Each cell.pct ≈ (cell.count / n) * 100
+  for (const cell of slice.cells) {
+    expect(cell.count).toBeGreaterThanOrEqual(0);
+    if (slice.n > 0) {
+      expect(cell.pct).toBeCloseTo((cell.count / slice.n) * 100, 3);
+    }
+  }
+
+  // 5. sum(cells.count) ≈ n (each numeric value counted once)
+  const sumCounts = slice.cells.reduce((s, c) => s + c.count, 0);
+  expect(sumCounts).toBeCloseTo(slice.n, 3);
+
+  // 6. sum(cells.pct) ≈ 100 (when n > 0)
+  if (slice.n > 0) {
+    const sumPct = slice.cells.reduce((s, c) => s + c.pct, 0);
+    expect(sumPct).toBeCloseTo(100, 3);
+  }
+
+  // 7. stats.min <= stats.mean <= stats.max (when n > 0)
+  if (slice.n > 0) {
+    expect(stats.min).toBeLessThanOrEqual(stats.mean + 1e-9);
+    expect(stats.mean).toBeLessThanOrEqual(stats.max + 1e-9);
+  }
+
+  // 8. stats.min <= stats.median <= stats.max (when n > 0)
+  if (slice.n > 0) {
+    expect(stats.min).toBeLessThanOrEqual(stats.median + 1e-9);
+    expect(stats.median).toBeLessThanOrEqual(stats.max + 1e-9);
+  }
+
+  // 9. stats.sd >= 0
+  expect(stats.sd).toBeGreaterThanOrEqual(0);
+
+  // 10. stats.n === slice.n
+  expect(stats.n).toBeCloseTo(slice.n, 3);
+
+  // 11. codes are sorted in numeric ascending order
+  for (let i = 1; i < result.codes.length; i++) {
+    expect(Number(result.codes[i])).toBeGreaterThanOrEqual(Number(result.codes[i - 1]));
+  }
+}
+
 export function assertCrossInvariants(
   result: AggOutput,
   type: "SA" | "MA",


### PR DESCRIPTION
## Summary
- `tests/helpers/generators.ts` に `generateNADataset()` を追加（NA用のCSVデータ生成）
- `tests/helpers/invariants.ts` に `assertNaGrandTotalInvariants()` を追加（統計量の11項目の不変条件チェック）
- `tests/aggNaGrandTotalPbt.test.ts` を新規作成（50シード × 重みなし/重みありの計100テスト）

## Test plan
- [x] `pnpm test -- tests/aggNaGrandTotalPbt.test.ts` で100テスト全件パス確認済み
- [x] 既存テスト含む全774テストがパスすることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)