### PR TITLE
test: add oracle PBT for aggregation (SA GT, MA GT, SA×SA Cross)

### DIFF
--- a/tests/aggCrossTabOracle.test.ts
+++ b/tests/aggCrossTabOracle.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, beforeAll, afterAll } from "vitest";
+import { aggCrossTab } from "../src/lib/agg/aggCrossTab";
+import { setupDuckDB, teardownDuckDB, getConn, loadCSV } from "./helpers/duckdb";
+import { generateCrossDataset } from "./helpers/generators";
+import { parseCSVToRows } from "./helpers/parseCSV";
+import { oracleSaSaCross, assertOracleMatch } from "./helpers/oracle";
+
+beforeAll(async () => {
+  await setupDuckDB();
+}, 30_000);
+
+afterAll(async () => {
+  await teardownDuckDB();
+});
+
+const SEEDS = 50;
+const ROW_RANGE = { min: 50, max: 200 };
+
+function rowCount(seed: number): number {
+  return ROW_RANGE.min + ((seed * 17) % (ROW_RANGE.max - ROW_RANGE.min + 1));
+}
+
+describe("Oracle - aggCrossTab SA×SA 重みなし", () => {
+  for (let seed = 1; seed <= SEEDS; seed++) {
+    it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
+      const ds = generateCrossDataset({ seed, rowCount: rowCount(seed) });
+      await loadCSV(ds.csv);
+      const actual = await aggCrossTab(getConn(), ds.saInput, ds.sa2Input, "");
+      const rows = parseCSVToRows(ds.csv);
+      const expected = oracleSaSaCross(
+        rows,
+        "q_sa",
+        ds.saInput.codes,
+        "q_sa2",
+        ds.sa2Input.codes,
+        "",
+      );
+      assertOracleMatch(actual, expected);
+    });
+  }
+});
+
+describe("Oracle - aggCrossTab SA×SA 重みあり", () => {
+  for (let seed = 1; seed <= SEEDS; seed++) {
+    it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
+      const ds = generateCrossDataset({ seed, rowCount: rowCount(seed), weighted: true });
+      await loadCSV(ds.csv);
+      const actual = await aggCrossTab(getConn(), ds.saInput, ds.sa2Input, ds.weightCol);
+      const rows = parseCSVToRows(ds.csv);
+      const expected = oracleSaSaCross(
+        rows,
+        "q_sa",
+        ds.saInput.codes,
+        "q_sa2",
+        ds.sa2Input.codes,
+        ds.weightCol,
+      );
+      assertOracleMatch(actual, expected);
+    });
+  }
+});

--- a/tests/aggCrossTabOracle.test.ts
+++ b/tests/aggCrossTabOracle.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeAll, afterAll } from "vitest";
 import { aggCrossTab } from "../src/lib/agg/aggCrossTab";
 import { setupDuckDB, teardownDuckDB, getConn, loadCSV } from "./helpers/duckdb";
-import { generateCrossDataset } from "./helpers/generators";
+import { generateCrossDataset, SEEDS, rowCount } from "./helpers/generators";
 import { parseCSVToRows } from "./helpers/parseCSV";
 import { oracleSaSaCross, assertOracleMatch } from "./helpers/oracle";
 
