### PR TITLE
feat: connect shared code to apps/desktop (issue #216 Step 5)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@aggy/lib": "workspace:*",
     "@aggy/ui": "workspace:*",
+    "@duckdb/duckdb-wasm": "^1.33.1-dev18.0",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2",
     "@tauri-apps/plugin-fs": "^2",

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -1,14 +1,55 @@
 <script lang="ts">
   import "./tailwind.css";
-  import { initTheme } from "@aggy/ui";
   import { onMount } from "svelte";
+  import { initTheme } from "@aggy/ui";
+  import { initDuckDB } from "./lib/duckdb";
+  import Header from "./components/Header.svelte";
+  import ImportScreen from "./components/ImportScreen.svelte";
+  import AggregationScreen from "./components/AggregationScreen.svelte";
+  import type { Layout, RawData, LayoutData } from "@aggy/lib";
+
+  let screen = $state<"import" | "aggregation">("import");
+  let loadedData = $state<{
+    rawData: RawData;
+    layout: LayoutData;
+    preparedLayout: Layout;
+    dateWarnings: string[];
+  } | null>(null);
+
+  let isImport = $derived(screen === "import");
+
+  function handleComplete(
+    rawData: RawData,
+    layout: LayoutData,
+    dateWarnings: string[],
+    preparedLayout: Layout,
+  ) {
+    loadedData = { rawData, layout, preparedLayout, dateWarnings };
+    screen = "aggregation";
+  }
 
   onMount(() => {
     initTheme();
+    initDuckDB().catch(() => {});
   });
 </script>
 
-<div class="flex h-screen flex-col items-center justify-center gap-4 bg-bg text-text">
-  <h1 class="text-3xl font-bold">Aggy</h1>
-  <p class="text-muted">Desktop app scaffold — Step 5 で集計機能を接続します</p>
+<div class="flex h-screen flex-col overflow-hidden">
+  <Header {isImport} onBack={() => (screen = "import")} />
+
+  <main
+    class="grid min-h-0 flex-1 grid-rows-1"
+    style:grid-template-columns={isImport ? "1fr" : "360px 1fr"}
+  >
+    {#if isImport}
+      <ImportScreen onComplete={handleComplete} />
+    {:else if loadedData}
+      <AggregationScreen
+        rawData={loadedData.rawData}
+        layout={loadedData.layout}
+        preparedLayout={loadedData.preparedLayout}
+        dateWarnings={loadedData.dateWarnings}
+      />
+    {/if}
+  </main>
 </div>

--- a/apps/desktop/src/components/AggregationScreen.svelte
+++ b/apps/desktop/src/components/AggregationScreen.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import type { Tab, Layout, RawData, LayoutData } from "@aggy/lib";
+  import { buildQuestions, findWeightColumn } from "@aggy/lib";
+  import { ResultPanel, SettingsPanel, t } from "@aggy/ui";
+  import { runAggregation } from "../lib/duckdb";
+
+  interface Props {
+    rawData: RawData;
+    layout: LayoutData;
+    preparedLayout: Layout;
+    dateWarnings: string[];
+  }
+
+  let { rawData, layout, preparedLayout, dateWarnings }: Props = $props();
+
+  let questions = $derived(buildQuestions(preparedLayout));
+  let weightCol = $derived(findWeightColumn(preparedLayout));
+
+  let crossSelected = $state<Record<string, boolean>>({});
+  let weightEnabled = $state(true);
+  let errorMsg = $state("");
+  let aggResult = $state<{ tabs: Tab[]; weightCol: string } | null>(null);
+
+  $effect(() => {
+    const sel: Record<string, boolean> = {};
+    for (const q of questions) sel[q.code] = false;
+    crossSelected = sel;
+  });
+
+  async function handleRunAggregation(): Promise<void> {
+    errorMsg = "";
+    const activeWeightCol = weightEnabled ? weightCol : "";
+    const crossQuestions = questions.filter((q) => crossSelected[q.code]);
+
+    try {
+      const tabs = await runAggregation(questions, crossQuestions, activeWeightCol);
+      aggResult = { tabs, weightCol: activeWeightCol };
+    } catch (e) {
+      errorMsg = t("error.aggregation", { msg: (e as Error).message });
+    }
+  }
+
+  onMount(() => {
+    void handleRunAggregation();
+  });
+</script>
+
+<SettingsPanel
+  {rawData}
+  {layout}
+  {preparedLayout}
+  {questions}
+  {crossSelected}
+  onCrossToggle={(key, checked) => (crossSelected = { ...crossSelected, [key]: checked })}
+  {weightCol}
+  {weightEnabled}
+  onWeightToggle={(on) => (weightEnabled = on)}
+  {dateWarnings}
+  {errorMsg}
+  onRun={() => handleRunAggregation()}
+/>
+
+<ResultPanel tabs={aggResult?.tabs ?? null} weightCol={aggResult?.weightCol ?? ""} />

--- a/apps/desktop/src/components/Header.svelte
+++ b/apps/desktop/src/components/Header.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import { t, SettingsModal, IconButton, ChangelogButton } from "@aggy/ui";
+  import WasmStatus from "./header/WasmStatus.svelte";
+
+  interface Props {
+    isImport: boolean;
+    onBack: () => void;
+  }
+
+  let { isImport, onBack }: Props = $props();
+</script>
+
+<header class="flex items-center gap-4 border-b border-border bg-surface px-6 py-4">
+  {#if !isImport}
+    <IconButton size="md" label={t("header.back")} onclick={onBack}>
+      &larr;
+    </IconButton>
+  {/if}
+  <h1 class="text-lg font-bold text-text">Aggy</h1>
+  <span class="text-xs tracking-widest text-muted">{t("header.subtitle")}</span>
+  <div class="relative ml-auto flex items-center gap-3">
+    <WasmStatus />
+    <ChangelogButton />
+    <SettingsModal />
+  </div>
+</header>

--- a/apps/desktop/src/components/ImportScreen.svelte
+++ b/apps/desktop/src/components/ImportScreen.svelte
@@ -1,0 +1,195 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { parseLayoutJson, buildValidLayout, filterLayout } from "@aggy/lib";
+  import type { RawData, LayoutData, Layout, Diagnostic } from "@aggy/lib";
+  import { loadCSV, prepareDateLayout, runValidation } from "../lib/duckdb";
+  import { t, ValidationStep, Button, SectionTitle, Alert, GettingStarted } from "@aggy/ui";
+  import FileUploadPanel from "./import/FileUploadPanel.svelte";
+
+  interface Props {
+    onComplete: (
+      rawData: RawData,
+      layout: LayoutData,
+      dateWarnings: string[],
+      preparedLayout: Layout,
+    ) => void;
+  }
+
+  let { onComplete }: Props = $props();
+
+  let rawData = $state<RawData | null>(null);
+  let layout = $state<LayoutData | null>(null);
+  let step = $state(1);
+  let gsOpen = $state(false);
+  let loadError = $state<string | null>(null);
+  let validating = $state(false);
+  let validationResult = $state<Diagnostic[] | null>(null);
+  let validationError = $state<string | null>(null);
+
+  let bothLoaded = $derived(rawData !== null && layout !== null);
+  let loadedInfo = $derived(
+    rawData
+      ? t("summary.rows", {
+          rows: rawData.rowCount,
+          cols: rawData.headers.length,
+        })
+      : null,
+  );
+
+  const STEPS = [
+    { num: 1, labelKey: "import.step.select" },
+    { num: 2, labelKey: "import.step.proceed" },
+  ] as const;
+
+  async function handleRawDataFile(file: File) {
+    try {
+      loadError = null;
+      const text = await file.text();
+      const result = await loadCSV(text);
+      rawData = { fileName: file.name, headers: result.headers, rowCount: result.rowCount };
+    } catch (e) {
+      loadError = t("error.csv.load", { msg: (e as Error).message });
+    }
+  }
+
+  async function handleLayoutFile(file: File) {
+    try {
+      loadError = null;
+      const text = await file.text();
+      const rawJson = parseLayoutJson(text);
+      layout = { fileName: file.name, rawJson };
+    } catch (e) {
+      loadError = t("error.layout.load", { msg: (e as Error).message });
+    }
+  }
+
+  async function handleStart() {
+    if (!rawData || !layout) return;
+    validating = true;
+    validationResult = null;
+    validationError = null;
+    try {
+      const diags = await runValidation(layout.rawJson, rawData.headers);
+      if (diags.length === 0) {
+        await handleProceed();
+      } else {
+        validationResult = diags;
+        step = 2;
+      }
+    } catch (e) {
+      validationError = (e as Error).message;
+      step = 2;
+    } finally {
+      validating = false;
+    }
+  }
+
+  async function handleProceed() {
+    if (!rawData || !layout) return;
+    const validLayout = buildValidLayout(layout.rawJson);
+    const filtered = filterLayout(rawData.headers, validLayout);
+    const { layout: prepared, warnings } = await prepareDateLayout(filtered);
+    onComplete(rawData, layout, warnings, prepared);
+  }
+</script>
+
+{#snippet StepIndicator(currentStep: number)}
+  <div class="mb-6 flex items-center justify-center gap-0">
+    {#each STEPS as s, i (s.num)}
+      {@const isDone = s.num < currentStep}
+      {@const isActive = s.num === currentStep}
+      <div class="flex items-center">
+        {#if i > 0}
+          <div
+            class="mx-2 h-px w-8 transition-colors duration-300 {s.num <= currentStep
+              ? 'bg-accent'
+              : 'bg-border'}"
+          ></div>
+        {/if}
+        <div class="flex items-center gap-2">
+          <span
+            class="flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold transition-colors duration-300 {isDone
+              ? 'bg-accent text-accent-contrast'
+              : isActive
+                ? 'border-2 border-accent bg-surface text-accent'
+                : 'border-2 border-border bg-surface text-muted'}"
+          >
+            {isDone ? "\u2713" : s.num}
+          </span>
+          <span
+            class="text-sm font-medium transition-colors duration-300 {isActive
+              ? 'text-text'
+              : isDone
+                ? 'text-accent'
+                : 'text-muted'}"
+          >
+            {t(s.labelKey)}
+          </span>
+        </div>
+      </div>
+    {/each}
+  </div>
+{/snippet}
+
+<div class="flex items-center justify-center p-6">
+  <div class="w-full max-w-[480px] rounded-xl border border-border bg-surface p-8 shadow-md">
+    <h2 class="mb-5 text-xl font-bold text-text">{t("import.title")}</h2>
+
+    {@render StepIndicator(step)}
+
+    {#if step === 1}
+      <FileUploadPanel
+        rawDataFileName={rawData?.fileName ?? null}
+        layoutFileName={layout?.fileName ?? null}
+        onRawDataFile={handleRawDataFile}
+        onLayoutFile={handleLayoutFile}
+      />
+
+      {#if loadedInfo}
+        <Alert variant="info" role="status" class="mt-3 whitespace-pre-line">
+          {loadedInfo}
+        </Alert>
+      {/if}
+
+      {#if loadError}
+        <Alert variant="error" class="mt-3">
+          {loadError}
+        </Alert>
+      {/if}
+
+      {#if bothLoaded}
+        <div class="mt-5 w-full">
+          <Button variant="primary" size="lg" onclick={handleStart} disabled={validating}>
+            {#if validating}
+              {t("validation.running")}
+            {:else}
+              {t("import.start")} &rarr;
+            {/if}
+          </Button>
+        </div>
+      {/if}
+    {:else if step === 2 && rawData && layout}
+      <ValidationStep
+        {rawData}
+        {layout}
+        diagnostics={validationResult}
+        error={validationError}
+        onProceed={handleProceed}
+        onBack={() => (step = 1)}
+      />
+    {/if}
+  </div>
+
+  <button
+    class="fixed bottom-5 left-5 z-900 flex h-9 cursor-pointer items-center gap-1.5 rounded-full border-[1.5px] border-border-strong bg-surface px-3.5 text-sm font-semibold text-text-secondary shadow-[0_2px_8px_rgba(0,0,0,0.12)] transition-[background,color,transform] duration-150 hover:scale-[1.03] hover:border-[var(--color-primary-500)] hover:bg-[var(--color-primary-50)] hover:text-[var(--color-primary-700)]"
+    aria-label={t("help.label")}
+    onclick={() => (gsOpen = true)}
+  >
+    <span class="text-base leading-none">?</span>
+    {t("help.button")}
+  </button>
+
+  {#if gsOpen}
+    <GettingStarted open={gsOpen} onClose={() => (gsOpen = false)} />
+  {/if}
+</div>

--- a/apps/desktop/src/components/header/WasmStatus.svelte
+++ b/apps/desktop/src/components/header/WasmStatus.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { setStatusListener, type DuckStatus } from "../../lib/duckdb";
+  import { t } from "@aggy/ui";
+
+  const STATUS_CLASSES: Record<DuckStatus, string> = {
+    loading: "bg-[var(--color-warning-700)] animate-[pulse_1s_infinite]",
+    ready: "bg-[var(--color-success-700)]",
+    error: "bg-danger",
+  };
+
+  let status = $state<DuckStatus>("loading");
+  let label = $state<string>(t("wasm.loading"));
+
+  onMount(() => {
+    setStatusListener((s, l) => {
+      status = s;
+      if (l !== undefined) label = l;
+    });
+  });
+</script>
+
+<div
+  class="flex min-w-40 items-center justify-end gap-2 text-sm text-muted"
+  role="status"
+  aria-live="polite"
+>
+  <div
+    class="h-2 w-2 rounded-full transition-[background] duration-300 {STATUS_CLASSES[status]}"
+    aria-hidden="true"
+  ></div>
+  <span>{label}</span>
+</div>

--- a/apps/desktop/src/components/import/FileUploadPanel.svelte
+++ b/apps/desktop/src/components/import/FileUploadPanel.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import { t, Dropzone } from "@aggy/ui";
+
+  interface Props {
+    rawDataFileName: string | null;
+    layoutFileName: string | null;
+    onRawDataFile: (file: File) => void;
+    onLayoutFile: (file: File) => void;
+  }
+
+  let { rawDataFileName, layoutFileName, onRawDataFile, onLayoutFile }: Props = $props();
+</script>
+
+<div class="flex flex-col gap-3 md:flex-row">
+  <div class="flex-1">
+    <Dropzone
+      accept=".csv"
+      icon={t("dropzone.csv.icon")}
+      text={t("dropzone.csv.text")}
+      loadedFileName={rawDataFileName}
+      onFile={onRawDataFile}
+    />
+  </div>
+  <div class="flex-1">
+    <Dropzone
+      accept=".json"
+      icon={t("dropzone.layout.icon")}
+      text={t("dropzone.layout.text")}
+      loadedFileName={layoutFileName}
+      onFile={onLayoutFile}
+    />
+  </div>
+</div>

--- a/apps/desktop/src/lib/duckdb.ts
+++ b/apps/desktop/src/lib/duckdb.ts
@@ -1,0 +1,120 @@
+import * as duckdb from "@duckdb/duckdb-wasm";
+import type { Question, Tab, Layout, DatePreparationResult, Diagnostic } from "@aggy/lib";
+import {
+  validateLayoutStructure,
+  buildValidLayout,
+  buildTabs,
+  prepareDateColumns,
+  validateRawData,
+} from "@aggy/lib";
+
+export type DuckStatus = "loading" | "ready" | "error";
+export type StatusListener = (s: DuckStatus, label: string) => void;
+
+let statusListener: StatusListener | null = null;
+
+export function setStatusListener(listener: StatusListener): void {
+  statusListener = listener;
+}
+
+export async function initDuckDB(): Promise<void> {
+  if (initPromise) return initPromise;
+
+  initPromise = (async () => {
+    try {
+      statusListener?.("loading", "DuckDB 読み込み中...");
+
+      const BUNDLES: duckdb.DuckDBBundles = {
+        mvp: {
+          mainModule: `${DUCKDB_CDN}/duckdb-mvp.wasm`,
+          mainWorker: `${DUCKDB_CDN}/duckdb-browser-mvp.worker.js`,
+        },
+        eh: {
+          mainModule: `${DUCKDB_CDN}/duckdb-eh.wasm`,
+          mainWorker: `${DUCKDB_CDN}/duckdb-browser-eh.worker.js`,
+        },
+      };
+
+      const bundle = await duckdb.selectBundle(BUNDLES);
+      const workerBlob = new Blob([`importScripts("${bundle.mainWorker!}");`], {
+        type: "application/javascript",
+      });
+      const worker = new Worker(URL.createObjectURL(workerBlob));
+      const logger = new duckdb.ConsoleLogger();
+      db = new duckdb.AsyncDuckDB(logger, worker);
+      await db.instantiate(bundle.mainModule, bundle.pthreadWorker);
+
+      status = "ready";
+      statusListener?.("ready", "DuckDB Ready");
+    } catch (err) {
+      status = "error";
+      statusListener?.("error", `DuckDB エラー: ${(err as Error).message}`);
+      throw err;
+    }
+  })();
+
+  return initPromise;
+}
+
+/** Register CSV text in DuckDB and return headers and row count */
+export async function loadCSV(csvText: string): Promise<{ headers: string[]; rowCount: number }> {
+  await initDuckDB();
+  if (!db) throw new Error("DuckDB is not ready");
+
+  await db.registerFileText("survey.csv", csvText);
+
+  const c = await getConnection();
+  await c.query(
+    `CREATE OR REPLACE TABLE survey AS
+     SELECT * FROM read_csv('survey.csv')`,
+  );
+
+  const descResult = await c.query(`DESCRIBE survey`);
+  const headers = descResult.toArray().map((r) => String(r.column_name));
+
+  const countResult = await c.query(`SELECT COUNT(*) AS n FROM survey`);
+  const rowCount = Number(countResult.toArray()[0].n);
+
+  return { headers, rowCount };
+}
+
+/** Validate layout structure + CSV data against layout definition */
+export async function runValidation(rawJson: unknown[], headers: string[]): Promise<Diagnostic[]> {
+  const layoutDiags = validateLayoutStructure(rawJson);
+  if (layoutDiags.length > 0) return layoutDiags;
+
+  const layout = buildValidLayout(rawJson);
+  const c = await getConnection();
+  return validateRawData(c, headers, layout);
+}
+
+/** Execute aggregation for all question × axis combinations */
+export async function runAggregation(
+  questions: Question[],
+  crossQuestions: Question[],
+  weightCol: string,
+): Promise<Tab[]> {
+  const c = await getConnection();
+  return buildTabs(c, questions, crossQuestions, weightCol);
+}
+
+/** Prepare DATE columns in layout (convert to SA with auto-generated items) */
+export async function prepareDateLayout(layout: Layout): Promise<DatePreparationResult> {
+  const c = await getConnection();
+  return prepareDateColumns(c, layout);
+}
+
+// ─── Internal ───────────────────────────────────────────────
+
+const DUCKDB_CDN = "https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.33.1-dev18.0/dist";
+
+let db: duckdb.AsyncDuckDB | null = null;
+let conn: duckdb.AsyncDuckDBConnection | null = null;
+let status: DuckStatus = "loading";
+let initPromise: Promise<void> | null = null;
+
+async function getConnection(): Promise<duckdb.AsyncDuckDBConnection> {
+  if (!db || status !== "ready") throw new Error("DuckDB is not ready");
+  if (!conn) conn = await db.connect();
+  return conn;
+}

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -98,4 +98,7 @@ export default defineConfig({
     },
   },
   plugins: [tailwindcss(), svelte()],
+  optimizeDeps: {
+    exclude: ["@duckdb/duckdb-wasm"],
+  },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@aggy/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@duckdb/duckdb-wasm':
+        specifier: ^1.33.1-dev18.0
+        version: 1.33.1-dev18.0
       '@tauri-apps/api':
         specifier: ^2
         version: 2.10.1


### PR DESCRIPTION
## Summary

Issue #216 Step 5 — `@aggy/lib` と `@aggy/ui` を `apps/desktop` に接続し、DuckDB Wasm を使った集計フロー全体を実装。

### 追加ファイル

| ファイル | 説明 |
|---|---|
| `src/lib/duckdb.ts` | apps/web と同一（CDN ベース）。Tauri は SharedArrayBuffer がデフォルト有効なので COOP/COEP ヘッダ不要 |
| `src/components/AggregationScreen.svelte` | apps/web と同一。AIBubble は省略（Chrome AI は Web 専用） |
| `src/components/Header.svelte` | WasmStatus + ChangelogButton + SettingsModal |
| `src/components/header/WasmStatus.svelte` | ローカル duckdb.ts を参照 |
| `src/components/ImportScreen.svelte` | ブラウザ file input ベース。保存履歴は Step 6 で実装 |
| `src/components/import/FileUploadPanel.svelte` | ブラウザ `<input type="file">` + D&D（Tauri WebView で動作） |

### Step 6 との差分
- 保存履歴（SavedFiles）は未実装 → Step 6 で Tauri fs を使って追加
- ファイルダイアログはブラウザ標準 → Step 6 で `@tauri-apps/plugin-dialog` に差し替え

## Test plan

- [x] `vp build` passes (554 kB, 503ms)
- [ ] `pnpm tauri dev` でウィンドウが開き、CSV + JSON を読み込んで集計できる（手動確認）
- [ ] DuckDB Wasm がエラーなく起動する（WasmStatus が "ready" になる）

🤖 Generated with [Claude Code](https://claude.com/claude-code)