### PR TITLE
feat: MATRIX 集計結果の表示対応

### DIFF
--- a/src/components/AggregationScreen.svelte
+++ b/src/components/AggregationScreen.svelte
@@ -5,7 +5,7 @@
   import SettingsPanel from "./aggregation/SettingsPanel.svelte";
   import { runAggregation } from "../lib/duckdb.svelte";
   import type { Layout } from "../lib/layout";
-  import { buildQuestions, findWeightColumn } from "../lib/layout";
+  import { buildQuestions, buildMatrixGroups, findWeightColumn } from "../lib/layout";
   import { t } from "../lib/i18n.svelte";
 
   interface Props {
@@ -19,6 +19,9 @@
 
   let questions = $derived(buildQuestions(preparedLayout));
   let weightCol = $derived(findWeightColumn(preparedLayout));
+  let matrixLabels = $derived(
+    Object.fromEntries(buildMatrixGroups(preparedLayout).map((g) => [g.matrixKey, g.matrixLabel])),
+  );
 
   let crossSelected = $state<Record<string, boolean>>({});
   let weightEnabled = $state(true);
@@ -38,7 +41,7 @@
     const crossQuestions = questions.filter((q) => crossSelected[q.code]);
 
     try {
-      const tabs = await runAggregation(questions, crossQuestions, activeWeightCol);
+      const tabs = await runAggregation(questions, crossQuestions, activeWeightCol, matrixLabels);
       aggResult = { tabs, weightCol: activeWeightCol };
     } catch (e) {
       errorMsg = t("error.aggregation", { msg: (e as Error).message });

--- a/src/components/aggregation/MatrixGtChart.svelte
+++ b/src/components/aggregation/MatrixGtChart.svelte
@@ -1,0 +1,131 @@
+<script lang="ts">
+  import type { Tab } from "../../lib/types";
+  import { Chart, getSeriesColor, getThemeColors, type PaletteId } from "../../lib/chartConfig";
+  import type { ChartType } from "./viewTypes";
+  import type { ChartConfiguration } from "chart.js";
+
+  interface Props {
+    tabs: Tab[];
+    chartType: ChartType;
+    paletteId: PaletteId;
+  }
+
+  let { tabs, chartType, paletteId }: Props = $props();
+
+  let canvas: HTMLCanvasElement;
+  let chart: Chart | null = null;
+
+  $effect(() => {
+    const _tabs = tabs;
+    const _chartType = chartType;
+    const _paletteId = paletteId;
+
+    if (!canvas) return;
+    chart?.destroy();
+    const theme = getThemeColors();
+    chart = build(canvas, _tabs, _chartType, theme, _paletteId);
+
+    return () => {
+      chart?.destroy();
+      chart = null;
+    };
+  });
+
+  function build(
+    cvs: HTMLCanvasElement,
+    ts: Tab[],
+    ct: ChartType,
+    theme: ReturnType<typeof getThemeColors>,
+    pid: PaletteId,
+  ): Chart {
+    // All children share the same codes; use the first child's codes/labels
+    const codes = ts[0].codes;
+    const codeLabels = codes.map((c) => ts[0].labels[c]);
+
+    if (ct === "obi") {
+      // Per-child stacked bar: rows = children, stacks = option codes
+      const datasets = codes.map((code, i) => ({
+        label: ts[0].labels[code],
+        data: ts.map((t) => t.slices[0].cells[i]?.pct ?? 0),
+        backgroundColor: getSeriesColor(i, pid),
+        maxBarThickness: 48,
+      }));
+
+      return new Chart(cvs, {
+        type: "bar",
+        data: {
+          labels: ts.map((t) => t.label),
+          datasets,
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          indexAxis: "y",
+          plugins: {
+            legend: { position: "bottom", labels: { color: theme.text, font: { size: 12 } } },
+            tooltip: {
+              callbacks: {
+                label: (c) => `${c.dataset.label}: ${(c.parsed.x as number).toFixed(1)}%`,
+              },
+            },
+          },
+          scales: {
+            x: {
+              stacked: true,
+              max: 100,
+              ticks: { color: theme.muted, callback: (v) => `${v}%` },
+              grid: { color: theme.gridLine },
+            },
+            y: { stacked: true, ticks: { color: theme.text }, grid: { display: false } },
+          },
+        },
+      } as ChartConfiguration);
+    }
+
+    // Grouped bar: groups = option codes, bars within = children
+    const isHorizontal = ct === "bar-h";
+    const datasets = ts.map((t, i) => ({
+      label: t.label,
+      data: codes.map((_, ci) => t.slices[0].cells[ci]?.pct ?? 0),
+      backgroundColor: getSeriesColor(i, pid),
+      borderRadius: 3,
+      maxBarThickness: 40,
+    }));
+
+    return new Chart(cvs, {
+      type: "bar",
+      data: { labels: codeLabels, datasets },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        indexAxis: isHorizontal ? "y" : "x",
+        plugins: {
+          legend: { position: "top", labels: { color: theme.text, font: { size: 12 } } },
+          tooltip: {
+            callbacks: {
+              label: (c) => {
+                const val = c.parsed[isHorizontal ? "x" : "y"] as number;
+                return `${c.dataset.label}: ${val.toFixed(1)}%`;
+              },
+            },
+          },
+        },
+        scales: {
+          [isHorizontal ? "x" : "y"]: {
+            beginAtZero: true,
+            ticks: { color: theme.muted, callback: (v) => `${v}%` },
+            grid: { color: theme.gridLine },
+          },
+          [isHorizontal ? "y" : "x"]: {
+            ticks: { color: theme.text },
+            grid: { display: false },
+          },
+        },
+      },
+    } as ChartConfiguration);
+  }
+</script>
+
+<div class="h-[400px] p-4">
+  <canvas bind:this={canvas}></canvas>
+</div>

--- a/src/components/aggregation/MatrixGtTable.svelte
+++ b/src/components/aggregation/MatrixGtTable.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import type { Tab } from "../../lib/types";
+  import { formatN } from "../../lib/format";
+  import Th from "./Th.svelte";
+  import Td from "./Td.svelte";
+
+  interface Props {
+    tabs: Tab[];
+  }
+
+  let { tabs }: Props = $props();
+
+  // All children share the same codes/labels (common-option matrix precondition)
+  let codes = $derived(tabs[0].codes);
+  let labels = $derived(tabs[0].labels);
+</script>
+
+<table class="w-full border-collapse text-sm tabular-nums">
+  <thead>
+    <tr>
+      <Th></Th>
+      <Th right>n</Th>
+      {#each codes as code (code)}
+        <Th right>{labels[code]}</Th>
+      {/each}
+    </tr>
+  </thead>
+  <tbody class="[&_tr:hover_td]:bg-row-hover [&_tr:last-child_td]:border-b-0">
+    {#each tabs as tab (tab.questionCode)}
+      {@const slice = tab.slices[0]}
+      <tr>
+        <Td>{tab.label}</Td>
+        <Td right mono>{formatN(slice.n)}</Td>
+        {#each codes as code, i (code)}
+          {@const cell = slice.cells[i]}
+          <Td right mono class="text-muted">
+            {cell && cell.pct !== null ? cell.pct.toFixed(1) + "%" : "-"}
+          </Td>
+        {/each}
+      </tr>
+    {/each}
+  </tbody>
+</table>

--- a/src/components/aggregation/MatrixNaGtChart.svelte
+++ b/src/components/aggregation/MatrixNaGtChart.svelte
@@ -1,0 +1,154 @@
+<script lang="ts">
+  import type { Tab } from "../../lib/types";
+  import { Chart, getSeriesColor, getThemeColors, type PaletteId } from "../../lib/chartConfig";
+  import { t } from "../../lib/i18n.svelte";
+  import type { ChartConfiguration } from "chart.js";
+
+  interface Props {
+    tabs: Tab[];
+    paletteId: PaletteId;
+  }
+
+  let { tabs, paletteId }: Props = $props();
+
+  let canvas: HTMLCanvasElement;
+  let chart: Chart | null = null;
+  let binWidth = $state(0);
+
+  let globalMin = $derived(
+    Math.min(
+      ...tabs
+        .map((tb) => tb.slices[0]?.stats?.min ?? Number.POSITIVE_INFINITY)
+        .filter(Number.isFinite),
+    ),
+  );
+  let globalMax = $derived(
+    Math.max(
+      ...tabs
+        .map((tb) => tb.slices[0]?.stats?.max ?? Number.NEGATIVE_INFINITY)
+        .filter(Number.isFinite),
+    ),
+  );
+  let range = $derived(Number.isFinite(globalMax - globalMin) ? globalMax - globalMin : 0);
+  let sliderMax = $derived(Math.max(Math.ceil(range / 2), 1));
+
+  /** Expand a single tab's codes/cells into a flat number array */
+  function expandValues(tab: Tab): number[] {
+    const result: number[] = [];
+    const cells = tab.slices[0].cells;
+    for (let i = 0; i < tab.codes.length; i++) {
+      const v = Number(tab.codes[i]);
+      for (let j = 0; j < cells[i].count; j++) result.push(v);
+    }
+    return result;
+  }
+
+  $effect(() => {
+    const _tabs = tabs;
+    const _paletteId = paletteId;
+    const _binWidth = binWidth;
+    const _min = globalMin;
+    const _max = globalMax;
+
+    if (!canvas) return;
+    chart?.destroy();
+    const theme = getThemeColors();
+    chart = build(canvas, _tabs, _binWidth, _min, _max, theme, _paletteId);
+
+    return () => {
+      chart?.destroy();
+      chart = null;
+    };
+  });
+
+  function build(
+    cvs: HTMLCanvasElement,
+    ts: Tab[],
+    bw: number,
+    minVal: number,
+    maxVal: number,
+    theme: ReturnType<typeof getThemeColors>,
+    pid: PaletteId,
+  ): Chart {
+    let labels: string[];
+    let perChildData: number[][];
+
+    if (bw > 0 && Number.isFinite(minVal) && Number.isFinite(maxVal)) {
+      const binStart = Math.floor(minVal / bw) * bw;
+      const binEnd = Math.floor(maxVal / bw) * bw + bw;
+      const bins: number[] = [];
+      for (let b = binStart; b < binEnd; b += bw) bins.push(b);
+      labels = bins.map((b) => `${b}–${b + bw - 1}`);
+
+      perChildData = ts.map((tb) => {
+        const counts = Array.from({ length: bins.length }, () => 0);
+        const values = expandValues(tb);
+        for (const v of values) {
+          const idx = Math.floor((v - binStart) / bw);
+          if (idx >= 0 && idx < counts.length) counts[idx]++;
+        }
+        return counts;
+      });
+    } else {
+      // Raw: union of all distinct numeric values across children
+      const codeSet = new Set<string>();
+      for (const tb of ts) for (const c of tb.codes) codeSet.add(c);
+      const sortedCodes = [...codeSet].sort((a, b) => Number(a) - Number(b));
+      labels = sortedCodes;
+
+      perChildData = ts.map((tb) => {
+        const map = new Map<string, number>();
+        for (let i = 0; i < tb.codes.length; i++) {
+          map.set(tb.codes[i], tb.slices[0].cells[i]?.count ?? 0);
+        }
+        return sortedCodes.map((c) => map.get(c) ?? 0);
+      });
+    }
+
+    const datasets = ts.map((tb, i) => ({
+      label: tb.label,
+      data: perChildData[i],
+      backgroundColor: getSeriesColor(i, pid),
+      borderRadius: 3,
+      maxBarThickness: 40,
+    }));
+
+    return new Chart(cvs, {
+      type: "bar",
+      data: { labels, datasets },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { position: "top", labels: { color: theme.text, font: { size: 12 } } },
+          tooltip: {
+            callbacks: {
+              label: (c) => `${c.dataset.label}: ${(c.parsed.y as number).toFixed(1)}`,
+            },
+          },
+        },
+        scales: {
+          x: { ticks: { color: theme.text }, grid: { display: false } },
+          y: {
+            beginAtZero: true,
+            ticks: { color: theme.muted },
+            grid: { color: theme.gridLine },
+          },
+        },
+      },
+    } as ChartConfiguration);
+  }
+</script>
+
+<div class="h-[400px] p-4">
+  {#if range > 0}
+    <div class="mb-2 flex items-center justify-end gap-2 text-xs text-muted-foreground">
+      <label>
+        {t("na.binWidth")}
+        <input type="range" min={0} max={sliderMax} step={1} bind:value={binWidth} class="w-32" />
+      </label>
+      <span class="w-6 text-center tabular-nums">{binWidth || "–"}</span>
+    </div>
+  {/if}
+  <canvas bind:this={canvas}></canvas>
+</div>

--- a/src/components/aggregation/MatrixNaGtTable.svelte
+++ b/src/components/aggregation/MatrixNaGtTable.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import type { Tab } from "../../lib/types";
+  import { formatStat } from "../../lib/format";
+  import { t } from "../../lib/i18n.svelte";
+  import Th from "./Th.svelte";
+  import Td from "./Td.svelte";
+
+  interface Props {
+    tabs: Tab[];
+  }
+
+  let { tabs }: Props = $props();
+
+  const STAT_KEYS = ["n", "mean", "median", "sd", "min", "max"] as const;
+</script>
+
+<table class="w-full border-collapse text-sm tabular-nums">
+  <thead>
+    <tr>
+      <Th></Th>
+      {#each STAT_KEYS as key (key)}
+        <Th right>{t(`na.stat.${key}`)}</Th>
+      {/each}
+    </tr>
+  </thead>
+  <tbody class="[&_tr:hover_td]:bg-row-hover [&_tr:last-child_td]:border-b-0">
+    {#each tabs as tab (tab.questionCode)}
+      {@const stats = tab.slices[0].stats!}
+      <tr>
+        <Td>{tab.label}</Td>
+        {#each STAT_KEYS as key (key)}
+          <Td right mono>{formatStat(key, stats[key])}</Td>
+        {/each}
+      </tr>
+    {/each}
+  </tbody>
+</table>

--- a/src/components/aggregation/MatrixTabCard.svelte
+++ b/src/components/aggregation/MatrixTabCard.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  import type { Tab } from "../../lib/types";
+  import MatrixGtTable from "./MatrixGtTable.svelte";
+  import MatrixNaGtTable from "./MatrixNaGtTable.svelte";
+  import MatrixGtChart from "./MatrixGtChart.svelte";
+  import MatrixNaGtChart from "./MatrixNaGtChart.svelte";
+  import CrossTable from "./CrossTable.svelte";
+  import NaCrossTable from "./NaCrossTable.svelte";
+  import ChartCardBody from "./ChartCardBody.svelte";
+  import NaChartCardBody from "./NaChartCardBody.svelte";
+  import type { ChartOpts, TableOpts, ViewMode } from "./viewTypes";
+
+  interface MatrixItem {
+    gtTab: Tab;
+    crossTabs: Tab[];
+  }
+
+  interface Props {
+    matrix: { key: string; label: string };
+    items: MatrixItem[];
+    viewMode: ViewMode;
+    tableOpts: TableOpts;
+    chartOpts: ChartOpts;
+  }
+
+  let { matrix, items, viewMode, tableOpts, chartOpts }: Props = $props();
+
+  let hasCross = $derived(items.some((it) => it.crossTabs.length > 0));
+  let firstType = $derived(items[0]?.gtTab.type ?? "SA");
+  let gtTabs = $derived(items.map((it) => it.gtTab));
+  let chartType = $derived(firstType === "MA" ? chartOpts.maChartType : chartOpts.saChartType);
+</script>
+
+<div
+  class="overflow-hidden rounded-xl border border-border bg-surface shadow-sm{hasCross
+    ? ' overflow-x-auto'
+    : ''}"
+>
+  <div class="flex items-baseline gap-3 border-b border-border p-4">
+    <div class="flex min-w-0 flex-col gap-0.5">
+      <span class="text-sm font-bold text-accent">{matrix.label}</span>
+      <span class="text-xs tracking-wide text-muted">{matrix.key}</span>
+    </div>
+    <span class="text-xs tracking-wide text-muted">{firstType} MATRIX</span>
+  </div>
+
+  {#if viewMode === "chart"}
+    {#if hasCross}
+      <div class="divide-y divide-border">
+        {#each items as it (it.gtTab.questionCode)}
+          <div>
+            <div class="bg-surface2 px-4 py-2 text-xs font-bold text-muted">
+              {it.gtTab.label}
+              <span class="ml-2 text-muted">({it.gtTab.questionCode})</span>
+            </div>
+            {#if it.gtTab.type === "NA"}
+              <NaChartCardBody
+                tab={it.gtTab}
+                crossTabs={it.crossTabs}
+                paletteId={chartOpts.paletteId}
+              />
+            {:else}
+              <ChartCardBody
+                tab={it.gtTab}
+                crossTabs={it.crossTabs}
+                tabChartType={it.gtTab.type === "SA"
+                  ? chartOpts.saChartType
+                  : chartOpts.maChartType}
+                paletteId={chartOpts.paletteId}
+              />
+            {/if}
+          </div>
+        {/each}
+      </div>
+    {:else if firstType === "NA"}
+      <MatrixNaGtChart tabs={gtTabs} paletteId={chartOpts.paletteId} />
+    {:else}
+      <MatrixGtChart tabs={gtTabs} {chartType} paletteId={chartOpts.paletteId} />
+    {/if}
+  {:else if hasCross}
+    <div class="divide-y divide-border">
+      {#each items as it (it.gtTab.questionCode)}
+        <div>
+          <div class="bg-surface2 px-4 py-2 text-xs font-bold text-muted">
+            {it.gtTab.label}
+            <span class="ml-2 text-muted">({it.gtTab.questionCode})</span>
+          </div>
+          {#if it.gtTab.type === "NA"}
+            <NaCrossTable tab={it.gtTab} crossTabs={it.crossTabs} />
+          {:else}
+            <CrossTable tab={it.gtTab} crossTabs={it.crossTabs} basis={tableOpts.basis} />
+          {/if}
+        </div>
+      {/each}
+    </div>
+  {:else if firstType === "NA"}
+    <MatrixNaGtTable tabs={gtTabs} />
+  {:else}
+    <MatrixGtTable tabs={gtTabs} />
+  {/if}
+</div>

--- a/src/components/aggregation/ResultPanel.svelte
+++ b/src/components/aggregation/ResultPanel.svelte
@@ -3,6 +3,7 @@
   import type { Tab } from "../../lib/types";
   import Toolbar from "./Toolbar.svelte";
   import TabCard from "./TabCard.svelte";
+  import MatrixTabCard from "./MatrixTabCard.svelte";
   import AIBubble from "./AIBubble.svelte";
   import { t } from "../../lib/i18n.svelte";
   import type { Basis, ChartType, ViewMode } from "./viewTypes";
@@ -45,6 +46,37 @@
   let questionCodes = $derived(tabs ? [...new Set(tabs.map((tab) => tab.questionCode))] : []);
   let hasCross = $derived(tabs?.some((tab) => tab.by !== null) ?? false);
 
+  type RenderItem =
+    | { kind: "single"; questionCode: string }
+    | {
+        kind: "matrix";
+        matrix: { key: string; label: string };
+        questionCodes: string[];
+      };
+
+  let renderItems = $derived.by<RenderItem[]>(() => {
+    if (!tabs) return [];
+    const gtByCode = new Map<string, Tab>();
+    for (const tab of tabs) {
+      if (tab.by === null) gtByCode.set(tab.questionCode, tab);
+    }
+    const emittedMatrix = new Set<string>();
+    const items: RenderItem[] = [];
+    for (const code of questionCodes) {
+      const gt = gtByCode.get(code);
+      const mx = gt?.matrix;
+      if (mx) {
+        if (emittedMatrix.has(mx.key)) continue;
+        emittedMatrix.add(mx.key);
+        const children = questionCodes.filter((c) => gtByCode.get(c)?.matrix?.key === mx.key);
+        items.push({ kind: "matrix", matrix: mx, questionCodes: children });
+      } else {
+        items.push({ kind: "single", questionCode: code });
+      }
+    }
+    return items;
+  });
+
   let maxPct = $derived(
     Math.max(
       ...(tabs
@@ -77,14 +109,27 @@
         {callbacks}
       />
       <div class={gridClass}>
-        {#each questionCodes as q (q)}
-          <TabCard
-            tab={tabs.find((tab) => tab.questionCode === q && tab.by === null)!}
-            crossTabs={tabs.filter((tab) => tab.questionCode === q && tab.by !== null)}
-            {viewMode}
-            {tableOpts}
-            {chartOpts}
-          />
+        {#each renderItems as item (item.kind === "matrix" ? `m:${item.matrix.key}` : `s:${item.questionCode}`)}
+          {#if item.kind === "matrix"}
+            <MatrixTabCard
+              matrix={item.matrix}
+              items={item.questionCodes.map((c) => ({
+                gtTab: tabs.find((tab) => tab.questionCode === c && tab.by === null)!,
+                crossTabs: tabs.filter((tab) => tab.questionCode === c && tab.by !== null),
+              }))}
+              {viewMode}
+              {tableOpts}
+              {chartOpts}
+            />
+          {:else}
+            <TabCard
+              tab={tabs.find((tab) => tab.questionCode === item.questionCode && tab.by === null)!}
+              crossTabs={tabs.filter((tab) => tab.questionCode === item.questionCode && tab.by !== null)}
+              {viewMode}
+              {tableOpts}
+              {chartOpts}
+            />
+          {/if}
         {/each}
       </div>
       <AIBubble {tabs} {weightCol} />

--- a/src/lib/agg/buildTabs.ts
+++ b/src/lib/agg/buildTabs.ts
@@ -13,10 +13,11 @@ export async function buildTabs(
   questions: Question[],
   crossQuestions: Question[],
   weightCol: string,
+  matrixLabels: Record<string, string> = {},
 ): Promise<Tab[]> {
   const tabs: Tab[] = [];
   for (const q of questions) {
-    const qTabs = await buildTabsFor(conn, q, crossQuestions, weightCol);
+    const qTabs = await buildTabsFor(conn, q, crossQuestions, weightCol, matrixLabels);
     tabs.push(...qTabs);
   }
   return tabs;
@@ -27,27 +28,33 @@ async function buildTabsFor(
   q: Question,
   crossQuestions: Question[],
   weightCol: string,
+  matrixLabels: Record<string, string>,
 ): Promise<Tab[]> {
   const tabs: Tab[] = [];
   if (q.type === "NA") {
     const tabOutput = await aggNaTab(conn, q.columns[0], weightCol);
-    tabs.push(assembleTab(q, tabOutput));
+    tabs.push(assembleTab(q, tabOutput, matrixLabels));
     for (const axisQuestion of crossQuestions) {
       const crossOutput = await aggNaCrossTab(conn, q.columns[0], axisQuestion, weightCol);
-      tabs.push(assembleTab(q, crossOutput, axisQuestion));
+      tabs.push(assembleTab(q, crossOutput, matrixLabels, axisQuestion));
     }
   } else {
     const tabOutput = await aggTab(conn, q, weightCol);
-    tabs.push(assembleTab(q, tabOutput));
+    tabs.push(assembleTab(q, tabOutput, matrixLabels));
     for (const axisQuestion of crossQuestions) {
       const crossOutput = await aggCrossTab(conn, q, axisQuestion, weightCol);
-      tabs.push(assembleTab(q, crossOutput, axisQuestion));
+      tabs.push(assembleTab(q, crossOutput, matrixLabels, axisQuestion));
     }
   }
   return tabs;
 }
 
-function assembleTab(question: Question, tabData: TabData, axisQuestion?: Question): Tab {
+function assembleTab(
+  question: Question,
+  tabData: TabData,
+  matrixLabels: Record<string, string>,
+  axisQuestion?: Question,
+): Tab {
   return {
     questionCode: question.code,
     type: question.type,
@@ -56,6 +63,9 @@ function assembleTab(question: Question, tabData: TabData, axisQuestion?: Questi
     codes: tabData.codes,
     by: axisQuestion ? buildAxis(tabData, axisQuestion) : null,
     slices: tabData.slices,
+    matrix: question.matrixKey
+      ? { key: question.matrixKey, label: matrixLabels[question.matrixKey] ?? question.matrixKey }
+      : null,
   };
 }
 

--- a/src/lib/duckdb.svelte.ts
+++ b/src/lib/duckdb.svelte.ts
@@ -135,9 +135,10 @@ export async function runAggregation(
   questions: Question[],
   crossQuestions: Question[],
   weightCol: string,
+  matrixLabels: Record<string, string> = {},
 ): Promise<Tab[]> {
   const { conn } = await requireDuckDB();
-  return buildTabs(conn, questions, crossQuestions, weightCol);
+  return buildTabs(conn, questions, crossQuestions, weightCol, matrixLabels);
 }
 
 /** Prepare DATE columns in layout (convert to SA with auto-generated items) */

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -262,6 +262,28 @@ export function findWeightColumn(layout: Layout): string {
   return layout.find((e) => e.type === "WEIGHT")?.key ?? "";
 }
 
+export interface MatrixGroup {
+  matrixKey: string;
+  matrixLabel: string;
+  questionCodes: string[];
+}
+
+/** Build groups of matrix children keyed by MATRIX parent, preserving layout order */
+export function buildMatrixGroups(layout: Layout): MatrixGroup[] {
+  return layout
+    .filter((e): e is Extract<LayoutQuestion, { type: "MATRIX" }> => e.type === "MATRIX")
+    .map((parent) => ({
+      matrixKey: parent.key,
+      matrixLabel: parent.label,
+      questionCodes: layout
+        .filter(
+          (e) =>
+            (e.type === "SA" || e.type === "MA" || e.type === "NA") && e.matrixKey === parent.key,
+        )
+        .map((e) => e.key),
+    }));
+}
+
 /** Count total layout-defined columns (SA: 1 each, MA: items count, WEIGHT: 1, MATRIX: 0) */
 export function countLayoutColumns(layout: Layout): number {
   return layout.reduce(

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -46,4 +46,5 @@ export interface Tab {
   codes: string[];
   labels: Record<string, string>;
   slices: Slice[];
+  matrix: { key: string; label: string } | null;
 }

--- a/tests/aiComment.test.ts
+++ b/tests/aiComment.test.ts
@@ -23,6 +23,7 @@ function makeTab(overrides: Partial<Tab> = {}): Tab {
         ],
       },
     ],
+    matrix: null,
     ...overrides,
   };
 }

--- a/tests/export.test.ts
+++ b/tests/export.test.ts
@@ -167,6 +167,7 @@ describe("formatCSV", () => {
       codes: ["1"],
       by: null,
       slices: [{ code: null, n: 10, cells: [{ count: 10, pct: 100 }] }],
+      matrix: null,
     };
     const csv = formatCSV([tab]);
     expect(csv).toContain('""quotes""');
@@ -181,6 +182,7 @@ describe("formatCSV", () => {
       codes: ["1"],
       by: null,
       slices: [{ code: null, n: 5, cells: [{ count: 5, pct: 100 }] }],
+      matrix: null,
     };
     const csv = formatCSV([tab]);
     expect(csv).toContain('"A, B"');
@@ -195,6 +197,7 @@ describe("formatCSV", () => {
       codes: ["1"],
       by: null,
       slices: [{ code: null, n: 5, cells: [{ count: 5, pct: 100 }] }],
+      matrix: null,
     };
     const csv = formatCSV([tab]);
     expect(csv).toContain('"line1\nline2"');
@@ -243,6 +246,7 @@ describe("formatMarkdown", () => {
       codes: ["1"],
       by: null,
       slices: [{ code: null, n: 5, cells: [{ count: 5, pct: 100 }] }],
+      matrix: null,
     };
     const md = formatMarkdown([tab]);
     expect(md).toContain(String.raw`A\|B`);

--- a/tests/helpers/tabFixtures.ts
+++ b/tests/helpers/tabFixtures.ts
@@ -18,6 +18,7 @@ export const SA_GT: Tab = {
       ],
     },
   ],
+  matrix: null,
 };
 
 // ─── MA Grand Total ─────────────────────────────────────────
@@ -39,6 +40,7 @@ export const MA_GT: Tab = {
       ],
     },
   ],
+  matrix: null,
 };
 
 // ─── NA Grand Total ─────────────────────────────────────────
@@ -57,6 +59,7 @@ export const NA_GT: Tab = {
       stats: { n: 8, mean: 3.5, median: 3, sd: 1.2, min: 1, max: 6 },
     },
   ],
+  matrix: null,
 };
 
 // ─── SA Cross ───────────────────────────────────────────────
@@ -93,6 +96,7 @@ export const SA_CROSS: Tab[] = [
         ],
       },
     ],
+    matrix: null,
   },
 ];
 
@@ -126,6 +130,7 @@ export const NA_CROSS: Tab[] = [
         stats: { n: 4, mean: 3.0, median: 3, sd: 1.4, min: 1, max: 6 },
       },
     ],
+    matrix: null,
   },
 ];
 

--- a/tests/layout.test.ts
+++ b/tests/layout.test.ts
@@ -5,6 +5,7 @@ import {
   buildValidLayout,
   filterLayout,
   buildQuestions,
+  buildMatrixGroups,
   countLayoutColumns,
 } from "../src/lib/layout";
 import type { Layout } from "../src/lib/layout";
@@ -463,5 +464,41 @@ describe("countLayoutColumns — MATRIX", () => {
   it("counts MATRIX parent as 0 columns", () => {
     // q3: 0, q3a: 1, q3b: 1, q1: 1 = 3
     expect(countLayoutColumns(matrixLayout)).toBe(3);
+  });
+});
+
+describe("buildMatrixGroups", () => {
+  it("returns empty array when layout has no MATRIX entries", () => {
+    expect(buildMatrixGroups(layout)).toEqual([]);
+  });
+
+  it("builds a single group with child codes in layout order", () => {
+    expect(buildMatrixGroups(matrixLayout)).toEqual([
+      {
+        matrixKey: "q3",
+        matrixLabel: "Satisfaction matrix",
+        questionCodes: ["q3a", "q3b"],
+      },
+    ]);
+  });
+
+  it("handles multiple MATRIX parents independently", () => {
+    const multi: Layout = [
+      { key: "m1", label: "M1", type: "MATRIX" },
+      {
+        key: "m1a",
+        label: "A",
+        type: "SA",
+        matrixKey: "m1",
+        items: [{ code: "1", label: "x" }],
+      },
+      { key: "m2", label: "M2", type: "MATRIX" },
+      { key: "m2a", label: "B", type: "NA", matrixKey: "m2" },
+      { key: "m2b", label: "C", type: "NA", matrixKey: "m2" },
+    ];
+    expect(buildMatrixGroups(multi)).toEqual([
+      { matrixKey: "m1", matrixLabel: "M1", questionCodes: ["m1a"] },
+      { matrixKey: "m2", matrixLabel: "M2", questionCodes: ["m2a", "m2b"] },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- PR #250（取り込み層）の上にスタック。base は `feat/matrix-layout-import`
- MATRIX 子設問の集計結果を **1 枚のカードにまとめて表示** する UI を追加
- `Tab` に `matrix: { key; label } \| null` を追加し、表示側が `Tab[]` だけでグルーピング判定できるように配線
- エクスポートは **意図的に変更しない**（Python 等での後段処理のしやすさのためフラットな子グリッドを維持）

## 主な変更

### データ層 (1 コミット目)

- `Tab.matrix: { key; label } \| null`（approach Y）
- `buildMatrixGroups(layout)` ヘルパーと `MatrixGroup` 型を `layout.ts` に追加
- `buildTabs` / `runAggregation` に `matrixLabels: Record<string, string>` を渡し、`assembleTab` で `Tab.matrix` を焼き込み
- `AggregationScreen.svelte` が `buildMatrixGroups` から label map を組み立てて渡す
- `Question.matrixKey: string \| null` は変更なし（集計層は label 不要）
- 既存の `Tab` リテラル（fixtures / export test / aiComment test）に `matrix: null` を補記
- layout テストに `buildMatrixGroups` の 3 件を追加

### 表示層 (2 コミット目)

- `ResultPanel.svelte`: `Tab.matrix` を見て renderItems を組み立て、MATRIX 子を順序保持でグルーピング
- `MatrixTabCard.svelte` (新規): 外枠 + body ディスパッチャ（viewMode × hasCross × 子 type）
- `MatrixGtTable.svelte` (新規): GT SA/MA 用。行=子、列= n + 共通選択肢の %
- `MatrixNaGtTable.svelte` (新規): GT NA 用。行=子、列= n / mean / median / sd / min / max
- `MatrixGtChart.svelte` (新規): GT SA/MA 用
  - `bar-v` / `bar-h`: **選択肢ごとにグループ化**した grouped bar（バー群 = 子設問）
  - `obi`: 子設問ごとに 1 本の帯（`buildCrossChart` と同型）
- `MatrixNaGtChart.svelte` (新規): GT NA 用
  - **共通 `binWidth` スライダー** で全子を同じ階級幅に binning
  - **bin = グループ、子 = バー**のグループ化 bar
- cross / chart×cross モードは `MatrixTabCard` 内で子ごとに小見出し + 既存 `CrossTable` / `NaCrossTable` / `ChartCardBody` / `NaChartCardBody` を縦並びで再利用

### スコープ外（確定）

- **エクスポートは変更しない** — 子設問ごとに独立した grid として書き出すフラット構造を維持

## 参考

- PR #142 の設計（`MatrixResultCard` / 同一選択肢の GT マトリクステーブル / 子設問ごとの cross 表示）を現在の Svelte 5 / Tailwind v4 / DuckDB-Wasm 構成に移植
- PR #250 の import 層（`matrixKey` + `MATRIX` 親 + 孤児除去）を前提とする

## Test plan

- [x] `vp check` クリーン（新規警告なし）
- [x] `vp test run` 1862 件通過（layout テスト 48 件、うち MATRIX 系 16 件）
- [x] ブラウザで q3 マトリクスを GT 表 / GT bar-h / GT obi / 性別クロス表 の 4 モード目視確認（サンプル `public/samples/sample_layout.json` の q3a〜q3d）
- [ ] NA マトリクスの GT 表 / GT チャート（サンプルにないため別 layout で確認が必要）

## Stacking note

このブランチは `feat/matrix-layout-import` (PR #250) をベースにスタックしています。#250 がマージされた後、base を `develop` に切り替えてください（または #250 を先にマージしてから PR を作り直してください）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)