### PR TITLE
feat(ui): add desktop download section to GettingStarted modal

### DIFF
--- a/packages/lib/src/locales/en.ts
+++ b/packages/lib/src/locales/en.ts
@@ -151,6 +151,10 @@ const en: Record<string, string> = {
   "gs.section3.step1": "Load a raw data file and a layout file",
   "gs.section3.step2": "Select cross-tabulation axes if needed",
   "gs.section3.step3": 'Click the "Run Aggregation" button',
+  "gs.section4.title": "Desktop App",
+  "gs.section4.desc": "Install for offline use and faster performance",
+  "gs.section4.mac": "Download for Mac",
+  "gs.section4.windows": "Download for Windows",
   "gs.dismiss": "Don't show again",
   "gs.ok": "Get Started",
 

--- a/packages/lib/src/locales/ja.ts
+++ b/packages/lib/src/locales/ja.ts
@@ -151,6 +151,10 @@ const ja: Record<string, string> = {
   "gs.section3.step1": "ローデータファイルとレイアウトファイルを読み込む",
   "gs.section3.step2": "必要に応じてクロス集計軸を選択する",
   "gs.section3.step3": "「集計を実行」ボタンをクリック",
+  "gs.section4.title": "デスクトップ版",
+  "gs.section4.desc": "インストール版でオフライン・高速動作",
+  "gs.section4.mac": "Mac 版をダウンロード",
+  "gs.section4.windows": "Windows 版をダウンロード",
   "gs.dismiss": "今後表示しない",
   "gs.ok": "はじめる",
 

--- a/packages/ui/src/components/import/GettingStarted.svelte
+++ b/packages/ui/src/components/import/GettingStarted.svelte
@@ -97,6 +97,37 @@
             <li>{t("gs.section3.step3")}</li>
           </ol>
         </section>
+
+        <section class="mb-5 last:mb-0">
+          <h3 class="m-0 mb-2 text-base font-bold text-accent dark:text-accent-light">
+            {t("gs.section4.title")}
+          </h3>
+          <p class="m-0 mb-3 text-text-secondary">{t("gs.section4.desc")}</p>
+          <div class="flex gap-3">
+            <a
+              href="https://github.com/Yuki-bach/aggy/releases/latest"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="flex items-center gap-1.5 rounded border border-border-strong bg-surface px-3 py-1.5 text-xs font-semibold text-text transition-colors hover:border-accent hover:bg-accent-bg dark:bg-surface2"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 2C6.477 2 2 6.477 2 12c0 4.418 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.009-.868-.013-1.703-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0 1 12 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+              </svg>
+              {t("gs.section4.mac")}
+            </a>
+            <a
+              href="https://github.com/Yuki-bach/aggy/releases/latest"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="flex items-center gap-1.5 rounded border border-border-strong bg-surface px-3 py-1.5 text-xs font-semibold text-text transition-colors hover:border-accent hover:bg-accent-bg dark:bg-surface2"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 2C6.477 2 2 6.477 2 12c0 4.418 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.009-.868-.013-1.703-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0 1 12 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+              </svg>
+              {t("gs.section4.windows")}
+            </a>
+          </div>
+        </section>
       </div>
 
       <div class="mt-6 flex items-center justify-end border-t border-border pt-4">


### PR DESCRIPTION
## 変更内容

「はじめ方」モーダルにデスクトップ版ダウンロードセクションを追加。

- **section 4** を新規追加（既存の section 1〜3 の後）
- Mac / Windows ダウンロードリンク → `https://github.com/Yuki-bach/aggy/releases/latest`
- i18n: `gs.section4.*` キーを ja / en に追加

## 注意

現在リンク先は GitHub Releases ページ全体。  
リリースワークフローに artifact アップロードを追加すれば、直接ファイルダウンロード URL に切り替え可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)