### PR TITLE
Rename toTab to assembleTab and extract buildLabels

### DIFF
--- a/src/lib/agg/buildTabs.ts
+++ b/src/lib/agg/buildTabs.ts
@@ -14,13 +14,13 @@ export async function buildTabs(
 ): Promise<Tab[]> {
   const tabs: Tab[] = [];
   for (const q of questions) {
-    const qTabs = await buildTab(conn, q, crossQuestions, weightCol);
+    const qTabs = await buildTabsFor(conn, q, crossQuestions, weightCol);
     tabs.push(...qTabs);
   }
   return tabs;
 }
 
-async function buildTab(
+async function buildTabsFor(
   conn: AsyncDuckDBConnection,
   q: Question,
   crossQuestions: Question[],


### PR DESCRIPTION
- toTab → assembleTab: better reflects assembling a Tab from multiple parts
- Extract label construction logic into buildLabels for separation of concerns

https://claude.ai/code/session_01D2pgpF9Q78i8fx71DTx2hS