### PR TITLE
fix: add missing label to WEIGHT entry in sample layout

### DIFF
--- a/public/samples/sample_layout.json
+++ b/public/samples/sample_layout.json
@@ -1,6 +1,7 @@
 [
   {
     "key": "weight",
+    "label": "ウェイト",
     "type": "WEIGHT"
   },
   {


### PR DESCRIPTION
## Summary
- サンプルレイアウトファイルのWEIGHTエントリに必須の `label` フィールドが欠けていたため、インポート時にバリデーションエラーが発生していた
- `"label": "ウェイト"` を追加して修正

## Test plan
- [x] サンプルデータのインポートでバリデーションエラーが出ないことを確認
- [x] `vp test run` 全テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)