### PR TITLE
fix(chart): クロス集計の棒グラフを100%固定スケールに

### DIFF
--- a/src/components/aggregation/ChartCardBody.svelte
+++ b/src/components/aggregation/ChartCardBody.svelte
@@ -222,6 +222,7 @@
         scales: {
           [isHorizontal ? "x" : "y"]: {
             beginAtZero: true,
+            max: 100,
             ticks: { color: theme.muted, callback: (v) => `${v}%` },
             grid: { color: theme.gridLine },
           },


### PR DESCRIPTION
## Summary
- クロス集計時の `bar` / `bar-h` チャートは % 軸が自動スケールで、タブごとに最大値が揃わず視覚的な比較がしづらかった
- `max: 100` を指定して固定スケール化 (obi は既に 100 固定)

## Test plan
- [ ] CSV/layout をインポートし、クロス設問を 1 つ以上選んで集計
- [ ] `bar` / `bar-h` 両方のチャートで Y/X 軸 が常に 0〜100% 表示されることを確認
- [ ] obi / 単純集計 (非cross) の表示が従来通りであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)