### PR TITLE
refactor: csv/csvData → rawData に命名統一

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,13 +5,13 @@ import Header from "./components/Header";
 import ImportScreen from "./components/ImportScreen";
 import AggregationScreen from "./components/AggregationScreen";
 import { onLocaleChange } from "./lib/i18n";
-import type { CsvData, LayoutData } from "./lib/types";
+import type { RawData, LayoutData } from "./lib/types";
 
 export default function App() {
   const [screen, setScreen] = useState<"import" | "aggregation">("import");
   const [, setTick] = useState(0);
   const [loadedData, setLoadedData] = useState<{
-    csv: CsvData;
+    rawData: RawData;
     layout: LayoutData;
     dateWarnings: string[];
   } | null>(null);
@@ -22,10 +22,13 @@ export default function App() {
     onLocaleChange(() => setTick((n) => n + 1));
   }, []);
 
-  const handleComplete = useCallback((csv: CsvData, layout: LayoutData, dateWarnings: string[]) => {
-    setLoadedData({ csv, layout, dateWarnings });
-    setScreen("aggregation");
-  }, []);
+  const handleComplete = useCallback(
+    (rawData: RawData, layout: LayoutData, dateWarnings: string[]) => {
+      setLoadedData({ rawData, layout, dateWarnings });
+      setScreen("aggregation");
+    },
+    [],
+  );
 
   // Imperative initialization (runs once after mount)
   useEffect(() => {
@@ -47,7 +50,7 @@ export default function App() {
         ) : (
           loadedData && (
             <AggregationScreen
-              csv={loadedData.csv}
+              rawData={loadedData.rawData}
               layout={loadedData.layout}
               dateWarnings={loadedData.dateWarnings}
             />

--- a/src/components/AggregationScreen.tsx
+++ b/src/components/AggregationScreen.tsx
@@ -5,15 +5,19 @@ import SettingsPanel from "./aggregation/SettingsPanel";
 import { runAggregation } from "../lib/duckdb";
 import { buildQuestions, findWeightColumn } from "../lib/layout";
 import { t } from "../lib/i18n";
-import type { CsvData, LayoutData } from "../lib/types";
+import type { RawData, LayoutData } from "../lib/types";
 
 interface AggregationScreenProps {
-  csv: CsvData;
+  rawData: RawData;
   layout: LayoutData;
   dateWarnings: string[];
 }
 
-export default function AggregationScreen({ csv, layout, dateWarnings }: AggregationScreenProps) {
+export default function AggregationScreen({
+  rawData,
+  layout,
+  dateWarnings,
+}: AggregationScreenProps) {
   const questions = buildQuestions(layout.layout);
   const weightCol = findWeightColumn(layout.layout);
 
@@ -50,7 +54,7 @@ export default function AggregationScreen({ csv, layout, dateWarnings }: Aggrega
   return (
     <>
       <SettingsPanel
-        csv={csv}
+        rawData={rawData}
         layout={layout}
         questions={questions}
         crossSelected={crossSelected}

--- a/src/components/ImportScreen.tsx
+++ b/src/components/ImportScreen.tsx
@@ -8,21 +8,21 @@ import { t } from "../lib/i18n";
 import { FileUploadPanel } from "./import/FileUploadPanel";
 import { SavedFilesList, triggerSavedFilesRefresh, useSavedFiles } from "./import/SavedFiles";
 import { ValidationStep } from "./import/ValidationStep";
-import type { CsvData, LayoutData } from "../lib/types";
+import type { RawData, LayoutData } from "../lib/types";
 
 const GettingStartedModal = lazy(() =>
   import("./import/GettingStarted").then((m) => ({ default: m.GettingStartedModal })),
 );
 
-function formatLoadedInfo(csv: CsvData): string {
+function formatLoadedInfo(rawData: RawData): string {
   return t("summary.rows", {
-    rows: csv.rowCount.toLocaleString(),
-    cols: csv.headers.length,
+    rows: rawData.rowCount.toLocaleString(),
+    cols: rawData.headers.length,
   });
 }
 
 interface ImportScreenProps {
-  onComplete: (csv: CsvData, layout: LayoutData, dateWarnings: string[]) => void;
+  onComplete: (rawData: RawData, layout: LayoutData, dateWarnings: string[]) => void;
 }
 
 const STEPS = [
@@ -98,30 +98,34 @@ function HelpButton({ onClick }: { onClick: () => void }) {
 }
 
 export default function ImportScreen({ onComplete }: ImportScreenProps) {
-  const [csv, setCsv] = useState<CsvData | null>(null);
+  const [rawData, setRawData] = useState<RawData | null>(null);
   const [layout, setLayout] = useState<LayoutData | null>(null);
   const [step, setStep] = useState(1);
   const [gsOpen, setGsOpen] = useState(false);
 
   const loadedFromSavedRef = useRef(false);
   const opfsPayloadRef = useRef<{
-    csvText?: string;
-    csvFileName?: string;
+    rawDataText?: string;
+    rawDataFileName?: string;
     layoutJson?: string;
     layoutFileName?: string;
   }>({});
 
   const { entries, deleteEntry } = useSavedFiles();
 
-  const bothLoaded = csv !== null && layout !== null;
-  const loadedInfo = csv ? formatLoadedInfo(csv) : null;
+  const bothLoaded = rawData !== null && layout !== null;
+  const loadedInfo = rawData ? formatLoadedInfo(rawData) : null;
 
-  const handleCsvFile = useCallback(async (file: File) => {
+  const handleRawDataFile = useCallback(async (file: File) => {
     try {
       const text = await file.text();
       const result = await loadCSV(text);
-      opfsPayloadRef.current = { ...opfsPayloadRef.current, csvText: text, csvFileName: file.name };
-      setCsv({
+      opfsPayloadRef.current = {
+        ...opfsPayloadRef.current,
+        rawDataText: text,
+        rawDataFileName: file.name,
+      };
+      setRawData({
         fileName: file.name,
         headers: result.headers,
         rowCount: result.rowCount,
@@ -150,18 +154,18 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
 
   const handleLoadFromSaved = useCallback(async (folderId: string) => {
     try {
-      const { csvText, csvName, layoutJson, layoutName } = await loadSaved(folderId);
+      const { rawDataText, rawDataName, layoutJson, layoutName } = await loadSaved(folderId);
       const parsed = parseLayout(layoutJson);
-      const result = await loadCSV(csvText);
+      const result = await loadCSV(rawDataText);
 
       opfsPayloadRef.current = {
-        csvText,
-        csvFileName: csvName,
+        rawDataText,
+        rawDataFileName: rawDataName,
         layoutJson,
         layoutFileName: layoutName,
       };
-      setCsv({
-        fileName: csvName,
+      setRawData({
+        fileName: rawDataName,
         headers: result.headers,
         rowCount: result.rowCount,
       });
@@ -181,13 +185,13 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
   }
 
   async function handleProceed(): Promise<void> {
-    if (!csv || !layout) return;
+    if (!rawData || !layout) return;
     const payload = opfsPayloadRef.current;
-    if (!loadedFromSavedRef.current && payload.csvText && payload.layoutJson) {
+    if (!loadedFromSavedRef.current && payload.rawDataText && payload.layoutJson) {
       try {
         await saveData(
-          payload.csvFileName!,
-          payload.csvText,
+          payload.rawDataFileName!,
+          payload.rawDataText,
           payload.layoutFileName!,
           payload.layoutJson,
         );
@@ -196,9 +200,9 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
         // OPFS save is best-effort
       }
     }
-    const filtered = filterLayout(csv.headers, layout.layout);
+    const filtered = filterLayout(rawData.headers, layout.layout);
     const { layout: prepared, warnings } = await prepareDateLayout(filtered);
-    onComplete(csv, { ...layout, layout: prepared }, warnings);
+    onComplete(rawData, { ...layout, layout: prepared }, warnings);
   }
 
   return (
@@ -211,9 +215,9 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
         {step === 1 && (
           <>
             <FileUploadPanel
-              csvFileName={csv?.fileName ?? null}
+              rawDataFileName={rawData?.fileName ?? null}
               layoutFileName={layout?.fileName ?? null}
-              onCsvFile={handleCsvFile}
+              onRawDataFile={handleRawDataFile}
               onLayoutFile={handleLayoutFile}
             />
 
@@ -243,9 +247,9 @@ export default function ImportScreen({ onComplete }: ImportScreenProps) {
           </>
         )}
 
-        {step === 2 && csv && layout && (
+        {step === 2 && rawData && layout && (
           <ValidationStep
-            csv={csv}
+            rawData={rawData}
             layout={layout}
             onProceed={handleProceed}
             onBack={handleBackToUpload}

--- a/src/components/aggregation/SettingsPanel.tsx
+++ b/src/components/aggregation/SettingsPanel.tsx
@@ -1,11 +1,11 @@
 import type { Question } from "../../lib/agg/types";
 import { t } from "../../lib/i18n";
 import { ToggleButton, ToggleGroup } from "../shared/ToggleButton";
-import type { CsvData, LayoutData } from "../../lib/types";
+import type { RawData, LayoutData } from "../../lib/types";
 import { countLayoutColumns } from "../../lib/layout";
 
 interface SettingsPanelProps {
-  csv: CsvData;
+  rawData: RawData;
   layout: LayoutData;
   questions: Question[];
   crossSelected: Record<string, boolean>;
@@ -19,7 +19,7 @@ interface SettingsPanelProps {
 }
 
 export default function SettingsPanel({
-  csv,
+  rawData,
   layout,
   questions,
   crossSelected,
@@ -42,10 +42,10 @@ export default function SettingsPanel({
         <h2 class="mb-3 text-sm font-bold tracking-wider text-muted">{t("section.summary")}</h2>
         <div class="text-sm leading-relaxed text-text-secondary">
           <DataSummary
-            csv={{
-              fileName: csv.fileName,
-              rowCount: csv.rowCount,
-              headers: csv.headers,
+            rawData={{
+              fileName: rawData.fileName,
+              rowCount: rawData.rowCount,
+              headers: rawData.headers,
             }}
             layout={{
               fileName: layout.fileName,
@@ -149,17 +149,17 @@ function CrossConfig({
 }
 
 export function DataSummary({
-  csv,
+  rawData,
   layout,
 }: {
-  csv: { fileName: string; rowCount: number; headers: string[] };
+  rawData: { fileName: string; rowCount: number; headers: string[] };
   layout: { fileName: string; colCount: number };
 }) {
   return (
     <>
       <div class="mb-1 flex items-baseline gap-2 pl-4">
         <span class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-text">
-          {csv.fileName}
+          {rawData.fileName}
         </span>
       </div>
       <div class="mb-1 flex items-baseline gap-2 pl-4">
@@ -169,7 +169,10 @@ export function DataSummary({
       </div>
       <div class="mb-1 flex items-baseline gap-2 pl-4">
         <span class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-text">
-          {t("summary.rows", { rows: csv.rowCount.toLocaleString(), cols: csv.headers.length })}
+          {t("summary.rows", {
+            rows: rawData.rowCount.toLocaleString(),
+            cols: rawData.headers.length,
+          })}
         </span>
       </div>
     </>

--- a/src/components/import/FileUploadPanel.tsx
+++ b/src/components/import/FileUploadPanel.tsx
@@ -2,16 +2,16 @@ import { t } from "../../lib/i18n";
 import { Dropzone } from "./Dropzone";
 
 interface FileUploadPanelProps {
-  csvFileName: string | null;
+  rawDataFileName: string | null;
   layoutFileName: string | null;
-  onCsvFile: (file: File) => void;
+  onRawDataFile: (file: File) => void;
   onLayoutFile: (file: File) => void;
 }
 
 export function FileUploadPanel({
-  csvFileName,
+  rawDataFileName,
   layoutFileName,
-  onCsvFile,
+  onRawDataFile,
   onLayoutFile,
 }: FileUploadPanelProps) {
   return (
@@ -21,8 +21,8 @@ export function FileUploadPanel({
           accept=".csv"
           icon={t("dropzone.csv.icon")}
           text={t("dropzone.csv.text")}
-          loadedFileName={csvFileName}
-          onFile={onCsvFile}
+          loadedFileName={rawDataFileName}
+          onFile={onRawDataFile}
         />
       </div>
       <div class="flex-1">

--- a/src/components/import/SavedFiles.tsx
+++ b/src/components/import/SavedFiles.tsx
@@ -67,12 +67,12 @@ export function SavedFilesList({
               type="button"
               onClick={() => onSelectEntry(entry.folderId)}
             >
-              {entry.csvName} ({dateStr})
+              {entry.rawDataName} ({dateStr})
             </button>
             <button
               class="flex min-h-11 min-w-11 shrink-0 cursor-pointer items-center justify-center px-3 py-2 text-sm text-muted transition-colors hover:text-danger"
               type="button"
-              aria-label={t("saved.delete", { name: entry.csvName })}
+              aria-label={t("saved.delete", { name: entry.rawDataName })}
               onClick={async (e) => {
                 e.stopPropagation();
                 onDeleteEntry(entry.folderId);

--- a/src/components/import/ValidationStep.tsx
+++ b/src/components/import/ValidationStep.tsx
@@ -1,17 +1,17 @@
 import { useEffect, useState } from "preact/hooks";
 import { t } from "../../lib/i18n";
 import { runValidation } from "../../lib/duckdb";
-import type { Diagnostics } from "../../lib/validateCsv";
-import type { CsvData, LayoutData } from "../../lib/types";
+import type { Diagnostics } from "../../lib/validateRawData";
+import type { RawData, LayoutData } from "../../lib/types";
 
 interface ValidationStepProps {
-  csv: CsvData;
+  rawData: RawData;
   layout: LayoutData;
   onProceed: () => void;
   onBack: () => void;
 }
 
-export function ValidationStep({ csv, layout, onProceed, onBack }: ValidationStepProps) {
+export function ValidationStep({ rawData, layout, onProceed, onBack }: ValidationStepProps) {
   const [diagnostics, setDiagnostics] = useState<Diagnostics | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -20,7 +20,7 @@ export function ValidationStep({ csv, layout, onProceed, onBack }: ValidationSte
     setDiagnostics(null);
     setError(null);
 
-    runValidation(csv.headers, layout.layout)
+    runValidation(rawData.headers, layout.layout)
       .then((r) => {
         if (!cancelled) setDiagnostics(r);
       })
@@ -31,7 +31,7 @@ export function ValidationStep({ csv, layout, onProceed, onBack }: ValidationSte
     return () => {
       cancelled = true;
     };
-  }, [csv, layout]);
+  }, [rawData, layout]);
 
   if (error) {
     return (

--- a/src/lib/duckdb.ts
+++ b/src/lib/duckdb.ts
@@ -3,7 +3,7 @@ import type { Question, Tally } from "./agg/types";
 import type { Layout } from "./layout";
 import { buildTallies } from "./agg/buildTallies";
 import { prepareDateColumns, type DatePreparationResult } from "./datePreparation";
-import { validateCsv, type Diagnostics } from "./validateCsv";
+import { validateRawData, type Diagnostics } from "./validateRawData";
 
 export type DuckStatus = "loading" | "ready" | "error";
 export type StatusListener = (s: DuckStatus, label: string) => void;
@@ -53,12 +53,14 @@ export async function initDuckDB(): Promise<void> {
   return initPromise;
 }
 
-/** Register CSV text in DuckDB and return headers and row count */
-export async function loadCSV(csvText: string): Promise<{ headers: string[]; rowCount: number }> {
+/** Register raw data text in DuckDB and return headers and row count */
+export async function loadCSV(
+  rawDataText: string,
+): Promise<{ headers: string[]; rowCount: number }> {
   await initDuckDB();
   if (!db) throw new Error("DuckDB is not ready");
 
-  await db.registerFileText("survey.csv", csvText);
+  await db.registerFileText("survey.csv", rawDataText);
 
   const c = await getConnection();
   await c.query(
@@ -78,7 +80,7 @@ export async function loadCSV(csvText: string): Promise<{ headers: string[]; row
 /** Validate CSV data against layout definition */
 export async function runValidation(headers: string[], layout: Layout): Promise<Diagnostics> {
   const c = await getConnection();
-  return validateCsv(c, headers, layout);
+  return validateRawData(c, headers, layout);
 }
 
 /** Execute aggregation for all question × axis combinations */

--- a/src/lib/duckdb.ts
+++ b/src/lib/duckdb.ts
@@ -53,14 +53,12 @@ export async function initDuckDB(): Promise<void> {
   return initPromise;
 }
 
-/** Register raw data text in DuckDB and return headers and row count */
-export async function loadCSV(
-  rawDataText: string,
-): Promise<{ headers: string[]; rowCount: number }> {
+/** Register CSV text in DuckDB and return headers and row count */
+export async function loadCSV(csvText: string): Promise<{ headers: string[]; rowCount: number }> {
   await initDuckDB();
   if (!db) throw new Error("DuckDB is not ready");
 
-  await db.registerFileText("survey.csv", rawDataText);
+  await db.registerFileText("survey.csv", csvText);
 
   const c = await getConnection();
   await c.query(

--- a/src/lib/opfs.ts
+++ b/src/lib/opfs.ts
@@ -1,13 +1,13 @@
 export interface SavedEntry {
   folderId: string;
-  csvName: string;
+  rawDataName: string;
   layoutName: string;
   timestamp: number;
 }
 
 export async function saveData(
-  csvName: string,
-  csvText: string,
+  rawDataName: string,
+  rawDataText: string,
   layoutName: string,
   layoutJson: string,
 ): Promise<SavedEntry> {
@@ -16,17 +16,17 @@ export async function saveData(
   const dir = await getAggyDir();
   const folder = await dir.getDirectoryHandle(folderId, { create: true });
 
-  const csvHandle = await folder.getFileHandle(csvName, { create: true });
-  const csvW = await csvHandle.createWritable();
-  await csvW.write(csvText);
-  await csvW.close();
+  const rawDataHandle = await folder.getFileHandle(rawDataName, { create: true });
+  const rawDataW = await rawDataHandle.createWritable();
+  await rawDataW.write(rawDataText);
+  await rawDataW.close();
 
   const jsonHandle = await folder.getFileHandle(layoutName, { create: true });
   const jsonW = await jsonHandle.createWritable();
   await jsonW.write(layoutJson);
   await jsonW.close();
 
-  return { folderId, csvName, layoutName, timestamp: ts };
+  return { folderId, rawDataName, layoutName, timestamp: ts };
 }
 
 export async function listSaved(): Promise<SavedEntry[]> {
@@ -38,14 +38,14 @@ export async function listSaved(): Promise<SavedEntry[]> {
     const ts = Number(name);
     if (!Number.isFinite(ts)) continue;
 
-    let csvName = "";
+    let rawDataName = "";
     let layoutName = "";
     for await (const [fileName] of (handle as FileSystemDirectoryHandle).entries()) {
-      if (fileName.endsWith(".csv")) csvName = fileName;
+      if (fileName.endsWith(".csv")) rawDataName = fileName;
       else if (fileName.endsWith(".json")) layoutName = fileName;
     }
-    if (csvName && layoutName) {
-      entries.push({ folderId: name, csvName, layoutName, timestamp: ts });
+    if (rawDataName && layoutName) {
+      entries.push({ folderId: name, rawDataName, layoutName, timestamp: ts });
     }
   }
 
@@ -55,24 +55,24 @@ export async function listSaved(): Promise<SavedEntry[]> {
 
 export async function loadSaved(
   folderId: string,
-): Promise<{ csvText: string; csvName: string; layoutJson: string; layoutName: string }> {
+): Promise<{ rawDataText: string; rawDataName: string; layoutJson: string; layoutName: string }> {
   const dir = await getAggyDir();
   const folder = await dir.getDirectoryHandle(folderId);
 
-  let csvName = "";
+  let rawDataName = "";
   let layoutName = "";
   for await (const [fileName] of folder.entries()) {
-    if (fileName.endsWith(".csv")) csvName = fileName;
+    if (fileName.endsWith(".csv")) rawDataName = fileName;
     else if (fileName.endsWith(".json")) layoutName = fileName;
   }
-  if (!csvName || !layoutName) throw new Error("不完全な保存データです");
+  if (!rawDataName || !layoutName) throw new Error("不完全な保存データです");
 
-  const csvFile = await (await folder.getFileHandle(csvName)).getFile();
-  const csvText = await csvFile.text();
+  const rawDataFile = await (await folder.getFileHandle(rawDataName)).getFile();
+  const rawDataText = await rawDataFile.text();
   const jsonFile = await (await folder.getFileHandle(layoutName)).getFile();
   const layoutJson = await jsonFile.text();
 
-  return { csvText, csvName, layoutJson, layoutName };
+  return { rawDataText, rawDataName, layoutJson, layoutName };
 }
 
 export async function deleteSaved(folderId: string): Promise<void> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
 import type { Layout } from "./layout";
 
-export type CsvData = { fileName: string; headers: string[]; rowCount: number };
+export type RawData = { fileName: string; headers: string[]; rowCount: number };
 export type LayoutData = { fileName: string; layout: Layout };

--- a/src/lib/validateRawData.ts
+++ b/src/lib/validateRawData.ts
@@ -12,8 +12,8 @@ export interface Diagnostic {
 
 export type Diagnostics = Diagnostic[];
 
-/** Validate CSV data against layout definition */
-export async function validateCsv(
+/** Validate raw data against layout definition */
+export async function validateRawData(
   conn: duckdb.AsyncDuckDBConnection,
   headers: string[],
   layout: Layout,

--- a/tests/validateRawData.test.ts
+++ b/tests/validateRawData.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { validateCsv, type Diagnostics } from "../src/lib/validateCsv";
+import { validateRawData, type Diagnostics } from "../src/lib/validateRawData";
 import { setupDuckDB, teardownDuckDB, getConn, loadCSV } from "./helpers/duckdb";
 import type { Layout } from "../src/lib/layout";
 
@@ -20,7 +20,7 @@ describe("validateData", () => {
       { type: "SA", key: "q1", label: "Q1", items: [{ code: "1", label: "A" }, { code: "2", label: "B" }] },
       { type: "MA", key: "q3", label: "Q3", items: [{ code: "1", label: "X" }, { code: "2", label: "Y" }] },
     ];
-    const result = await validateCsv(getConn(), ["q1", "q3_1", "q3_2"], layout);
+    const result = await validateRawData(getConn(), ["q1", "q3_1", "q3_2"], layout);
     expect(result).toEqual([]);
   });
 
@@ -31,7 +31,7 @@ describe("validateData", () => {
     const layout: Layout = [
       { type: "SA", key: "q1", label: "Q1", items: [{ code: "1", label: "A" }, { code: "2", label: "B" }] },
     ];
-    const result = await validateCsv(getConn(), ["q1"], layout);
+    const result = await validateRawData(getConn(), ["q1"], layout);
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       type: "unknownCode",
@@ -48,7 +48,7 @@ describe("validateData", () => {
     const layout: Layout = [
       { type: "SA", key: "q1", label: "Q1", items: [{ code: "1", label: "A" }] },
     ];
-    const result = await validateCsv(getConn(), ["other"], layout);
+    const result = await validateRawData(getConn(), ["other"], layout);
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({ type: "dropped", severity: "warn", key: "q1" });
   });
@@ -60,7 +60,7 @@ describe("validateData", () => {
     const layout: Layout = [
       { type: "NA", key: "age", label: "年齢" },
     ];
-    const result = await validateCsv(getConn(), ["other"], layout);
+    const result = await validateRawData(getConn(), ["other"], layout);
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({ type: "dropped", severity: "warn", key: "age" });
   });
@@ -72,7 +72,7 @@ describe("validateData", () => {
     const layout: Layout = [
       { type: "WEIGHT", key: "w", label: "ウェイト" },
     ];
-    const result = await validateCsv(getConn(), ["other"], layout);
+    const result = await validateRawData(getConn(), ["other"], layout);
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({ type: "dropped", severity: "warn", key: "w" });
   });
@@ -84,7 +84,7 @@ describe("validateData", () => {
     const layout: Layout = [
       { type: "DATE", key: "date1", label: "回答日", granularity: "month" },
     ];
-    const result = await validateCsv(getConn(), ["other"], layout);
+    const result = await validateRawData(getConn(), ["other"], layout);
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({ type: "dropped", severity: "warn", key: "date1" });
   });
@@ -96,7 +96,7 @@ describe("validateData", () => {
     const layout: Layout = [
       { type: "MA", key: "q3", label: "Q3", items: [{ code: "1", label: "X" }, { code: "2", label: "Y" }] },
     ];
-    const result = await validateCsv(getConn(), ["other"], layout);
+    const result = await validateRawData(getConn(), ["other"], layout);
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({ type: "dropped", severity: "warn", key: "q3" });
   });
@@ -108,7 +108,7 @@ describe("validateData", () => {
     const layout: Layout = [
       { type: "MA", key: "q3", label: "Q3", items: [{ code: "1", label: "X" }, { code: "2", label: "Y" }] },
     ];
-    const result = await validateCsv(getConn(), ["q3_1", "q3_2"], layout);
+    const result = await validateRawData(getConn(), ["q3_1", "q3_2"], layout);
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       type: "invalidMAValue",
@@ -125,7 +125,7 @@ describe("validateData", () => {
     const layout: Layout = [
       { type: "NA", key: "age", label: "年齢" },
     ];
-    const result = await validateCsv(getConn(), ["age"], layout);
+    const result = await validateRawData(getConn(), ["age"], layout);
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       type: "nonNumeric",
@@ -142,7 +142,7 @@ describe("validateData", () => {
     const layout: Layout = [
       { type: "WEIGHT", key: "w", label: "ウェイト" },
     ];
-    const result = await validateCsv(getConn(), ["w"], layout);
+    const result = await validateRawData(getConn(), ["w"], layout);
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       type: "nonNumeric",
@@ -161,7 +161,7 @@ describe("validateData", () => {
       { type: "MA", key: "q3", label: "Q3", items: [{ code: "1", label: "X" }, { code: "2", label: "Y" }] },
       { type: "NA", key: "missing", label: "欠損NA" },
     ];
-    const result = await validateCsv(getConn(), ["q1", "q3_1"], layout);
+    const result = await validateRawData(getConn(), ["q1", "q3_1"], layout);
 
     const types = result.map((d) => d.type);
     expect(types).toContain("unknownCode"); // q1 has code 9

--- a/tests/validateRawData.test.ts
+++ b/tests/validateRawData.test.ts
@@ -11,7 +11,7 @@ afterAll(async () => {
   await teardownDuckDB();
 });
 
-describe("validateData", () => {
+describe("validateRawData", () => {
   it("全項目正常 → 空配列", async () => {
     const csv = "q1,q3_1,q3_2\n1,0,1\n2,1,0\n";
     await loadCSV(csv);


### PR DESCRIPTION
## Summary
- `csv` はファイル形式にすぎないため、ローデータの概念を指す変数・型・関数名を `rawData` 系にリネーム
- `CsvData` → `RawData`、`csvText` → `rawDataText`、`csvName` → `rawDataName`、`validateCsv` → `validateRawData` 等
- CSVフォーマット処理（`loadCSV`, `formatCSV`, `downloadCSV`, `buildCSV`）やロケールキーはそのまま維持

## Test plan
- [x] `pnpm check` 通過（fmt, lint, tsc）
- [x] `pnpm test` 全1085テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)