### PR TITLE
fix(ci): add pnpm setup and install to desktop build job

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -33,6 +33,11 @@ jobs:
           node-version-file: .node-version
           cache: true
 
+      - uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
## 問題

`desktop.yml` の `build` ジョブで `pnpm: command not found` エラー。

`voidzero-dev/setup-vp@v1` は `vp` CLI をセットアップするが、`pnpm` 自体はインストールしない。  
macOS / Windows ランナーでは `pnpm tauri build` を実行する前に明示的なセットアップが必要。

## 修正

```yaml
- uses: pnpm/action-setup@v4          # pnpm をインストール (packageManager フィールドからバージョン自動検出)
- run: pnpm install --frozen-lockfile  # 依存関係インストール
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)