### PR TITLE
feat: GT 単問のテーブル/チャート切替をやめて数直線バーに

### DIFF
--- a/src/components/aggregation/ResultPanel.svelte
+++ b/src/components/aggregation/ResultPanel.svelte
@@ -77,15 +77,7 @@
     return items;
   });
 
-  let maxPct = $derived(
-    Math.max(
-      ...(tabs
-        ?.filter((tab) => tab.by === null && tab.type !== "NA")
-        .flatMap((tab) => tab.slices[0]?.cells.map((c) => c.pct ?? 0) ?? []) ?? []),
-      0,
-    ),
-  );
-  let tableOpts = $derived({ basis, maxPct });
+  let tableOpts = $derived({ basis });
   let chartOpts = $derived({ saChartType, maChartType, paletteId });
 
   let minWidth = $derived(viewMode === "chart" ? "400px" : "360px");

--- a/src/components/aggregation/TabCard.svelte
+++ b/src/components/aggregation/TabCard.svelte
@@ -58,6 +58,6 @@
       <CrossTable {tab} {crossTabs} basis={tableOpts.basis} />
     {/if}
   {:else}
-    <TabTable {tab} maxPct={tableOpts.maxPct} />
+    <TabTable {tab} />
   {/if}
 </div>

--- a/src/components/aggregation/TabCard.svelte
+++ b/src/components/aggregation/TabCard.svelte
@@ -38,25 +38,25 @@
     <span class="ml-auto text-xs text-muted">n={formatN(tabN)}</span>
   </div>
 
