### PR TITLE
perf(import): OPFS save を画面遷移の critical path から外す

### DIFF
--- a/src/components/ImportScreen.svelte
+++ b/src/components/ImportScreen.svelte
@@ -180,21 +180,23 @@
   async function handleProceed() {
     if (!rawData || !layout) return;
     if (!loadedFromSaved && opfsPayload.layoutJson) {
-      try {
-        const rawDataText =
-          opfsPayload.rawDataText ?? (pendingRawDataFile ? await pendingRawDataFile.text() : null);
-        if (rawDataText) {
-          await saveData(
-            opfsPayload.rawDataFileName!,
-            rawDataText,
-            opfsPayload.layoutFileName!,
-            opfsPayload.layoutJson,
-          );
-          await refreshSavedFiles();
+      // Fire-and-forget: reading an 11MB File via .text() would block the screen transition ~100-200ms.
+      const fileName = opfsPayload.rawDataFileName!;
+      const layoutFileName = opfsPayload.layoutFileName!;
+      const layoutJson = opfsPayload.layoutJson;
+      const cachedText = opfsPayload.rawDataText;
+      const file = pendingRawDataFile;
+      void (async () => {
+        try {
+          const rawDataText = cachedText ?? (file ? await file.text() : null);
+          if (rawDataText) {
+            await saveData(fileName, rawDataText, layoutFileName, layoutJson);
+            await refreshSavedFiles();
+          }
+        } catch {
+          // OPFS save is best-effort
         }
-      } catch {
-        // OPFS save is best-effort
-      }
+      })();
     }
     const validLayout = buildValidLayout(layout.rawJson);
     const filtered = filterLayout(rawData.headers, validLayout);


### PR DESCRIPTION
## Summary

- `handleProceed` 内の OPFS save（`File.text()` で 11MB 読み込み → `saveData` 書き込み → `refreshSavedFiles`）を fire-and-forget 化
- 元々 `// OPFS save is best-effort` とコメントされていた通り失敗を握り潰す扱いなので、await で待つ必要なし
- opfsPayload / pendingRawDataFile はクリック時点の値をローカル変数にスナップショットしてから非同期 IIFE に渡し、以降の state 変化に影響されないようにしている

## 計測結果（dev サーバ, `both.csv` 10,000行 × 602列）

| マイルストーン           | Before（#256 マージ後） | After   | 差分 |
| ------------------------ | ---------------------- | ------- | ---- |
| 画面切替                 | 315 ms                 | 252 ms  | -63 ms |
| Run Aggregation ボタン   | 496 ms                 | 435 ms  | -61 ms |
| 最初の `<table>` 描画    | 824 ms                 | 767 ms  | -57 ms |

クリック → 画面切替は元々の 744ms から見ると累計 -66%。

## Test plan

- [x] `vp check`
- [x] `vp test run`（1862 tests）
- [x] OPFS に CSV + layout が background 保存されることを DevTools で手動確認（`navigator.storage.getDirectory()` で確認）
- [ ] 既存 e2e validation テスト（regression 防止）
- [ ] レビュー観点: fire-and-forget 中にユーザがタブを閉じた場合、保存は中断されるが元々 best-effort なので受容してよいか

🤖 Generated with [Claude Code](https://claude.com/claude-code)