@@ -12,13 +12,6 @@ beforeAll(async () => {
 afterAll(async () => {
   await teardownDuckDB();
 });
-
-const SEEDS = 50;
-const ROW_RANGE = { min: 50, max: 200 };
-
-function rowCount(seed: number): number {
-  return ROW_RANGE.min + ((seed * 17) % (ROW_RANGE.max - ROW_RANGE.min + 1));
-}
 
 describe("Oracle - aggCrossTab SA×SA 重みなし", () => {
   for (let seed = 1; seed <= SEEDS; seed++) {

--- a/tests/aggCrossTabPbt.test.ts
+++ b/tests/aggCrossTabPbt.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeAll, afterAll } from "vitest";
 import { aggCrossTab } from "../src/lib/agg/aggCrossTab";
 import { setupDuckDB, teardownDuckDB, getConn, loadCSV } from "./helpers/duckdb";
-import { generateCrossDataset } from "./helpers/generators";
+import { generateCrossDataset, SEEDS, rowCount } from "./helpers/generators";
 import { assertCrossInvariants } from "./helpers/invariants";
 
 beforeAll(async () => {
@@ -11,13 +11,6 @@ beforeAll(async () => {
 afterAll(async () => {
   await teardownDuckDB();
 });
-
-const SEEDS = 50;
-const ROW_RANGE = { min: 50, max: 200 };
-
-function rowCount(seed: number): number {
-  return ROW_RANGE.min + ((seed * 17) % (ROW_RANGE.max - ROW_RANGE.min + 1));
-}
 
 describe("PBT - aggCrossTab SA×SA 重みなし", () => {
   for (let seed = 1; seed <= SEEDS; seed++) {

--- a/tests/aggGrandTotalOracle.test.ts
+++ b/tests/aggGrandTotalOracle.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, beforeAll, afterAll } from "vitest";
+import { aggGrandTotal } from "../src/lib/agg/aggGrandTotal";
+import { setupDuckDB, teardownDuckDB, getConn, loadCSV } from "./helpers/duckdb";
+import { generateSADataset, generateMADataset } from "./helpers/generators";
+import { parseCSVToRows } from "./helpers/parseCSV";
+import {
+  oracleSaGrandTotal,
+  oracleMaGrandTotal,
+  assertOracleMatch,
+} from "./helpers/oracle";
+
+beforeAll(async () => {
+  await setupDuckDB();
+}, 30_000);
+
+afterAll(async () => {
+  await teardownDuckDB();
+});
+
+const SEEDS = 50;
+const ROW_RANGE = { min: 50, max: 200 };
+
+function rowCount(seed: number): number {
+  return ROW_RANGE.min + ((seed * 17) % (ROW_RANGE.max - ROW_RANGE.min + 1));
+}
+
+describe("Oracle - aggGrandTotal SA 重みなし", () => {
+  for (let seed = 1; seed <= SEEDS; seed++) {
+    it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
+      const ds = generateSADataset({ seed, rowCount: rowCount(seed) });
+      await loadCSV(ds.csv);
+      const actual = await aggGrandTotal(getConn(), ds.shape, "");
+      const rows = parseCSVToRows(ds.csv);
+      const expected = oracleSaGrandTotal(rows, "q_sa", ds.shape.codes, "");
+      assertOracleMatch(actual, expected);
+    });
+  }
+});
+
+describe("Oracle - aggGrandTotal SA 重みあり", () => {
+  for (let seed = 1; seed <= SEEDS; seed++) {
+    it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
+      const ds = generateSADataset({ seed, rowCount: rowCount(seed), weighted: true });
+      await loadCSV(ds.csv);
+      const actual = await aggGrandTotal(getConn(), ds.shape, ds.weightCol);
+      const rows = parseCSVToRows(ds.csv);
+      const expected = oracleSaGrandTotal(rows, "q_sa", ds.shape.codes, ds.weightCol);
+      assertOracleMatch(actual, expected);
+    });
+  }
+});
+
+describe("Oracle - aggGrandTotal MA 重みなし", () => {
+  for (let seed = 1; seed <= SEEDS; seed++) {
+    it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
+      const ds = generateMADataset({ seed, rowCount: rowCount(seed) });
+      await loadCSV(ds.csv);
+      const actual = await aggGrandTotal(getConn(), ds.shape, "");
+      const rows = parseCSVToRows(ds.csv);
+      const expected = oracleMaGrandTotal(rows, ds.shape.columns, ds.shape.codes, "");
+      assertOracleMatch(actual, expected);
+    });
+  }
+});
+
+describe("Oracle - aggGrandTotal MA 重みあり", () => {
+  for (let seed = 1; seed <= SEEDS; seed++) {
+    it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
+      const ds = generateMADataset({ seed, rowCount: rowCount(seed), weighted: true });
+      await loadCSV(ds.csv);
+      const actual = await aggGrandTotal(getConn(), ds.shape, ds.weightCol);
+      const rows = parseCSVToRows(ds.csv);
+      const expected = oracleMaGrandTotal(
+        rows,
+        ds.shape.columns,
+        ds.shape.codes,
+        ds.weightCol,
+      );
+      assertOracleMatch(actual, expected);
+    });
+  }
+});

--- a/tests/aggGrandTotalOracle.test.ts
+++ b/tests/aggGrandTotalOracle.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeAll, afterAll } from "vitest";
 import { aggGrandTotal } from "../src/lib/agg/aggGrandTotal";
 import { setupDuckDB, teardownDuckDB, getConn, loadCSV } from "./helpers/duckdb";
-import { generateSADataset, generateMADataset } from "./helpers/generators";
+import { generateSADataset, generateMADataset, SEEDS, rowCount } from "./helpers/generators";
 import { parseCSVToRows } from "./helpers/parseCSV";
 import {
   oracleSaGrandTotal,
@@ -16,13 +16,6 @@ beforeAll(async () => {
 afterAll(async () => {
   await teardownDuckDB();
 });
-
-const SEEDS = 50;
-const ROW_RANGE = { min: 50, max: 200 };
-
-function rowCount(seed: number): number {
-  return ROW_RANGE.min + ((seed * 17) % (ROW_RANGE.max - ROW_RANGE.min + 1));
-}
 
 describe("Oracle - aggGrandTotal SA 重みなし", () => {
   for (let seed = 1; seed <= SEEDS; seed++) {

--- a/tests/aggGrandTotalPbt.test.ts
+++ b/tests/aggGrandTotalPbt.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeAll, afterAll } from "vitest";
 import { aggGrandTotal } from "../src/lib/agg/aggGrandTotal";
 import { setupDuckDB, teardownDuckDB, getConn, loadCSV } from "./helpers/duckdb";
-import { generateSADataset, generateMADataset } from "./helpers/generators";
+import { generateSADataset, generateMADataset, SEEDS, rowCount } from "./helpers/generators";
 import { assertGrandTotalInvariants } from "./helpers/invariants";
 
 beforeAll(async () => {
@@ -11,13 +11,6 @@ beforeAll(async () => {
 afterAll(async () => {
   await teardownDuckDB();
 });
-
-const SEEDS = 50;
-const ROW_RANGE = { min: 50, max: 200 };
-
-function rowCount(seed: number): number {
-  return ROW_RANGE.min + ((seed * 17) % (ROW_RANGE.max - ROW_RANGE.min + 1));
-}
 
 describe("PBT - aggGrandTotal SA 重みなし", () => {
   for (let seed = 1; seed <= SEEDS; seed++) {

--- a/tests/helpers/generators.ts
+++ b/tests/helpers/generators.ts
@@ -1,6 +1,13 @@
 import type { Shape } from "../../src/lib/agg/types";
 import { buildCSV } from "./csv";
 
+export const SEEDS = 50;
+const ROW_RANGE = { min: 50, max: 200 };
+
+export function rowCount(seed: number): number {
+  return ROW_RANGE.min + ((seed * 17) % (ROW_RANGE.max - ROW_RANGE.min + 1));
+}
+
 export class Rng {
   private state: number;
 

--- a/tests/helpers/oracle.ts
+++ b/tests/helpers/oracle.ts
@@ -1,0 +1,145 @@
+/**
+ * Oracle (reference) implementations for aggregation.
+ * These are intentionally independent of src/lib/agg/ — no imports from production code
+ * except AggOutput (used only in the assertion signature).
+ */
+
+import { expect } from "vitest";
+import type { AggOutput } from "../../src/lib/agg/types";
+
+// ── Local types ──
+
+interface OracleCell {
+  count: number;
+  pct: number;
+}
+
+interface OracleSlice {
+  code: string | null;
+  n: number;
+  cells: OracleCell[];
+}
+
+export interface OracleOutput {
+  codes: string[];
+  slices: OracleSlice[];
+}
+
+// ── Constants ──
+
+const NO_ANSWER_VALUE = "N/A";
+
+// ── Public API ──
+
+export function oracleSaGrandTotal(
+  rows: Record<string, string | null>[],
+  column: string,
+  codes: string[],
+  weightCol: string,
+): OracleOutput {
+  const valid = rows.filter((r) => r[column] !== null);
+  const weighted = weightCol !== "";
+  const n = weighted ? sumWeights(valid, weightCol) : valid.length;
+
+  const cells = codes.map((code) => {
+    const matching = valid.filter((r) => r[column] === code);
+    const count = weighted ? sumWeights(matching, weightCol) : matching.length;
+    const pct = n > 0 ? (count / n) * 100 : 0;
+    return { count, pct };
+  });
+
+  return { codes, slices: [{ code: null, n, cells }] };
+}
+
+export function oracleMaGrandTotal(
+  rows: Record<string, string | null>[],
+  columns: string[],
+  codes: string[],
+  weightCol: string,
+): OracleOutput {
+  const shown = rows.filter((r) => columns.some((col) => r[col] !== null));
+  const weighted = weightCol !== "";
+  const n = weighted ? sumWeights(shown, weightCol) : shown.length;
+
+  const cells: OracleCell[] = columns.map((col) => {
+    const matching = shown.filter((r) => r[col] === "1");
+    const count = weighted ? sumWeights(matching, weightCol) : matching.length;
+    const pct = n > 0 ? (count / n) * 100 : 0;
+    return { count, pct };
+  });
+
+  const resultCodes = [...codes];
+
+  // N/A: shown rows where ALL columns !== "1"
+  const naRows = shown.filter((r) =>
+    columns.every((col) => r[col] !== "1"),
+  );
+  const naCount = weighted ? sumWeights(naRows, weightCol) : naRows.length;
+  if (naCount > 0) {
+    const naPct = n > 0 ? (naCount / n) * 100 : 0;
+    cells.push({ count: naCount, pct: naPct });
+    resultCodes.push(NO_ANSWER_VALUE);
+  }
+
+  return { codes: resultCodes, slices: [{ code: null, n, cells }] };
+}
+
+export function oracleSaSaCross(
+  rows: Record<string, string | null>[],
+  mainCol: string,
+  mainCodes: string[],
+  crossCol: string,
+  crossCodes: string[],
+  weightCol: string,
+): OracleOutput {
+  const valid = rows.filter(
+    (r) => r[mainCol] !== null && r[crossCol] !== null,
+  );
+  const weighted = weightCol !== "";
+
+  const slices = crossCodes.map((crossCode) => {
+    const sliceRows = valid.filter((r) => r[crossCol] === crossCode);
+    const n = weighted ? sumWeights(sliceRows, weightCol) : sliceRows.length;
+    const cells = mainCodes.map((mainCode) => {
+      const matching = sliceRows.filter((r) => r[mainCol] === mainCode);
+      const count = weighted
+        ? sumWeights(matching, weightCol)
+        : matching.length;
+      const pct = n > 0 ? (count / n) * 100 : 0;
+      return { count, pct };
+    });
+    return { code: crossCode, n, cells };
+  });
+
+  return { codes: mainCodes, slices };
+}
+
+export function assertOracleMatch(
+  actual: AggOutput,
+  expected: OracleOutput,
+): void {
+  expect(actual.codes).toEqual(expected.codes);
+  expect(actual.slices).toHaveLength(expected.slices.length);
+
+  for (let i = 0; i < expected.slices.length; i++) {
+    const aSlice = actual.slices[i];
+    const eSlice = expected.slices[i];
+    expect(aSlice.code).toBe(eSlice.code);
+    expect(aSlice.n).toBeCloseTo(eSlice.n, 3);
+    expect(aSlice.cells).toHaveLength(eSlice.cells.length);
+
+    for (let j = 0; j < eSlice.cells.length; j++) {
+      expect(aSlice.cells[j].count).toBeCloseTo(eSlice.cells[j].count, 3);
+      expect(aSlice.cells[j].pct).toBeCloseTo(eSlice.cells[j].pct, 3);
+    }
+  }
+}
+
+// ── Internal helpers ──
+
+function sumWeights(
+  rows: Record<string, string | null>[],
+  weightCol: string,
+): number {
+  return rows.reduce((sum, r) => sum + Number(r[weightCol] ?? 0), 0);
+}

--- a/tests/helpers/parseCSV.ts
+++ b/tests/helpers/parseCSV.ts
@@ -1,0 +1,17 @@
+/** Simple CSV parser for oracle tests — converts CSV string to row objects. */
+
+export function parseCSVToRows(
+  csv: string,
+): Record<string, string | null>[] {
+  const lines = csv.trimEnd().split("\n");
+  const headers = lines[0].split(",");
+
+  return lines.slice(1).map((line) => {
+    const values = line.split(",");
+    const row: Record<string, string | null> = {};
+    for (let i = 0; i < headers.length; i++) {
+      row[headers[i]] = values[i] === "" ? null : values[i];
+    }
+    return row;
+  });
+}


### PR DESCRIPTION
## Summary

- Add **oracle (reference implementation) property-based tests** that verify DuckDB SQL aggregation results against independent plain-JavaScript computations
- Follows the **SQLite SLT (Script Logic Test)** approach: two completely independent implementations must produce the same results for randomly generated inputs, catching bugs that invariant-only checks would miss
- 300 new test cases across 6 describe blocks: SA Grand Total (weighted/unweighted), MA Grand Total (weighted/unweighted), SA×SA Cross-tab (weighted/unweighted)

## New files

| File | Purpose |
|------|---------|
| `tests/helpers/parseCSV.ts` | Simple CSV string → `Record<string, string \| null>[]` parser |
| `tests/helpers/oracle.ts` | Oracle functions (`oracleSaGrandTotal`, `oracleMaGrandTotal`, `oracleSaSaCross`) + `assertOracleMatch` |
| `tests/aggGrandTotalOracle.test.ts` | 4 × 50 seeds — SA/MA GT oracle tests |
| `tests/aggCrossTabOracle.test.ts` | 2 × 50 seeds — SA×SA Cross oracle tests |

## Test plan

- [x] `pnpm test` — all 974 tests pass (including 300 new oracle tests)
- [x] `pnpm check` — formatting, linting, and type checking all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)