### PR TITLE
Rename AggOutput to TabCore = Pick<Tab, "codes" | "slices">

### DIFF
--- a/src/lib/agg/aggCrossTab.ts
+++ b/src/lib/agg/aggCrossTab.ts
@@ -1,7 +1,7 @@
 /** Cross-tabulation aggregation — one cross axis at a time */
 
 import type * as duckdb from "@duckdb/duckdb-wasm";
-import type { Shape, TabCore } from "./types";
+import type { Shape, TabData } from "./types";
 import {
   esc,
   weightExpr,
@@ -23,7 +23,7 @@ export async function aggCrossTab(
   shape: Shape,
   axisShape: Shape,
   weightCol: string,
-): Promise<TabCore> {
+): Promise<TabData> {
   const ca = new CrossTabAggregator(conn, weightCol, axisShape);
   const isMainSa = shape.type === "SA";
   const isCrossSa = axisShape.type === "SA";
@@ -43,7 +43,7 @@ class CrossTabAggregator {
 
   // ── SA main × SA cross ──
 
-  async saSA(column: string, codes: string[]): Promise<TabCore> {
+  async saSA(column: string, codes: string[]): Promise<TabData> {
     const crossCol = this.axisShape.columns[0];
     const crossValues = this.axisShape.codes;
     const wExpr = weightExpr(this.weightCol);
@@ -88,7 +88,7 @@ class CrossTabAggregator {
 
   // ── SA main × MA cross ──
 
-  async saMA(column: string, codes: string[]): Promise<TabCore> {
+  async saMA(column: string, codes: string[]): Promise<TabData> {
     const selectClauses = this.axisShape.columns.map(
       (maCol, i) => `${maWeightedCountExpr(maCol, this.weightCol)} AS c${i}`,
     );
@@ -126,7 +126,7 @@ class CrossTabAggregator {
 
   // ── MA main × SA cross ──
 
-  async maSA(columns: string[], codes: string[]): Promise<TabCore> {
+  async maSA(columns: string[], codes: string[]): Promise<TabData> {
     const crossCol = this.axisShape.columns[0];
     const crossValues = this.axisShape.codes;
     const wExpr = weightExpr(this.weightCol);
@@ -176,7 +176,7 @@ class CrossTabAggregator {
 
   // ── shared slice builder ──
 
-  private buildSlices(data: CrossSliceData[], codes: string[]): TabCore {
+  private buildSlices(data: CrossSliceData[], codes: string[]): TabData {
     const slices = data.map(({ code, n, counts }) => ({
       code,
       n,
@@ -190,7 +190,7 @@ class CrossTabAggregator {
 
   // ── MA main × MA cross ──
 
-  async maMA(columns: string[], codes: string[]): Promise<TabCore> {
+  async maMA(columns: string[], codes: string[]): Promise<TabData> {
     const shownCond = maShownCondition(columns);
 
     const selectClauses: string[] = [];

--- a/src/lib/agg/aggCrossTab.ts
+++ b/src/lib/agg/aggCrossTab.ts
@@ -1,7 +1,7 @@
 /** Cross-tabulation aggregation — one cross axis at a time */
 
 import type * as duckdb from "@duckdb/duckdb-wasm";
-import type { Shape, AggOutput } from "./types";
+import type { Shape, TabCore } from "./types";
 import {
   esc,
   weightExpr,
@@ -23,7 +23,7 @@ export async function aggCrossTab(
   shape: Shape,
   axisShape: Shape,
   weightCol: string,
-): Promise<AggOutput> {
+): Promise<TabCore> {
   const ca = new CrossTabAggregator(conn, weightCol, axisShape);
   const isMainSa = shape.type === "SA";
   const isCrossSa = axisShape.type === "SA";
@@ -43,7 +43,7 @@ class CrossTabAggregator {
 
   // ── SA main × SA cross ──
 
-  async saSA(column: string, codes: string[]): Promise<AggOutput> {
+  async saSA(column: string, codes: string[]): Promise<TabCore> {
     const crossCol = this.axisShape.columns[0];
     const crossValues = this.axisShape.codes;
     const wExpr = weightExpr(this.weightCol);
@@ -88,7 +88,7 @@ class CrossTabAggregator {
 
   // ── SA main × MA cross ──
 
-  async saMA(column: string, codes: string[]): Promise<AggOutput> {
+  async saMA(column: string, codes: string[]): Promise<TabCore> {
     const selectClauses = this.axisShape.columns.map(
       (maCol, i) => `${maWeightedCountExpr(maCol, this.weightCol)} AS c${i}`,
     );
@@ -126,7 +126,7 @@ class CrossTabAggregator {
 
   // ── MA main × SA cross ──
 
-  async maSA(columns: string[], codes: string[]): Promise<AggOutput> {
+  async maSA(columns: string[], codes: string[]): Promise<TabCore> {
     const crossCol = this.axisShape.columns[0];
     const crossValues = this.axisShape.codes;
     const wExpr = weightExpr(this.weightCol);
@@ -176,7 +176,7 @@ class CrossTabAggregator {
 
   // ── shared slice builder ──
 
-  private buildSlices(data: CrossSliceData[], codes: string[]): AggOutput {
+  private buildSlices(data: CrossSliceData[], codes: string[]): TabCore {
     const slices = data.map(({ code, n, counts }) => ({
       code,
       n,
@@ -190,7 +190,7 @@ class CrossTabAggregator {
 
   // ── MA main × MA cross ──
 
-  async maMA(columns: string[], codes: string[]): Promise<AggOutput> {
+  async maMA(columns: string[], codes: string[]): Promise<TabCore> {
     const shownCond = maShownCondition(columns);
 
     const selectClauses: string[] = [];

--- a/src/lib/agg/aggNa.ts
+++ b/src/lib/agg/aggNa.ts
@@ -1,7 +1,7 @@
 /** NA (Numerical Answer) aggregation — Tab and Cross */
 
 import type * as duckdb from "@duckdb/duckdb-wasm";
-import type { Shape, TabCore, NaStats, Slice } from "./types";
+import type { Shape, TabData, NaStats, Slice } from "./types";
 import { esc, maShownCondition } from "./sqlHelpers";
 
 interface ValueCount {
@@ -15,7 +15,7 @@ export async function aggNaTab(
   conn: duckdb.AsyncDuckDBConnection,
   column: string,
   weightCol: string,
-): Promise<TabCore> {
+): Promise<TabData> {
   const valExpr = `CAST("${esc(column)}" AS DOUBLE)`;
   const whereCond = `"${esc(column)}" IS NOT NULL AND TRY_CAST("${esc(column)}" AS DOUBLE) IS NOT NULL`;
 
@@ -33,7 +33,7 @@ export async function aggNaCrossTab(
   naColumn: string,
   axisShape: Shape,
   weightCol: string,
-): Promise<TabCore> {
+): Promise<TabData> {
   if (axisShape.type === "SA") {
     return naCrossSA(conn, naColumn, axisShape.columns[0], axisShape.codes, weightCol);
   }
@@ -240,7 +240,7 @@ async function naCrossSA(
   crossCol: string,
   crossCodes: string[],
   weightCol: string,
-): Promise<TabCore> {
+): Promise<TabData> {
   const valExpr = `CAST("${esc(naColumn)}" AS DOUBLE)`;
   const whereCond = `"${esc(naColumn)}" IS NOT NULL AND TRY_CAST("${esc(naColumn)}" AS DOUBLE) IS NOT NULL`;
 
@@ -265,7 +265,7 @@ async function naCrossMA(
   maCols: string[],
   maCodes: string[],
   weightCol: string,
-): Promise<TabCore> {
+): Promise<TabData> {
   const valExpr = `CAST("${esc(naColumn)}" AS DOUBLE)`;
   const baseWhere = `"${esc(naColumn)}" IS NOT NULL AND TRY_CAST("${esc(naColumn)}" AS DOUBLE) IS NOT NULL AND (${maShownCondition(maCols)})`;
 

--- a/src/lib/agg/aggNa.ts
+++ b/src/lib/agg/aggNa.ts
@@ -1,7 +1,7 @@
 /** NA (Numerical Answer) aggregation — Tab and Cross */
 
 import type * as duckdb from "@duckdb/duckdb-wasm";
-import type { Shape, AggOutput, NaStats, Slice } from "./types";
+import type { Shape, TabCore, NaStats, Slice } from "./types";
 import { esc, maShownCondition } from "./sqlHelpers";
 
 interface ValueCount {
@@ -15,7 +15,7 @@ export async function aggNaTab(
   conn: duckdb.AsyncDuckDBConnection,
   column: string,
   weightCol: string,
-): Promise<AggOutput> {
+): Promise<TabCore> {
   const valExpr = `CAST("${esc(column)}" AS DOUBLE)`;
   const whereCond = `"${esc(column)}" IS NOT NULL AND TRY_CAST("${esc(column)}" AS DOUBLE) IS NOT NULL`;
 
@@ -33,7 +33,7 @@ export async function aggNaCrossTab(
   naColumn: string,
   axisShape: Shape,
   weightCol: string,
-): Promise<AggOutput> {
+): Promise<TabCore> {
   if (axisShape.type === "SA") {
     return naCrossSA(conn, naColumn, axisShape.columns[0], axisShape.codes, weightCol);
   }
@@ -240,7 +240,7 @@ async function naCrossSA(
   crossCol: string,
   crossCodes: string[],
   weightCol: string,
-): Promise<AggOutput> {
+): Promise<TabCore> {
   const valExpr = `CAST("${esc(naColumn)}" AS DOUBLE)`;
   const whereCond = `"${esc(naColumn)}" IS NOT NULL AND TRY_CAST("${esc(naColumn)}" AS DOUBLE) IS NOT NULL`;
 
@@ -265,7 +265,7 @@ async function naCrossMA(
   maCols: string[],
   maCodes: string[],
   weightCol: string,
-): Promise<AggOutput> {
+): Promise<TabCore> {
   const valExpr = `CAST("${esc(naColumn)}" AS DOUBLE)`;
   const baseWhere = `"${esc(naColumn)}" IS NOT NULL AND TRY_CAST("${esc(naColumn)}" AS DOUBLE) IS NOT NULL AND (${maShownCondition(maCols)})`;
 

--- a/src/lib/agg/aggTab.ts
+++ b/src/lib/agg/aggTab.ts
@@ -1,7 +1,7 @@
 /** Tab (single tabulation) aggregation — SA and MA */
 
 import type * as duckdb from "@duckdb/duckdb-wasm";
-import type { Shape, AggOutput } from "./types";
+import type { Shape, TabCore } from "./types";
 import {
   esc,
   weightExpr,
@@ -16,7 +16,7 @@ export async function aggTab(
   conn: duckdb.AsyncDuckDBConnection,
   shape: Shape,
   weightCol: string,
-): Promise<AggOutput> {
+): Promise<TabCore> {
   const agg = new TabAggregator(conn, weightCol);
   return shape.type === "SA"
     ? agg.aggregateSA(shape.columns[0], shape.codes)
@@ -29,7 +29,7 @@ class TabAggregator {
     private weightCol: string,
   ) {}
 
-  async aggregateSA(column: string, codes: string[]): Promise<AggOutput> {
+  async aggregateSA(column: string, codes: string[]): Promise<TabCore> {
     const wExpr = weightExpr(this.weightCol);
     const sql = `
       SELECT
@@ -55,7 +55,7 @@ class TabAggregator {
     return { codes, slices: [{ code: null, n, cells }] };
   }
 
-  async aggregateMA(columns: string[], codes: string[]): Promise<AggOutput> {
+  async aggregateMA(columns: string[], codes: string[]): Promise<TabCore> {
     const selectClauses = columns.map((col, i) => {
       return `${maWeightedCountExpr(col, this.weightCol)} AS c${i}`;
     });

--- a/src/lib/agg/aggTab.ts
+++ b/src/lib/agg/aggTab.ts
@@ -1,7 +1,7 @@
 /** Tab (single tabulation) aggregation — SA and MA */
 
 import type * as duckdb from "@duckdb/duckdb-wasm";
-import type { Shape, TabCore } from "./types";
+import type { Shape, TabData } from "./types";
 import {
   esc,
   weightExpr,
@@ -16,7 +16,7 @@ export async function aggTab(
   conn: duckdb.AsyncDuckDBConnection,
   shape: Shape,
   weightCol: string,
-): Promise<TabCore> {
+): Promise<TabData> {
   const agg = new TabAggregator(conn, weightCol);
   return shape.type === "SA"
     ? agg.aggregateSA(shape.columns[0], shape.codes)
@@ -29,7 +29,7 @@ class TabAggregator {
     private weightCol: string,
   ) {}
 
-  async aggregateSA(column: string, codes: string[]): Promise<TabCore> {
+  async aggregateSA(column: string, codes: string[]): Promise<TabData> {
     const wExpr = weightExpr(this.weightCol);
     const sql = `
       SELECT
@@ -55,7 +55,7 @@ class TabAggregator {
     return { codes, slices: [{ code: null, n, cells }] };
   }
 
-  async aggregateMA(columns: string[], codes: string[]): Promise<TabCore> {
+  async aggregateMA(columns: string[], codes: string[]): Promise<TabData> {
     const selectClauses = columns.map((col, i) => {
       return `${maWeightedCountExpr(col, this.weightCol)} AS c${i}`;
     });

--- a/src/lib/agg/buildTabs.ts
+++ b/src/lib/agg/buildTabs.ts
@@ -1,5 +1,5 @@
 import type * as duckdb from "@duckdb/duckdb-wasm";
-import type { Question, AggOutput, Axis, Tab } from "./types";
+import type { Question, TabCore, Axis, Tab } from "./types";
 import { aggTab } from "./aggTab";
 import { aggCrossTab } from "./aggCrossTab";
 import { aggNaTab, aggNaCrossTab } from "./aggNa";
@@ -33,17 +33,17 @@ export async function buildTabs(
   return tabs;
 }
 
-function toTab(question: Question, aggOutput: AggOutput, axisQuestion?: Question): Tab {
+function toTab(question: Question, tabCore: TabCore, axisQuestion?: Question): Tab {
   const labels: Record<string, string> = { ...question.labels };
 
   if (question.type === "NA") {
     // NA: self-labeling (value string as label)
-    for (const code of aggOutput.codes) {
+    for (const code of tabCore.codes) {
       labels[code] = code;
     }
   }
 
-  if (aggOutput.codes.includes(NO_ANSWER_VALUE)) {
+  if (tabCore.codes.includes(NO_ANSWER_VALUE)) {
     labels[NO_ANSWER_VALUE] = t("label.noAnswer");
   }
 
@@ -52,15 +52,15 @@ function toTab(question: Question, aggOutput: AggOutput, axisQuestion?: Question
     type: question.type,
     label: question.label,
     labels,
-    codes: aggOutput.codes,
-    by: axisQuestion ? buildAxis(aggOutput, axisQuestion) : null,
-    slices: aggOutput.slices,
+    codes: tabCore.codes,
+    by: axisQuestion ? buildAxis(tabCore, axisQuestion) : null,
+    slices: tabCore.slices,
   };
 }
 
-function buildAxis(aggOutput: AggOutput, axisQuestion: Question): Axis {
+function buildAxis(tabCore: TabCore, axisQuestion: Question): Axis {
   const axisLabels: Record<string, string> = { ...axisQuestion.labels };
-  const hasNoAnswer = aggOutput.slices.some((s) => s.code === NO_ANSWER_VALUE);
+  const hasNoAnswer = tabCore.slices.some((s) => s.code === NO_ANSWER_VALUE);
   if (hasNoAnswer) {
     axisLabels[NO_ANSWER_VALUE] = t("label.noAnswer");
   }

--- a/src/lib/agg/buildTabs.ts
+++ b/src/lib/agg/buildTabs.ts
@@ -1,5 +1,5 @@
 import type * as duckdb from "@duckdb/duckdb-wasm";
-import type { Question, TabCore, Axis, Tab } from "./types";
+import type { Question, TabData, Axis, Tab } from "./types";
 import { aggTab } from "./aggTab";
 import { aggCrossTab } from "./aggCrossTab";
 import { aggNaTab, aggNaCrossTab } from "./aggNa";
@@ -33,17 +33,17 @@ export async function buildTabs(
   return tabs;
 }
 
-function toTab(question: Question, tabCore: TabCore, axisQuestion?: Question): Tab {
+function toTab(question: Question, tabData: TabData, axisQuestion?: Question): Tab {
   const labels: Record<string, string> = { ...question.labels };
 
   if (question.type === "NA") {
     // NA: self-labeling (value string as label)
-    for (const code of tabCore.codes) {
+    for (const code of tabData.codes) {
       labels[code] = code;
     }
   }
 
-  if (tabCore.codes.includes(NO_ANSWER_VALUE)) {
+  if (tabData.codes.includes(NO_ANSWER_VALUE)) {
     labels[NO_ANSWER_VALUE] = t("label.noAnswer");
   }
 
@@ -52,15 +52,15 @@ function toTab(question: Question, tabCore: TabCore, axisQuestion?: Question): T
     type: question.type,
     label: question.label,
     labels,
-    codes: tabCore.codes,
-    by: axisQuestion ? buildAxis(tabCore, axisQuestion) : null,
-    slices: tabCore.slices,
+    codes: tabData.codes,
+    by: axisQuestion ? buildAxis(tabData, axisQuestion) : null,
+    slices: tabData.slices,
   };
 }
 
-function buildAxis(tabCore: TabCore, axisQuestion: Question): Axis {
+function buildAxis(tabData: TabData, axisQuestion: Question): Axis {
   const axisLabels: Record<string, string> = { ...axisQuestion.labels };
-  const hasNoAnswer = tabCore.slices.some((s) => s.code === NO_ANSWER_VALUE);
+  const hasNoAnswer = tabData.slices.some((s) => s.code === NO_ANSWER_VALUE);
   if (hasNoAnswer) {
     axisLabels[NO_ANSWER_VALUE] = t("label.noAnswer");
   }

--- a/src/lib/agg/types.ts
+++ b/src/lib/agg/types.ts
@@ -28,7 +28,7 @@ export interface Slice {
 }
 
 /** aggregate() の戻り値 — rawdata 由来のみ */
-export type TabCore = Pick<Tab, "codes" | "slices">;
+export type TabData = Pick<Tab, "codes" | "slices">;
 
 export interface NaStats {
   n: number;

--- a/src/lib/agg/types.ts
+++ b/src/lib/agg/types.ts
@@ -28,10 +28,7 @@ export interface Slice {
 }
 
 /** aggregate() の戻り値 — rawdata 由来のみ */
-export interface AggOutput {
-  codes: string[];
-  slices: Slice[];
-}
+export type TabCore = Pick<Tab, "codes" | "slices">;
 
 export interface NaStats {
   n: number;

--- a/tests/helpers/invariants.ts
+++ b/tests/helpers/invariants.ts
@@ -1,8 +1,8 @@
 import { expect } from "vitest";
-import type { AggOutput } from "../../src/lib/agg/types";
+import type { TabCore } from "../../src/lib/agg/types";
 
 export function assertTabInvariants(
-  result: AggOutput,
+  result: TabCore,
   type: "SA" | "MA",
 ): void {
   expect(result.slices).toHaveLength(1);
@@ -33,7 +33,7 @@ export function assertTabInvariants(
   }
 }
 
-export function assertNaTabInvariants(result: AggOutput): void {
+export function assertNaTabInvariants(result: TabCore): void {
   // 1. Single slice with code === null
   expect(result.slices).toHaveLength(1);
   const slice = result.slices[0];
@@ -89,7 +89,7 @@ export function assertNaTabInvariants(result: AggOutput): void {
 }
 
 export function assertCrossInvariants(
-  result: AggOutput,
+  result: TabCore,
   type: "SA" | "MA",
   expectedSliceCount: number,
 ): void {

--- a/tests/helpers/invariants.ts
+++ b/tests/helpers/invariants.ts
@@ -1,8 +1,8 @@
 import { expect } from "vitest";
-import type { TabCore } from "../../src/lib/agg/types";
+import type { TabData } from "../../src/lib/agg/types";
 
 export function assertTabInvariants(
-  result: TabCore,
+  result: TabData,
   type: "SA" | "MA",
 ): void {
   expect(result.slices).toHaveLength(1);
@@ -33,7 +33,7 @@ export function assertTabInvariants(
   }
 }
 
-export function assertNaTabInvariants(result: TabCore): void {
+export function assertNaTabInvariants(result: TabData): void {
   // 1. Single slice with code === null
   expect(result.slices).toHaveLength(1);
   const slice = result.slices[0];
@@ -89,7 +89,7 @@ export function assertNaTabInvariants(result: TabCore): void {
 }
 
 export function assertCrossInvariants(
-  result: TabCore,
+  result: TabData,
   type: "SA" | "MA",
   expectedSliceCount: number,
 ): void {

--- a/tests/helpers/oracle.ts
+++ b/tests/helpers/oracle.ts
@@ -1,11 +1,11 @@
 /**
  * Oracle (reference) implementations for aggregation.
  * These are intentionally independent of src/lib/agg/ — no imports from production code
- * except AggOutput (used only in the assertion signature).
+ * except TabCore (used only in the assertion signature).
  */
 
 import { expect } from "vitest";
-import type { AggOutput } from "../../src/lib/agg/types";
+import type { TabCore } from "../../src/lib/agg/types";
 
 // ── Local types ──
 
@@ -115,7 +115,7 @@ export function oracleSaSaCross(
 }
 
 export function assertOracleMatch(
-  actual: AggOutput,
+  actual: TabCore,
   expected: OracleOutput,
 ): void {
   expect(actual.codes).toEqual(expected.codes);

--- a/tests/helpers/oracle.ts
+++ b/tests/helpers/oracle.ts
@@ -1,11 +1,11 @@
 /**
  * Oracle (reference) implementations for aggregation.
  * These are intentionally independent of src/lib/agg/ — no imports from production code
- * except TabCore (used only in the assertion signature).
+ * except TabData (used only in the assertion signature).
  */
 
 import { expect } from "vitest";
-import type { TabCore } from "../../src/lib/agg/types";
+import type { TabData } from "../../src/lib/agg/types";
 
 // ── Local types ──
 
@@ -115,7 +115,7 @@ export function oracleSaSaCross(
 }
 
 export function assertOracleMatch(
-  actual: TabCore,
+  actual: TabData,
   expected: OracleOutput,
 ): void {
   expect(actual.codes).toEqual(expected.codes);


### PR DESCRIPTION
Clarifies that the aggregation return type is the core subset of Tab,
making the relationship between TabCore and Tab explicit at the type level.
