### PR TITLE
fix(na): NA設問のn値を丸めて表示

### DIFF
--- a/src/components/aggregation/NaChartCardBody.svelte
+++ b/src/components/aggregation/NaChartCardBody.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { Tab, Cell } from "../../lib/types";
   import { Chart, getSeriesColor, getThemeColors, type PaletteId } from "../../lib/chartConfig";
+  import { formatN } from "../../lib/format";
   import { t } from "../../lib/i18n.svelte";
   import type { ChartConfiguration } from "chart.js";
 
@@ -137,7 +138,7 @@
           legend: { display: false },
           title: {
             display: true,
-            text: `n=${sliceStats.n}  ${t("na.stat.mean")}=${sliceStats.mean?.toFixed(2) ?? "-"}  SD=${sliceStats.sd?.toFixed(2) ?? "-"}`,
+            text: `n=${formatN(sliceStats.n)}  ${t("na.stat.mean")}=${sliceStats.mean?.toFixed(2) ?? "-"}  SD=${sliceStats.sd?.toFixed(2) ?? "-"}`,
             color: theme.muted,
             font: { size: 12, weight: "normal" },
           },

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -6,6 +6,6 @@ export function formatN(n: number): string {
 /** NA統計値をフォーマット: null→"-", n→整数, 他→小数2桁 */
 export function formatStat(key: string, value: number | null): string {
   if (value === null) return "-";
-  if (key === "n") return `${value}`;
+  if (key === "n") return formatN(value);
   return value.toFixed(2);
 }


### PR DESCRIPTION
## Summary
- ウェイト適用時に GT/Cross/Matrix の NA 設問の n 値が `169.8400000000001` のように浮動小数誤差まで表示されていた
- `formatStat` の `n` 分岐で `formatN` を通すことで、整数はそのまま・小数は小数点1桁に丸めて表示
- NA チャートのタイトル `n=...` も同じく `formatN` で整形

## Test plan
- [ ] ウェイト列を有効化して NA 設問を含むデータで集計を実行し、n 値が `169.8` のように丸められて表示されることを確認
- [ ] ウェイトなし（整数 n）の場合は従来通り整数表示されることを確認
- [ ] GT・Cross・Matrix・NA チャートタイトルすべてで反映されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)