### PR TITLE
test: add PBT tests for aggNaCrossTab

### DIFF
--- a/tests/aggNaCrossTabPbt.test.ts
+++ b/tests/aggNaCrossTabPbt.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, beforeAll, afterAll } from "vitest";
+import { aggNaCrossTab } from "../src/lib/agg/aggNa";
+import { setupDuckDB, teardownDuckDB, getConn, loadCSV } from "./helpers/duckdb";
+import { generateNACrossDataset } from "./helpers/generators";
+import { assertNaCrossInvariants } from "./helpers/invariants";
+
+beforeAll(async () => {
+  await setupDuckDB();
+}, 30_000);
+
+afterAll(async () => {
+  await teardownDuckDB();
+});
+
+const SEEDS = 50;
+const ROW_RANGE = { min: 50, max: 200 };
+
+function rowCount(seed: number): number {
+  return ROW_RANGE.min + ((seed * 17) % (ROW_RANGE.max - ROW_RANGE.min + 1));
+}
+
+describe("PBT - aggNaCrossTab NA×SA 重みなし", () => {
+  for (let seed = 1; seed <= SEEDS; seed++) {
+    it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
+      const ds = generateNACrossDataset({ seed, rowCount: rowCount(seed) });
+      await loadCSV(ds.csv);
+      const result = await aggNaCrossTab(getConn(), ds.naColumn, ds.saAxis, "");
+      assertNaCrossInvariants(result, ds.saAxis.codes.length);
+    });
+  }
+});
+
+describe("PBT - aggNaCrossTab NA×SA 重みあり", () => {
+  for (let seed = 1; seed <= SEEDS; seed++) {
+    it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
+      const ds = generateNACrossDataset({ seed, rowCount: rowCount(seed), weighted: true });
+      await loadCSV(ds.csv);
+      const result = await aggNaCrossTab(getConn(), ds.naColumn, ds.saAxis, ds.weightCol);
+      assertNaCrossInvariants(result, ds.saAxis.codes.length);
+    });
+  }
+});
+
+describe("PBT - aggNaCrossTab NA×MA 重みなし", () => {
+  for (let seed = 1; seed <= SEEDS; seed++) {
+    it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
+      const ds = generateNACrossDataset({ seed, rowCount: rowCount(seed) });
+      await loadCSV(ds.csv);
+      const result = await aggNaCrossTab(getConn(), ds.naColumn, ds.maAxis, "");
+      assertNaCrossInvariants(result, ds.maAxis.codes.length);
+    });
+  }
+});
+
+describe("PBT - aggNaCrossTab NA×MA 重みあり", () => {
+  for (let seed = 1; seed <= SEEDS; seed++) {
+    it(`seed=${seed}, rows=${rowCount(seed)}`, async () => {
+      const ds = generateNACrossDataset({ seed, rowCount: rowCount(seed), weighted: true });
+      await loadCSV(ds.csv);
+      const result = await aggNaCrossTab(getConn(), ds.naColumn, ds.maAxis, ds.weightCol);
+      assertNaCrossInvariants(result, ds.maAxis.codes.length);
+    });
+  }
+});

--- a/tests/helpers/generators.ts
+++ b/tests/helpers/generators.ts
@@ -142,6 +142,60 @@ export function generateNADataset(opts: DatasetOpts): NADataset {
   };
 }
 
