### PR TITLE
chore: point Release Please at main branch

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "target-branch": "main",
   "packages": {
     ".": {
       "release-type": "simple",


### PR DESCRIPTION
## Summary
- \`release-please-config.json\` に \`target-branch: main\` を追加
- これにより Release Please が \`develop\` ではなく \`main\` 上で \`chore(main): release vX.Y.Z\` PR を生成するようになる
- CLAUDE.md に書かれている「release-pr.yml → develop→main マージ → Release Please PR on main → マージで tag/Release」の 2 段階フローが正しく動くようになる

## Background
- 現状 \`target-branch\` 未指定でデフォルトブランチ (= develop) が採用されていたため、PR #257 のように base=develop の release PR が生成されていた
- main=本番 / develop=ステージングの運用意図と噛み合っていなかった
- 孤児になった PR #257 は close + ブランチ削除済み

## Test plan
- [ ] merge 後、次の develop→main PR マージで Release Please が **main 側に** \`chore(main): release vX.Y.Z\` PR を作ることを確認
- [ ] その PR をマージすると \`vX.Y.Z\` tag と GitHub Release が生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)