-  {#if viewMode === "chart"}
-    {#if isNA}
+  {#if isNA}
+    {#if viewMode === "chart"}
       <NaChartCardBody {tab} {crossTabs} paletteId={chartOpts.paletteId} />
+    {:else if hasCross}
+      <NaCrossTable {tab} {crossTabs} />
     {:else}
+      <NaTabTable {tab} />
+    {/if}
+  {:else if hasCross}
+    {#if viewMode === "chart"}
       <ChartCardBody
         {tab}
         {crossTabs}
         tabChartType={tab.type === "SA" ? chartOpts.saChartType : chartOpts.maChartType}
         paletteId={chartOpts.paletteId}
       />
-    {/if}
-  {:else if isNA}
-    {#if hasCross}
-      <NaCrossTable {tab} {crossTabs} />
     {:else}
-      <NaTabTable {tab} />
+      <CrossTable {tab} {crossTabs} basis={tableOpts.basis} />
     {/if}
-  {:else if hasCross}
-    <CrossTable {tab} {crossTabs} basis={tableOpts.basis} />
   {:else}
     <TabTable {tab} maxPct={tableOpts.maxPct} />
   {/if}

--- a/src/components/aggregation/TabTable.svelte
+++ b/src/components/aggregation/TabTable.svelte
@@ -7,10 +7,9 @@
 
   interface Props {
     tab: Tab;
-    maxPct: number;
   }
 
-  let { tab, maxPct }: Props = $props();
+  let { tab }: Props = $props();
 
   let slice = $derived(tab.slices[0]);
 </script>
@@ -33,7 +32,7 @@
       {@const label = tab.labels[code]}
       {@const countStr = formatN(cell.count)}
       {@const pct = cell.pct ?? 0}
-      {@const barWidthPct = ((pct / Math.max(maxPct, 1)) * 100).toFixed(1)}
+      {@const barWidthPct = pct.toFixed(1)}
       <tr>
         <Td>{label}</Td>
         <Td right mono>{countStr}</Td>

--- a/src/components/aggregation/TabTable.svelte
+++ b/src/components/aggregation/TabTable.svelte
@@ -33,17 +33,17 @@
       {@const label = tab.labels[code]}
       {@const countStr = formatN(cell.count)}
       {@const pct = cell.pct ?? 0}
-      {@const barWidth = ((pct / Math.max(maxPct, 1)) * 72).toFixed(1)}
+      {@const barWidthPct = ((pct / Math.max(maxPct, 1)) * 100).toFixed(1)}
       <tr>
         <Td>{label}</Td>
         <Td right mono>{countStr}</Td>
         <Td right mono class="text-muted">
           {cell.pct !== null ? cell.pct.toFixed(1) + "%" : "-"}
         </Td>
-        <td class="py-3 pr-4 pl-0 border-b border-row-border w-20" aria-hidden="true">
+        <td class="py-3 pr-4 pl-0 border-b border-row-border w-full" aria-hidden="true">
           <div
             class="h-1.5 bg-accent rounded transition-[width] duration-[400ms] opacity-80"
-            style:width="{barWidth}px"
+            style:width="{barWidthPct}%"
           ></div>
         </td>
       </tr>

--- a/src/components/aggregation/TabTable.svelte
+++ b/src/components/aggregation/TabTable.svelte
@@ -18,12 +18,22 @@
   <caption class="sr-only">{t("table.caption.tab", { question: tab.label })}</caption>
   <thead>
     <tr>
-      <Th>{t("table.option")}</Th>
+      <Th class="w-64 min-w-64">{t("table.option")}</Th>
       <Th right>n</Th>
       <Th right>%</Th>
-      <Th aria-hidden="true">
-        <span class="sr-only">{t("table.graph")}</span>
-      </Th>
+      <th
+        class="border-b-2 border-l border-border-strong bg-surface py-3 pr-4 pl-4 align-bottom text-[10px] font-normal text-muted"
+        aria-hidden="true"
+      >
+        <div class="relative h-3">
+          <span class="absolute top-0 left-0">0</span>
+          <span class="absolute top-0 -translate-x-1/2" style:left="20%">20</span>
+          <span class="absolute top-0 -translate-x-1/2" style:left="40%">40</span>
+          <span class="absolute top-0 -translate-x-1/2" style:left="60%">60</span>
+          <span class="absolute top-0 -translate-x-1/2" style:left="80%">80</span>
+          <span class="absolute top-0 right-0">100</span>
+        </div>
+      </th>
     </tr>
   </thead>
   <tbody class="[&_tr:hover_td]:bg-row-hover [&_tr:last-child_td]:border-b-0">
@@ -39,7 +49,13 @@
         <Td right mono class="text-muted">
           {cell.pct !== null ? cell.pct.toFixed(1) + "%" : "-"}
         </Td>
-        <td class="py-3 pr-4 pl-0 border-b border-row-border w-full" aria-hidden="true">
+        <td
+          class="border-b border-l border-row-border w-full px-4 py-3"
+          aria-hidden="true"
+          style:background-image="repeating-linear-gradient(to right, transparent 0 calc(20% - 1px), var(--border-strong) calc(20% - 1px) 20%)"
+          style:background-origin="content-box"
+          style:background-clip="content-box"
+        >
           <div
             class="h-1.5 bg-accent rounded transition-[width] duration-[400ms] opacity-80"
             style:width="{barWidthPct}%"

--- a/src/components/aggregation/TabTable.svelte
+++ b/src/components/aggregation/TabTable.svelte
@@ -18,7 +18,7 @@
   <caption class="sr-only">{t("table.caption.tab", { question: tab.label })}</caption>
   <thead>
     <tr>
-      <Th class="w-64 min-w-64">{t("table.option")}</Th>
+      <Th class="min-w-60">{t("table.option")}</Th>
       <Th right>n</Th>
       <Th right>%</Th>
       <th

--- a/src/components/aggregation/Toolbar.svelte
+++ b/src/components/aggregation/Toolbar.svelte
@@ -40,22 +40,25 @@
     {t("result.meta", { count: questionCount, weight: weightText })}
   </span>
 
-  <ToggleGroup class="ml-auto">
-    <ToggleButton
-      active={currentViewMode === "table"}
-      onclick={() => currentViewMode !== "table" && callbacks.onViewModeChange("table")}
-    >
-      {t("result.view.table")}
-    </ToggleButton>
-    <ToggleButton
-      active={currentViewMode === "chart"}
-      onclick={() => currentViewMode !== "chart" && callbacks.onViewModeChange("chart")}
-    >
-      {t("result.view.chart")}
-    </ToggleButton>
-  </ToggleGroup>
+  <div class="ml-auto flex items-center gap-4">
+    {#if hasCross}
+      <ToggleGroup>
+        <ToggleButton
+          active={currentViewMode === "table"}
+          onclick={() => currentViewMode !== "table" && callbacks.onViewModeChange("table")}
+        >
+          {t("result.view.table")}
+        </ToggleButton>
+        <ToggleButton
+          active={currentViewMode === "chart"}
+          onclick={() => currentViewMode !== "chart" && callbacks.onViewModeChange("chart")}
+        >
+          {t("result.view.chart")}
+        </ToggleButton>
+      </ToggleGroup>
+    {/if}
 
-  {#if hasDetailSettings}
+    {#if hasDetailSettings}
     <div
       class="relative"
       {@attach clickOutside({ onClose: () => (detailOpen = false) })}
@@ -187,5 +190,6 @@
     </div>
   {/if}
 
-  <ExportMenu onExport={(action: ExportAction) => executeExport(action, tabs, weightCol)} />
+    <ExportMenu onExport={(action: ExportAction) => executeExport(action, tabs, weightCol)} />
+  </div>
 </div>

--- a/src/components/aggregation/viewTypes.ts
+++ b/src/components/aggregation/viewTypes.ts
@@ -6,7 +6,6 @@ export type Basis = "column" | "row";
 
 export interface TableOpts {
   basis: Basis;
-  maxPct: number;
 }
 
 export interface ChartOpts {


### PR DESCRIPTION
## Summary
- 単問 GT (非クロス・非NA・非MATRIX) を「テーブル + 行内横棒バー」固定に。バー列を可変幅にし、最大値 100% 固定で 0/20/40/60/80/100 の目盛を描画
- Table/Chart トグルはクロス選択時のみ表示（GT のみの集計ではトグルが消える）
- Option 列に `min-w-60` を付与し、設問間でバー幅が揃うように

## Background
選択肢が少ない GT 設問 (Option/n/%/バー 4 列) では `w-full` のテーブルが間延びして見えていた。また Table と Chart ビューで選択肢ラベルが二重表示になる冗長さもあり、「GT は常にテーブル + バー可視化で一体化」方針に変更。バー列をチャート化することで数値比較もしやすくなる。

## Changes
- `TabTable.svelte`
  - バー列を `w-full` (可変幅) に変更し、テーブル stretch を吸収
  - バー幅を `(pct/maxPct) * 72px` → `pct%` (絶対比率・100% 固定) に
  - ヘッダに 0/20/40/60/80/100 の目盛ラベル、バーセル背景に 20% 刻みの縦罫線
  - テーブル列と数直線列の境目に `border-l` で視覚分離
  - Option 列に `min-w-60` を付与
- `TabCard.svelte` — 分岐を NA → cross → 単問GT の順に整理。単問 GT は viewMode を無視して常に TabTable
- `Toolbar.svelte` — Table/Chart トグルを `{#if hasCross}` で囲み、右寄せ要素をラッパで再配置
- `ResultPanel.svelte` / `viewTypes.ts` — 不要になった `maxPct` 導出と `TableOpts.maxPct` を削除

## Test plan
- [x] `vp check` (0 errors)
- [x] `vp test run` (1862 passed)
- [x] ブラウザで GT のみ → トグル非表示・行内バー表示を確認
- [x] ブラウザでクロス軸選択 → トグル復活・クロスカードに作用することを確認
- [x] ブラウザで MATRIX / NA 併存時も単問 GT カードは常にテーブルを確認
- [x] バー幅がカード間で揃うことを確認（`min-w-60` 効果）

🤖 Generated with [Claude Code](https://claude.com/claude-code)