### PR TITLE
feat(ci): attach desktop artifacts to GitHub Release on tag push

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -3,9 +3,12 @@ name: Desktop Build
 on:
   push:
     branches: [add-desktop, develop, main]
+    tags: ["v*"]
 
 jobs:
   build:
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -56,3 +59,9 @@ jobs:
           name: ${{ matrix.artifact-name }}
           path: ${{ matrix.artifact-path }}
           if-no-files-found: error
+
+      - name: Attach to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ matrix.artifact-path }}


### PR DESCRIPTION
## 変更内容

`desktop.yml` に `tags: ["v*"]` トリガーと Release 添付ステップを追加。

| トリガー | 動作 |
|---|---|
| ブランチ push | ビルド + Actions artifacts（従来通り） |
| タグ push（`v*`） | ビルド + Actions artifacts + **GitHub Release に DMG/MSI 添付** |

## リリースフロー（CLAUDE.md の手順と組み合わせ）

```bash
npm version minor          # package.json 更新 + git tag 作成
git push origin main --tags  # ← このタグ push で desktop.yml が走る
gh release create v0.x.0 --generate-notes  # Release 作成（CI が完了すると DMG/MSI が添付済み）
```

`gh release create` 実行時点で CI がまだ走っている場合は、完了後に自動添付されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)