+interface NACrossDataset {
+  csv: string;
+  naColumn: string;
+  saAxis: Shape;
+  maAxis: Shape;
+  weightCol: string;
+}
+
+export function generateNACrossDataset(opts: DatasetOpts): NACrossDataset {
+  const rng = new Rng(opts.seed);
+  const saCodes = ["1", "2", "3"];
+  const maCodes = ["1", "2", "3"];
+  const nullRate = opts.nullRate ?? 0.1;
+  const weighted = opts.weighted ?? false;
+
+  const maColumns = maCodes.map((_, i) => `q_ma_${i + 1}`);
+  const headers = [
+    "id",
+    ...(weighted ? ["weight"] : []),
+    "q_na",
+    "q_sa",
+    ...maColumns,
+  ];
+  const rows: (string | number | null)[][] = [];
+
+  for (let i = 1; i <= opts.rowCount; i++) {
+    const row: (string | number | null)[] = [i];
+    if (weighted) {
+      row.push(Math.round((0.5 + rng.next() * 1.5) * 10) / 10);
+    }
+    // NA column
+    row.push(rng.next() < nullRate ? null : rng.int(0, 10));
+    // SA column
+    row.push(rng.next() < nullRate ? null : rng.pick(saCodes));
+    // MA columns
+    if (rng.next() < nullRate) {
+      for (let j = 0; j < maCodes.length; j++) row.push(null);
+    } else {
+      for (let j = 0; j < maCodes.length; j++) {
+        row.push(rng.next() < 0.4 ? 1 : 0);
+      }
+    }
+    rows.push(row);
+  }
+
+  return {
+    csv: buildCSV(headers, rows),
+    naColumn: "q_na",
+    saAxis: { type: "SA", columns: ["q_sa"], codes: saCodes },
+    maAxis: { type: "MA", columns: maColumns, codes: maCodes },
+    weightCol: weighted ? "weight" : "",
+  };
+}
+
 export function generateCrossDataset(opts: DatasetOpts): CrossDataset {
   const rng = new Rng(opts.seed);
   const saCodes = ["1", "2", "3"];

--- a/tests/helpers/invariants.ts
+++ b/tests/helpers/invariants.ts
@@ -88,6 +88,59 @@ export function assertNaGrandTotalInvariants(result: AggOutput): void {
   }
 }
 
+export function assertNaCrossInvariants(
+  result: AggOutput,
+  expectedSliceCount: number,
+): void {
+  // 1. slices.length === expectedSliceCount
+  expect(result.slices).toHaveLength(expectedSliceCount);
+
+  for (const slice of result.slices) {
+    // 2. Each slice code !== null
+    expect(slice.code).not.toBeNull();
+
+    // 3. Each slice has stats defined
+    expect(slice.stats).toBeDefined();
+    const stats = slice.stats!;
+
+    // 4. codes.length === cells.length
+    expect(result.codes.length).toBe(slice.cells.length);
+
+    // 5. Each cell: pct ≈ (count / n) * 100
+    for (const cell of slice.cells) {
+      expect(cell.count).toBeGreaterThanOrEqual(0);
+      if (slice.n > 0) {
+        expect(cell.pct).toBeCloseTo((cell.count / slice.n) * 100, 3);
+      }
+    }
+
+    // 6. Each slice (when n > 0): sum(cells.count) ≈ n, sum(cells.pct) ≈ 100
+    if (slice.n > 0) {
+      const sumCounts = slice.cells.reduce((s, c) => s + c.count, 0);
+      expect(sumCounts).toBeCloseTo(slice.n, 3);
+      const sumPct = slice.cells.reduce((s, c) => s + c.pct, 0);
+      expect(sumPct).toBeCloseTo(100, 3);
+    }
+
+    // 7. Stats consistency: min <= mean <= max, min <= median <= max, sd >= 0, stats.n === slice.n
+    if (slice.n > 0) {
+      expect(stats.min).toBeLessThanOrEqual(stats.mean + 1e-9);
+      expect(stats.mean).toBeLessThanOrEqual(stats.max + 1e-9);
+      expect(stats.min).toBeLessThanOrEqual(stats.median + 1e-9);
+      expect(stats.median).toBeLessThanOrEqual(stats.max + 1e-9);
+    }
+    expect(stats.sd).toBeGreaterThanOrEqual(0);
+    expect(stats.n).toBeCloseTo(slice.n, 3);
+  }
+
+  // 8. codes are sorted in numeric ascending order
+  for (let i = 1; i < result.codes.length; i++) {
+    expect(Number(result.codes[i])).toBeGreaterThanOrEqual(
+      Number(result.codes[i - 1]),
+    );
+  }
+}
+
 export function assertCrossInvariants(
   result: AggOutput,
   type: "SA" | "MA",


### PR DESCRIPTION
## Summary
- Add `generateNACrossDataset()` generator that produces CSV with NA, SA, and MA columns for cross-tab testing
- Add `assertNaCrossInvariants()` with 8 invariant checks: slice count, non-null codes, stats presence, codes/cells alignment, pct accuracy, count/pct sums, stats consistency (min/mean/max/median/sd), and sorted codes
- Add `tests/aggNaCrossTabPbt.test.ts` with 4 describe blocks x 50 seeds = 200 tests covering NA×SA and NA×MA, both weighted and unweighted

## Test plan
- [x] `pnpm test -- tests/aggNaCrossTabPbt.test.ts` passes all 200 tests
- [x] Full test suite (974 tests) passes
- [x] Lint and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)