### PR TITLE
refactor: remove Diagnostics type alias, use Diagnostic[] directly

### DIFF
--- a/src/components/import/ValidationStep.tsx
+++ b/src/components/import/ValidationStep.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "preact/hooks";
 import { t } from "../../lib/i18n";
 import { runValidation } from "../../lib/duckdb";
-import type { Diagnostics } from "../../lib/validateRawData";
+import type { Diagnostic } from "../../lib/validateRawData";
 import type { RawData, LayoutData } from "../../lib/types";
 
 interface ValidationStepProps {
@@ -12,7 +12,7 @@ interface ValidationStepProps {
 }
 
 export function ValidationStep({ rawData, layout, onProceed, onBack }: ValidationStepProps) {
-  const [diagnostics, setDiagnostics] = useState<Diagnostics | null>(null);
+  const [diagnostics, setDiagnostics] = useState<Diagnostic[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {

--- a/src/lib/duckdb.ts
+++ b/src/lib/duckdb.ts
@@ -3,7 +3,7 @@ import type { Question, Tab } from "./agg/types";
 import type { Layout } from "./layout";
 import { buildTabs } from "./agg/buildTabs";
 import { prepareDateColumns, type DatePreparationResult } from "./datePreparation";
-import { validateRawData, type Diagnostics } from "./validateRawData";
+import { validateRawData, type Diagnostic } from "./validateRawData";
 
 export type DuckStatus = "loading" | "ready" | "error";
 export type StatusListener = (s: DuckStatus, label: string) => void;
@@ -76,7 +76,7 @@ export async function loadCSV(csvText: string): Promise<{ headers: string[]; row
 }
 
 /** Validate CSV data against layout definition */
-export async function runValidation(headers: string[], layout: Layout): Promise<Diagnostics> {
+export async function runValidation(headers: string[], layout: Layout): Promise<Diagnostic[]> {
   const c = await getConnection();
   return validateRawData(c, headers, layout);
 }

--- a/src/lib/validateRawData.ts
+++ b/src/lib/validateRawData.ts
@@ -10,16 +10,14 @@ export interface Diagnostic {
   params: Record<string, string>;
 }
 
-export type Diagnostics = Diagnostic[];
-
 /** Validate raw data against layout definition */
 export async function validateRawData(
   conn: duckdb.AsyncDuckDBConnection,
   headers: string[],
   layout: Layout,
-): Promise<Diagnostics> {
+): Promise<Diagnostic[]> {
   const headerSet = new Set(headers);
-  const diagnostics: Diagnostics = [];
+  const diagnostics: Diagnostic[] = [];
 
   for (const q of layout) {
     const dropped = checkDropped(q, headerSet);

--- a/tests/validateRawData.test.ts
+++ b/tests/validateRawData.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { validateRawData, type Diagnostics } from "../src/lib/validateRawData";
+import { validateRawData, type Diagnostic } from "../src/lib/validateRawData";
 import { setupDuckDB, teardownDuckDB, getConn, loadCSV } from "./helpers/duckdb";
 import type { Layout } from "../src/lib/layout";
 


### PR DESCRIPTION
The alias `type Diagnostics = Diagnostic[]` added no information —
plain `Diagnostic[]` is equally clear and one less export to track.

https://claude.ai/code/session_01GNVB3CwLY6RSh2pmEdwB4V