### PR TITLE
feat(ci): Step 8 — desktop check/test in CI and cross-platform Tauri build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,9 @@ jobs:
 
       - name: Build (web)
         run: cd apps/web && vp build
+
+      - name: Check (desktop)
+        run: cd apps/desktop && vp check
+
+      - name: Test (desktop)
+        run: cd apps/desktop && vp test run

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -1,0 +1,53 @@
+name: Desktop Build
+
+on:
+  push:
+    branches: [add-desktop, develop, main]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-latest
+            args: "--target universal-apple-darwin"
+            rust-targets: "aarch64-apple-darwin,x86_64-apple-darwin"
+            artifact-name: aggy-macos
+            artifact-path: apps/desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg
+          - platform: windows-latest
+            args: ""
+            rust-targets: ""
+            artifact-name: aggy-windows
+            artifact-path: |
+              apps/desktop/src-tauri/target/release/bundle/msi/*.msi
+              apps/desktop/src-tauri/target/release/bundle/nsis/*.exe
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version-file: .node-version
+          cache: true
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust-targets }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "./apps/desktop/src-tauri -> target"
+
+      - name: Build Tauri app
+        run: cd apps/desktop && pnpm tauri build ${{ matrix.args }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact-name }}
+          path: ${{ matrix.artifact-path }}
+          if-no-files-found: error


### PR DESCRIPTION
## Summary

- **`ci.yml`** — デスクトップの `vp check` + `vp test run` を既存の ubuntu ジョブに追加（Rust不要）
- **`desktop.yml`** — Tauri クロスプラットフォームビルド用の新規ワークフロー

## desktop.yml の仕様

| platform | Rust targets | 出力 |
|---|---|---|
| `macos-latest` | `aarch64-apple-darwin` + `x86_64-apple-darwin` | Universal `.dmg` |
| `windows-latest` | default | `.msi` / `.nsis.exe` |

- `Swatinem/rust-cache` で Cargo ビルドキャッシュ
- `push` 時のみ実行（`add-desktop` / `develop` / `main` ブランチ）
- 成果物は GitHub Actions artifacts にアップロード

## Test plan

- [ ] PR の CI ジョブで `vp check` + `vp test run` がパスする
- [ ] `add-desktop` へのマージ後、`desktop.yml` が macOS + Windows でそれぞれビルドし artifact が生成される

🤖 Generated with [Claude Code](https://claude.com/claude-code)