### PR TITLE
chore: add v0.3.0 changelog entry

### DIFF
--- a/src/lib/changelog.json
+++ b/src/lib/changelog.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "0.3.0",
+    "date": "2026-04-18",
+    "changes": [
+      {
+        "ja": "MATRIX 型レイアウトの取り込み・集計表示に対応",
+        "en": "Add MATRIX layout import and aggregation display"
+      }
+    ]
+  },
+  {
     "version": "0.2.0",
     "date": "2026-04-18",
     "changes": [


### PR DESCRIPTION
## Summary
- `src/lib/changelog.json` に v0.3.0 (2026-04-18) のエントリを追加
- MATRIX 型レイアウトの取り込み・集計表示対応を user-facing changelog に記載

## Test plan
- [ ] `vp dev` で Changelog モーダルに v0.3.0 の項目が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)