### PR TITLE
fix(aggregation): NA チャート下部が欠ける問題を修正

### DIFF
--- a/src/components/aggregation/MatrixNaGtChart.svelte
+++ b/src/components/aggregation/MatrixNaGtChart.svelte
@@ -140,7 +140,7 @@
   }
 </script>
 
-<div class="h-[400px] p-4">
+<div class="flex h-[400px] flex-col p-4">
   {#if range > 0}
     <div class="mb-2 flex items-center justify-end gap-2 text-xs text-muted-foreground">
       <label>
@@ -150,5 +150,7 @@
       <span class="w-6 text-center tabular-nums">{binWidth || "–"}</span>
     </div>
   {/if}
-  <canvas bind:this={canvas}></canvas>
+  <div class="relative flex-1 min-h-0">
+    <canvas bind:this={canvas}></canvas>
+  </div>
 </div>

--- a/src/components/aggregation/NaChartCardBody.svelte
+++ b/src/components/aggregation/NaChartCardBody.svelte
@@ -221,7 +221,7 @@
   }
 </script>
 
-<div class="p-4 {isCross ? 'h-[400px]' : 'h-80'}">
+<div class="flex flex-col p-4 {isCross ? 'h-[400px]' : 'h-80'}">
   {#if !isCross && range > 0}
     <div class="flex items-center justify-end gap-2 mb-2 text-xs text-muted-foreground">
       <label>
@@ -238,5 +238,7 @@
       <span class="w-6 text-center tabular-nums">{binWidth || "–"}</span>
     </div>
   {/if}
-  <canvas bind:this={canvas}></canvas>
+  <div class="relative flex-1 min-h-0">
+    <canvas bind:this={canvas}></canvas>
+  </div>
 </div>


### PR DESCRIPTION
## Summary
- GT の NA 設問カードで、階級幅スライダー行が親の固定高さを食うため、Chart.js の canvas 描画領域が不足し下端が欠けて見えていた
- 親を `flex flex-col` にし、canvas を `relative flex-1 min-h-0` のラッパに入れて、スライダー行ぶんを自動で差し引くよう変更
- 単一 NA (`NaChartCardBody.svelte`) とマトリックス NA (`MatrixNaGtChart.svelte`) の両方を修正

## Test plan
- [ ] 集計画面で NA 設問を GT 集計し、カード下部が欠けずに描画されることを確認
- [ ] 階級幅スライダーを動かしても canvas のサイズが親の残余高さに追従すること
- [ ] NA クロス集計 (`h-[400px]`) のカードが従来通り表示されること
- [ ] マトリックス NA 設問の GT チャートが正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)