### PR TITLE
refactor: remove type re-exports and add prevention script

### DIFF
--- a/.vite-hooks/pre-commit
+++ b/.vite-hooks/pre-commit
@@ -1,1 +1,2 @@
 vp staged
+bash scripts/no-reexport.sh

--- a/scripts/no-reexport.sh
+++ b/scripts/no-reexport.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Detect re-exports: export { ... } from "..." / export type { ... } from "..."
+# Exits non-zero if any re-export is found.
+
+matches=$(grep -rn --include="*.ts" --include="*.svelte" -E 'export\s+(type\s+)?\{[^}]*\}\s+from\s' src)
+
+if [ -n "$matches" ]; then
+  echo "Re-exports detected — import directly from the source module instead:"
+  echo "$matches"
+  exit 1
+fi

--- a/src/lib/agg/aggNaCrossTab.ts
+++ b/src/lib/agg/aggNaCrossTab.ts
@@ -1,7 +1,8 @@
 /** NA (Numerical Answer) cross-tabulation */
 
 import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
-import type { Shape, TabData, Slice, NaStats } from "./types";
+import type { Slice, NaStats } from "../types";
+import type { Shape, TabData } from "./types";
 import { calcPct } from "./types";
 import { esc, maShownCondition } from "./sqlHelpers";
 import {

--- a/src/lib/agg/aggNaTab.ts
+++ b/src/lib/agg/aggNaTab.ts
@@ -1,7 +1,8 @@
 /** NA (Numerical Answer) single tabulation */
 
 import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
-import type { NaStats, TabData } from "./types";
+import type { NaStats } from "../types";
+import type { TabData } from "./types";
 import { calcPct } from "./types";
 import { esc } from "./sqlHelpers";
 import {
@@ -37,7 +38,7 @@ class NaTabAggregator {
   private freqToCells(
     freq: ValueCount[],
     n: number,
-  ): { codes: string[]; cells: import("./types").Cell[] } {
+  ): { codes: string[]; cells: import("../types").Cell[] } {
     const codes = freq.map((f) => String(f.value));
     const cells = freq.map((f) => ({
       count: f.count,

--- a/src/lib/agg/buildTabs.ts
+++ b/src/lib/agg/buildTabs.ts
@@ -1,5 +1,6 @@
 import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
-import type { Question, TabData, Axis, Tab } from "./types";
+import type { Question, Axis, Tab } from "../types";
+import type { TabData } from "./types";
 import { aggTab } from "./aggTab";
 import { aggCrossTab } from "./aggCrossTab";
 import { aggNaTab } from "./aggNaTab";

--- a/src/lib/agg/naHelpers.ts
+++ b/src/lib/agg/naHelpers.ts
@@ -1,6 +1,6 @@
 /** Shared helpers for NA (Numerical Answer) aggregation */
 
-import type { NaStats } from "./types";
+import type { NaStats } from "../types";
 import { esc } from "./sqlHelpers";
 
 export interface ValueCount {

--- a/src/lib/agg/types.ts
+++ b/src/lib/agg/types.ts
@@ -1,7 +1,5 @@
 /** Aggregation-internal types */
 
-export type { QuestionType, Question, Cell, NaStats, Slice, Axis, Tab } from "../types";
-
 import type { Question, Tab } from "../types";
 
 export type Shape = Pick<Question, "type" | "columns" | "codes">;


### PR DESCRIPTION
## Summary
- `agg/types.ts` の不要な type re-export を削除し、各ファイルから `../types` を直接 import するよう修正
- re-export を防止する grep ベースのスクリプト (`scripts/no-reexport.sh`) を追加し、pre-commit hook に組み込み

## Test plan
- [x] `npx tsc --noEmit` 型チェック通過
- [x] スクリプトが re-export を検知して exit 1 を返すことを確認
- [x] re-export がない状態で exit 0 を返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)