### PR TITLE
fix(ci): narrow desktop build trigger — main PR only + tag push

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -1,11 +1,15 @@
 name: Desktop Build
 
 on:
+  pull_request:
+    branches: [main]
   push:
-    branches: [add-desktop, develop, main]
+    tags: ["v*"]
 
 jobs:
   build:
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -56,3 +60,9 @@ jobs:
           name: ${{ matrix.artifact-name }}
           path: ${{ matrix.artifact-path }}
           if-no-files-found: error
+
+      - name: Attach to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ matrix.artifact-path }}


### PR DESCRIPTION
## 問題

`push: branches: [add-desktop, develop, main]` のため、feature ブランチを `add-desktop` にマージするたびに macOS + Windows の Tauri ビルド（重い）が走っていた。

## 修正後のトリガー

| トリガー | 用途 |
|---|---|
| `pull_request: branches: [main]` | develop → main の release PR でビルド検証 |
| `push: tags: ["v*"]` | リリースタグ push 時に DMG/MSI を GitHub Release に添付 |

PR #232 の Release 添付機能もまとめて取り込み済み。Closes #232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)