### PR TITLE
refactor: replace namespace type imports with named imports for duckdb

### DIFF
--- a/src/lib/agg/aggCrossTab.ts
+++ b/src/lib/agg/aggCrossTab.ts
@@ -1,6 +1,6 @@
 /** Cross-tabulation aggregation — one cross axis at a time */
 
-import type * as duckdb from "@duckdb/duckdb-wasm";
+import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
 import type { Shape, TabData } from "./types";
 import {
   esc,
@@ -19,7 +19,7 @@ type CrossSliceData = {
 };
 
 export async function aggCrossTab(
-  conn: duckdb.AsyncDuckDBConnection,
+  conn: AsyncDuckDBConnection,
   shape: Shape,
   axisShape: Shape,
   weightCol: string,
@@ -36,7 +36,7 @@ export async function aggCrossTab(
 
 class CrossTabAggregator {
   constructor(
-    private conn: duckdb.AsyncDuckDBConnection,
+    private conn: AsyncDuckDBConnection,
     private weightCol: string,
     private axisShape: Shape,
   ) {}

--- a/src/lib/agg/aggNa.ts
+++ b/src/lib/agg/aggNa.ts
@@ -1,6 +1,6 @@
 /** NA (Numerical Answer) aggregation — Tab and Cross */
 
-import type * as duckdb from "@duckdb/duckdb-wasm";
+import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
 import type { Shape, TabData, NaStats, Slice } from "./types";
 import { esc, maShownCondition } from "./sqlHelpers";
 
@@ -12,7 +12,7 @@ interface ValueCount {
 // ── Tab ──
 
 export async function aggNaTab(
-  conn: duckdb.AsyncDuckDBConnection,
+  conn: AsyncDuckDBConnection,
   column: string,
   weightCol: string,
 ): Promise<TabData> {
@@ -29,7 +29,7 @@ export async function aggNaTab(
 // ── Cross (NA × SA or NA × MA) ──
 
 export async function aggNaCrossTab(
-  conn: duckdb.AsyncDuckDBConnection,
+  conn: AsyncDuckDBConnection,
   naColumn: string,
   axisShape: Shape,
   weightCol: string,
@@ -81,7 +81,7 @@ function alignSlices(sliceData: { code: string; freq: ValueCount[]; stats: NaSta
 // ── Internal ──
 
 async function queryStats(
-  conn: duckdb.AsyncDuckDBConnection,
+  conn: AsyncDuckDBConnection,
   valExpr: string,
   whereCond: string,
   weightCol: string,
@@ -126,7 +126,7 @@ async function queryStats(
 }
 
 async function queryStatsGrouped(
-  conn: duckdb.AsyncDuckDBConnection,
+  conn: AsyncDuckDBConnection,
   valExpr: string,
   whereCond: string,
   weightCol: string,
@@ -172,7 +172,7 @@ async function queryStatsGrouped(
 }
 
 async function queryFreq(
-  conn: duckdb.AsyncDuckDBConnection,
+  conn: AsyncDuckDBConnection,
   valExpr: string,
   whereCond: string,
   weightCol: string,
@@ -193,7 +193,7 @@ async function queryFreq(
 }
 
 async function queryFreqGrouped(
-  conn: duckdb.AsyncDuckDBConnection,
+  conn: AsyncDuckDBConnection,
   valExpr: string,
   whereCond: string,
   weightCol: string,
@@ -235,7 +235,7 @@ function toStats(row: Record<string, unknown>): NaStats {
 // ── NA × SA cross ──
 
 async function naCrossSA(
-  conn: duckdb.AsyncDuckDBConnection,
+  conn: AsyncDuckDBConnection,
   naColumn: string,
   crossCol: string,
   crossCodes: string[],
@@ -260,7 +260,7 @@ async function naCrossSA(
 // ── NA × MA cross ──
 
 async function naCrossMA(
-  conn: duckdb.AsyncDuckDBConnection,
+  conn: AsyncDuckDBConnection,
   naColumn: string,
   maCols: string[],
   maCodes: string[],

--- a/src/lib/agg/aggTab.ts
+++ b/src/lib/agg/aggTab.ts
@@ -1,6 +1,6 @@
 /** Tab (single tabulation) aggregation — SA and MA */
 
-import type * as duckdb from "@duckdb/duckdb-wasm";
+import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
 import type { Shape, TabData } from "./types";
 import {
   esc,
@@ -13,7 +13,7 @@ import {
 import { NO_ANSWER_VALUE } from "./constants";
 
 export async function aggTab(
-  conn: duckdb.AsyncDuckDBConnection,
+  conn: AsyncDuckDBConnection,
   shape: Shape,
   weightCol: string,
 ): Promise<TabData> {
@@ -25,7 +25,7 @@ export async function aggTab(
 
 class TabAggregator {
   constructor(
-    private conn: duckdb.AsyncDuckDBConnection,
+    private conn: AsyncDuckDBConnection,
     private weightCol: string,
   ) {}
 

--- a/src/lib/agg/buildTabs.ts
+++ b/src/lib/agg/buildTabs.ts
@@ -1,4 +1,4 @@
-import type * as duckdb from "@duckdb/duckdb-wasm";
+import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
 import type { Question, TabData, Axis, Tab } from "./types";
 import { aggTab } from "./aggTab";
 import { aggCrossTab } from "./aggCrossTab";
@@ -7,7 +7,7 @@ import { NO_ANSWER_VALUE } from "./constants";
 import { t } from "../i18n";
 
 export async function buildTabs(
-  conn: duckdb.AsyncDuckDBConnection,
+  conn: AsyncDuckDBConnection,
   questions: Question[],
   crossQuestions: Question[],
   weightCol: string,

--- a/src/lib/validateRawData.ts
+++ b/src/lib/validateRawData.ts
@@ -1,4 +1,4 @@
-import type * as duckdb from "@duckdb/duckdb-wasm";
+import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
 import type { Layout, LayoutQuestion } from "./layout";
 import { esc } from "./agg/sqlHelpers";
 
@@ -12,7 +12,7 @@ export interface Diagnostic {
 
 /** Validate raw data against layout definition */
 export async function validateRawData(
-  conn: duckdb.AsyncDuckDBConnection,
+  conn: AsyncDuckDBConnection,
   headers: string[],
   layout: Layout,
 ): Promise<Diagnostic[]> {
@@ -72,7 +72,7 @@ function checkDropped(q: LayoutQuestion, headerSet: Set<string>): Diagnostic | n
 }
 
 async function checkSAUnknownCodes(
-  conn: duckdb.AsyncDuckDBConnection,
+  conn: AsyncDuckDBConnection,
   q: Extract<LayoutQuestion, { type: "SA" }>,
   headerSet: Set<string>,
 ): Promise<Diagnostic | null> {
@@ -104,7 +104,7 @@ async function checkSAUnknownCodes(
 }
 
 async function checkMAValues(
-  conn: duckdb.AsyncDuckDBConnection,
+  conn: AsyncDuckDBConnection,
   q: Extract<LayoutQuestion, { type: "MA" }>,
   headerSet: Set<string>,
 ): Promise<Diagnostic | null> {
@@ -135,7 +135,7 @@ async function checkMAValues(
 }
 
 async function checkMAAllNull(
-  conn: duckdb.AsyncDuckDBConnection,
+  conn: AsyncDuckDBConnection,
   q: Extract<LayoutQuestion, { type: "MA" }>,
   headerSet: Set<string>,
 ): Promise<Diagnostic | null> {
@@ -162,7 +162,7 @@ async function checkMAAllNull(
 }
 
 async function checkNumeric(
-  conn: duckdb.AsyncDuckDBConnection,
+  conn: AsyncDuckDBConnection,
   q: Extract<LayoutQuestion, { type: "NA" }> | Extract<LayoutQuestion, { type: "WEIGHT" }>,
 ): Promise<Diagnostic | null> {
   const result = await conn.query(


### PR DESCRIPTION
Change `import type * as duckdb` to `import type { AsyncDuckDBConnection }`
since AsyncDuckDBConnection is the only type