### PR TITLE
chore: add v0.2.0 changelog entry

### DIFF
--- a/src/lib/changelog.json
+++ b/src/lib/changelog.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "0.2.0",
+    "date": "2026-04-18",
+    "changes": [
+      {
+        "ja": "ヒストグラム階級幅スライダーと Changelog 通知 UI を追加",
+        "en": "Add histogram bin-width slider and changelog notification UI"
+      }
+    ]
+  },
+  {
     "version": "0.1.0",
     "date": "2026-03-26",
     "changes": [{ "ja": "初回リリース", "en": "Initial release" }]


### PR DESCRIPTION
## Summary
- `src/lib/changelog.json` に v0.2.0 (2026-04-18) エントリを追加
- 変更内容: ヒストグラム階級幅スライダーと Changelog 通知 UI の追加

## Test plan
- [ ] アプリを開いて Changelog 通知 UI に v0.2.0 が表示されること
- [ ] ja / en 両方で文言が正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)