### PR TITLE
refactor: encapsulate chart palette config behind getter functions

### DIFF
--- a/src/components/aggregation/Toolbar.tsx
+++ b/src/components/aggregation/Toolbar.tsx
@@ -1,6 +1,6 @@
 import type { Tab } from "../../lib/agg/types";
 import { t } from "../../lib/i18n";
-import { PALETTE_BASES, PALETTE_IDS, type PaletteId } from "../../lib/chartConfig";
+import { getPaletteBase, getPaletteIds, type PaletteId } from "../../lib/chartConfig";
 import { ToggleButton, ToggleGroup } from "../shared/ToggleButton";
 import { ExportMenu } from "./ExportMenu";
 import { executeExport, type ExportAction } from "../../lib/export/export";
@@ -130,9 +130,9 @@ function PaletteSelector({
   return (
     <div class="flex items-center gap-1.5" role="radiogroup" aria-label={t("chart.palette")}>
       <span class="mr-0.5 text-muted">{t("chart.palette")}:</span>
-      {PALETTE_IDS.map((id) => {
+      {getPaletteIds().map((id) => {
         const isActive = id === current;
-        const base = id === "default" ? undefined : PALETTE_BASES[id];
+        const base = getPaletteBase(id);
         return (
           <button
             key={id}

--- a/src/lib/chartConfig.ts
+++ b/src/lib/chartConfig.ts
@@ -90,7 +90,7 @@ const COLORBREWER_PALETTES: Record<Exclude<PaletteId, "default">, string[]> = {
 };
 
 /** Representative base color for each palette (used for UI swatch) */
-export const PALETTE_BASES: Record<Exclude<PaletteId, "default">, string> = {
+const PALETTE_BASES: Record<Exclude<PaletteId, "default">, string> = {
   blue: "#2171b5",
   green: "#238b45",
   orange: "#d94801",
@@ -98,7 +98,16 @@ export const PALETTE_BASES: Record<Exclude<PaletteId, "default">, string> = {
   purple: "#6a51a3",
 };
 
-export const PALETTE_IDS: PaletteId[] = ["default", "red", "orange", "green", "blue", "purple"];
+const PALETTE_IDS: PaletteId[] = ["default", "red", "orange", "green", "blue", "purple"];
+
+export function getPaletteIds(): PaletteId[] {
+  return PALETTE_IDS;
+}
+
+export function getPaletteBase(id: PaletteId): string | undefined {
+  if (id === "default") return undefined;
+  return PALETTE_BASES[id];
+}
 
 export function getSeriesColor(index: number, paletteId: PaletteId = "default"): string {
   if (paletteId === "default") {


### PR DESCRIPTION
Replace exported PALETTE_BASES/PALETTE_IDS constants with getPaletteBase() and getPaletteIds() functions to hide internal data structures.