### PR TITLE
fix: resolve build warnings and improve initial load

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -4,7 +4,8 @@
   import { initTheme } from "./lib/theme";
   import Header from "./components/Header.svelte";
   import ImportScreen from "./components/ImportScreen.svelte";
-  import AggregationScreen from "./components/AggregationScreen.svelte";
+  const AggregationScreen = () =>
+    import("./components/AggregationScreen.svelte");
   import type { Layout } from "./lib/layout";
   import type { RawData, LayoutData } from "./lib/types";
 
@@ -45,12 +46,14 @@
     {#if isImport}
       <ImportScreen onComplete={handleComplete} />
     {:else if loadedData}
-      <AggregationScreen
-        rawData={loadedData.rawData}
-        layout={loadedData.layout}
-        preparedLayout={loadedData.preparedLayout}
-        dateWarnings={loadedData.dateWarnings}
-      />
+      {#await AggregationScreen() then { default: Agg }}
+        <Agg
+          rawData={loadedData.rawData}
+          layout={loadedData.layout}
+          preparedLayout={loadedData.preparedLayout}
+          dateWarnings={loadedData.dateWarnings}
+        />
+      {/await}
     {/if}
   </main>
 </div>

--- a/src/components/aggregation/NaChartCardBody.svelte
+++ b/src/components/aggregation/NaChartCardBody.svelte
@@ -224,15 +224,17 @@
 <div class="p-4 {isCross ? 'h-[400px]' : 'h-80'}">
   {#if !isCross && range > 0}
     <div class="flex items-center justify-end gap-2 mb-2 text-xs text-muted-foreground">
-      <label>{t("na.binWidth")}</label>
-      <input
+      <label>
+        {t("na.binWidth")}
+        <input
         type="range"
         min={0}
         max={sliderMax}
         step={1}
         bind:value={binWidth}
-        class="w-32"
-      />
+          class="w-32"
+        />
+      </label>
       <span class="w-6 text-center tabular-nums">{binWidth || "–"}</span>
     </div>
   {/if}

--- a/src/components/aggregation/ResultPanel.svelte
+++ b/src/components/aggregation/ResultPanel.svelte
@@ -89,10 +89,5 @@
       </div>
       <AIBubble {tabs} {weightCol} />
     </div>
-  {:else}
-    <div class="flex h-full flex-col items-center justify-center gap-3 text-muted">
-      <span class="text-4xl" aria-hidden="true">&#x2B1B;</span>
-      <p class="text-base">{t("empty.text")}</p>
-    </div>
   {/if}
 </div>

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -56,9 +56,6 @@ const en: Record<string, string> = {
   // Run button
   "run.button": "▶ Run Aggregation",
 
-  // Empty state
-  "empty.text": "Select cross-tabulation axes and run the aggregation",
-
   // Results
   "result.title.tab": "Aggregation Results",
   "result.meta": "{count} questions  /  {weight}",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -56,9 +56,6 @@ const ja: Record<string, string> = {
   // Run button
   "run.button": "▶ 集計を実行",
 
-  // Empty state
-  "empty.text": "クロス集計軸を選んで集計を実行してください",
-
   // Results
   "result.title.tab": "集計結果",
   "result.meta": "{count} 問  ／  {weight}",


### PR DESCRIPTION
## Summary
- Associate `<label>` with `<input>` to fix Svelte a11y warning in NaChartCardBody
- Lazy-load AggregationScreen via dynamic import, reducing initial JS from 500 kB to 240 kB (gzip: 148 kB → 59 kB)
- Remove empty-state placeholder (black square emoji) that briefly flashed during screen transitions

## Test plan
- [ ] `vp build` completes with no a11y warning and no chunk size warning
- [ ] Import screen loads normally
- [ ] Aggregation screen renders correctly after CSV upload
- [ ] No black square flicker on screen transition or re-aggregation

🤖 Generated with [Claude Code](https://claude.com/claude-code)