### PR TITLE
feat(aggregation): popover化 + 即時集計 + 設問TOC + sticky Toolbar

### DIFF
--- a/e2e/aggregation.spec.ts
+++ b/e2e/aggregation.spec.ts
@@ -16,8 +16,8 @@ test("ファイルアップロード → 検証 → 集計画面遷移", async (
   // 検証 → 集計画面へ進む
   await proceedToAggregation(page);
 
-  // 集計画面の「集計を実行」ボタンが表示される
-  await expect(page.getByRole("button", { name: /集計を実行/ })).toBeVisible();
+  // 集計画面の「集計設定」ボタンが表示される
+  await expect(page.getByRole("button", { name: /集計設定を開く/ })).toBeVisible();
 });
 
 test("GT集計結果の自動表示", async ({ page }) => {
@@ -46,16 +46,16 @@ test("クロス集計", async ({ page }) => {
     timeout: 30_000,
   });
 
-  // クロス集計軸セクションから q1 のチェックボックスを ON
+  // 集計設定ボタンを押して popover を開く
+  await page.getByRole("button", { name: /集計設定を開く/ }).click();
+
+  // popover 内の最初のチェックボックス（q1 = 性別）を ON
   const crossAxisGroup = page.getByRole("group", {
     name: /クロス集計軸の選択/,
   });
   await crossAxisGroup.getByRole("checkbox").first().check();
 
-  // 集計を実行
-  await page.getByRole("button", { name: /集計を実行/ }).click();
-
-  // クロス集計ヘッダー（「性別」列ヘッダー）がテーブル内に表示されること
+  // 即時集計でクロスヘッダー（「性別」列ヘッダー）がテーブル内に表示されること
   const crossHeader = page.locator("table th", { hasText: "性別" });
   await expect(crossHeader.first()).toBeVisible({ timeout: 30_000 });
 });

--- a/src/components/AggregationScreen.svelte
+++ b/src/components/AggregationScreen.svelte
@@ -35,23 +35,30 @@
     crossSelected = sel;
   });
 
-  async function handleRunAggregation(): Promise<void> {
-    errorMsg = "";
+  // Increments per scheduled run; only the latest run is allowed to commit results
+  let latestRunId = 0;
+
+  async function handleRunAggregation(runId: number): Promise<void> {
     const activeWeightCol = weightEnabled ? weightColumnName : "";
     const crossQuestions = questions.filter((q) => crossSelected[q.code]);
 
     try {
       const tabs = await runAggregation(questions, crossQuestions, activeWeightCol, matrixLabels);
+      if (runId !== latestRunId) return;
       aggResult = { tabs, weightCol: activeWeightCol };
+      errorMsg = "";
     } catch (e) {
+      if (runId !== latestRunId) return;
       errorMsg = t("error.aggregation", { msg: (e as Error).message });
     }
   }
 
-  // Auto-run aggregation whenever cross selection or weight toggle changes
+  // Auto-run aggregation whenever cross selection or weight toggle changes.
+  // A monotonic runId is captured per scheduling; older runs that finish later are dropped.
   $effect(() => {
     if (questions.length === 0) return;
-    void handleRunAggregation();
+    const runId = ++latestRunId;
+    void handleRunAggregation(runId);
   });
 </script>
 

--- a/src/components/AggregationScreen.svelte
+++ b/src/components/AggregationScreen.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onMount } from "svelte";
   import type { RawData, LayoutData, Tab } from "../lib/types";
   import ResultPanel from "./aggregation/ResultPanel.svelte";
   import SettingsPanel from "./aggregation/SettingsPanel.svelte";
@@ -18,7 +17,7 @@
   let { rawData, layout, preparedLayout, dateWarnings }: Props = $props();
 
   let questions = $derived(buildQuestions(preparedLayout));
-  let weightCol = $derived(findWeightColumn(preparedLayout));
+  let weightColumnName = $derived(findWeightColumn(preparedLayout));
   let matrixLabels = $derived(
     Object.fromEntries(buildMatrixGroups(preparedLayout).map((g) => [g.matrixKey, g.matrixLabel])),
   );
@@ -37,7 +36,7 @@
 
   async function handleRunAggregation(): Promise<void> {
     errorMsg = "";
-    const activeWeightCol = weightEnabled ? weightCol : "";
+    const activeWeightCol = weightEnabled ? weightColumnName : "";
     const crossQuestions = questions.filter((q) => crossSelected[q.code]);
 
     try {
@@ -48,25 +47,23 @@
     }
   }
 
-  // Run aggregation once on mount
-  onMount(() => {
+  // Auto-run aggregation whenever cross selection or weight toggle changes
+  $effect(() => {
+    if (questions.length === 0) return;
     void handleRunAggregation();
   });
 </script>
 
-<SettingsPanel
-  {rawData}
-  {layout}
-  {preparedLayout}
+<SettingsPanel {rawData} {layout} {dateWarnings} />
+
+<ResultPanel
+  tabs={aggResult?.tabs ?? null}
+  weightCol={aggResult?.weightCol ?? ""}
   {questions}
   {crossSelected}
   onCrossToggle={(key, checked) => (crossSelected = { ...crossSelected, [key]: checked })}
-  {weightCol}
+  {weightColumnName}
   {weightEnabled}
   onWeightToggle={(on) => (weightEnabled = on)}
-  {dateWarnings}
   {errorMsg}
-  onRun={() => handleRunAggregation()}
 />
-
-<ResultPanel tabs={aggResult?.tabs ?? null} weightCol={aggResult?.weightCol ?? ""} />

--- a/src/components/AggregationScreen.svelte
+++ b/src/components/AggregationScreen.svelte
@@ -18,8 +18,9 @@
 
   let questions = $derived(buildQuestions(preparedLayout));
   let weightColumnName = $derived(findWeightColumn(preparedLayout));
+  let matrixGroups = $derived(buildMatrixGroups(preparedLayout));
   let matrixLabels = $derived(
-    Object.fromEntries(buildMatrixGroups(preparedLayout).map((g) => [g.matrixKey, g.matrixLabel])),
+    Object.fromEntries(matrixGroups.map((g) => [g.matrixKey, g.matrixLabel])),
   );
 
   let crossSelected = $state<Record<string, boolean>>({});
@@ -54,7 +55,7 @@
   });
 </script>
 
-<SettingsPanel {rawData} {layout} {dateWarnings} />
+<SettingsPanel {rawData} {layout} {questions} {matrixGroups} {dateWarnings} />
 
 <ResultPanel
   tabs={aggResult?.tabs ?? null}

--- a/src/components/aggregation/AggSettingsPopover.svelte
+++ b/src/components/aggregation/AggSettingsPopover.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { Question } from "../../lib/types";
   import { t } from "../../lib/i18n.svelte";
+  import { getSamaQuestions } from "../../lib/layout";
   import ToggleButton from "../shared/ToggleButton.svelte";
   import ToggleGroup from "../shared/ToggleGroup.svelte";
   import { clickOutside } from "../../lib/dismiss";
@@ -25,7 +26,7 @@
 
   let open = $state(false);
 
-  let samaQuestions = $derived(questions.filter((q) => q.type !== "NA"));
+  let samaQuestions = $derived(getSamaQuestions(questions));
   let selectedCount = $derived(samaQuestions.filter((q) => crossSelected[q.code]).length);
 </script>
 

--- a/src/components/aggregation/AggSettingsPopover.svelte
+++ b/src/components/aggregation/AggSettingsPopover.svelte
@@ -1,0 +1,130 @@
+<script lang="ts">
+  import type { Question } from "../../lib/types";
+  import { t } from "../../lib/i18n.svelte";
+  import ToggleButton from "../shared/ToggleButton.svelte";
+  import ToggleGroup from "../shared/ToggleGroup.svelte";
+  import { clickOutside } from "../../lib/dismiss";
+
+  interface Props {
+    questions: Question[];
+    crossSelected: Record<string, boolean>;
+    onCrossToggle: (key: string, checked: boolean) => void;
+    weightColumnName: string;
+    weightEnabled: boolean;
+    onWeightToggle: (on: boolean) => void;
+  }
+
+  let {
+    questions,
+    crossSelected,
+    onCrossToggle,
+    weightColumnName,
+    weightEnabled,
+    onWeightToggle,
+  }: Props = $props();
+
+  let open = $state(false);
+
+  let samaQuestions = $derived(questions.filter((q) => q.type !== "NA"));
+  let selectedCount = $derived(samaQuestions.filter((q) => crossSelected[q.code]).length);
+</script>
+
+<div class="relative" {@attach clickOutside({ onClose: () => (open = false) })}>
+  <button
+    type="button"
+    class="flex items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium transition-colors {open
+      ? 'border-accent text-accent'
+      : 'border-border text-text-secondary hover:border-accent hover:text-accent'}"
+    onclick={() => (open = !open)}
+    aria-label={t("agg.settings.label")}
+    aria-expanded={open}
+    aria-haspopup="dialog"
+  >
+    <span>{t("agg.settings")}</span>
+    {#if selectedCount > 0}
+      <span
+        class="flex size-5 items-center justify-center rounded-full bg-accent text-xs font-bold text-accent-contrast"
+      >
+        {selectedCount}
+      </span>
+    {/if}
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      class="transition-transform {open ? 'rotate-180' : ''}"
+      aria-hidden="true"
+    >
+      <path d="M3 4.5l3 3 3-3" />
+    </svg>
+  </button>
+
+  {#if open}
+    <div
+      class="absolute right-0 top-full z-20 mt-1 w-80 rounded-lg border border-border bg-surface shadow-lg"
+      role="dialog"
+      aria-label={t("agg.settings")}
+    >
+      <!-- Cross axes -->
+      <div class="border-b border-border p-3">
+        <div class="mb-2 text-xs font-medium uppercase tracking-wide text-muted">
+          {t("section.cross")}
+        </div>
+        {#if samaQuestions.length === 0}
+          <p class="px-1 py-2 text-sm text-muted">{t("cross.popover.empty")}</p>
+        {:else}
+          <ul
+            class="flex max-h-64 flex-col gap-1 overflow-y-auto"
+            role="group"
+            aria-label={t("section.cross.label")}
+          >
+            {#each samaQuestions as q (q.code)}
+              {@const typeTag = q.type === "MA" ? " [MA]" : ""}
+              {@const hasLabel = q.label !== q.code}
+              {@const displayText = hasLabel
+                ? `${q.code}: ${q.label}${typeTag}`
+                : `${q.code}${typeTag}`}
+              <li>
+                <label
+                  class="flex min-h-9 cursor-pointer items-center gap-3 rounded-sm px-2 py-2 text-sm transition-colors hover:bg-surface2"
+                >
+                  <input
+                    type="checkbox"
+                    class="size-4.5 cursor-pointer accent-accent"
+                    checked={crossSelected[q.code] ?? false}
+                    onchange={(e) => {
+                      onCrossToggle(q.code, (e.target as HTMLInputElement).checked);
+                    }}
+                  />
+                  <span class="truncate">{displayText}</span>
+                </label>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+      </div>
+
+      <!-- Weight -->
+      {#if weightColumnName}
+        <div class="flex items-center justify-between gap-3 p-3 text-sm">
+          <span class="truncate text-text" title={weightColumnName}>
+            {t("weight.label", { col: weightColumnName })}
+          </span>
+          <ToggleGroup>
+            <ToggleButton active={weightEnabled} onclick={() => onWeightToggle(true)}>
+              {t("weight.on")}
+            </ToggleButton>
+            <ToggleButton active={!weightEnabled} onclick={() => onWeightToggle(false)}>
+              {t("weight.off")}
+            </ToggleButton>
+          </ToggleGroup>
+        </div>
+      {/if}
+    </div>
+  {/if}
+</div>

--- a/src/components/aggregation/MatrixTabCard.svelte
+++ b/src/components/aggregation/MatrixTabCard.svelte
@@ -32,6 +32,7 @@
 </script>
 
 <div
+  id="card-matrix-{matrix.key}"
   class="overflow-hidden rounded-xl border border-border bg-surface shadow-sm{hasCross
     ? ' overflow-x-auto'
     : ''}"

--- a/src/components/aggregation/ResultPanel.svelte
+++ b/src/components/aggregation/ResultPanel.svelte
@@ -52,6 +52,15 @@
     return () => observer.disconnect();
   });
 
+  // When the last cross axis is unchecked while in chart mode, the View Mode
+  // toggle disappears (it's only shown when hasCross). Without resetting,
+  // the user gets stuck in chart mode with no way back to table. Reset here.
+  $effect(() => {
+    if (!hasCross && viewMode === "chart") {
+      viewMode = "table";
+    }
+  });
+
   let callbacks = $derived({
     onViewModeChange: (m: ViewMode) => (viewMode = m),
     onSaChartTypeChange: (ct: ChartType) => (saChartType = ct),

--- a/src/components/aggregation/ResultPanel.svelte
+++ b/src/components/aggregation/ResultPanel.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import { onMount } from "svelte";
-  import type { Tab } from "../../lib/types";
+  import type { Question, Tab } from "../../lib/types";
   import Toolbar from "./Toolbar.svelte";
   import TabCard from "./TabCard.svelte";
   import MatrixTabCard from "./MatrixTabCard.svelte";
   import AIBubble from "./AIBubble.svelte";
+  import Alert from "../shared/Alert.svelte";
   import { t } from "../../lib/i18n.svelte";
   import type { Basis, ChartType, ViewMode } from "./viewTypes";
   import type { PaletteId } from "../../lib/chartConfig";
@@ -12,9 +12,26 @@
   interface Props {
     tabs: Tab[] | null;
     weightCol: string;
+    questions: Question[];
+    crossSelected: Record<string, boolean>;
+    onCrossToggle: (key: string, checked: boolean) => void;
+    weightColumnName: string;
+    weightEnabled: boolean;
+    onWeightToggle: (on: boolean) => void;
+    errorMsg: string;
   }
 
-  let { tabs, weightCol }: Props = $props();
+  let {
+    tabs,
+    weightCol,
+    questions,
+    crossSelected,
+    onCrossToggle,
+    weightColumnName,
+    weightEnabled,
+    onWeightToggle,
+    errorMsg,
+  }: Props = $props();
 
   let viewMode = $state<ViewMode>("table");
   let saChartType = $state<ChartType>("bar-h");
@@ -88,43 +105,57 @@
   );
 </script>
 
-<div class="overflow-y-auto bg-bg p-6" role="region" aria-label={t("section.results")}>
-  {#if tabs}
-    <div aria-live="polite">
-      <Toolbar
-        {tabs}
-        {weightCol}
-        currentViewMode={viewMode}
-        currentBasis={basis}
-        {hasCross}
-        {chartOpts}
-        {callbacks}
-      />
-      <div class={gridClass}>
-        {#each renderItems as item (item.kind === "matrix" ? `m:${item.matrix.key}` : `s:${item.questionCode}`)}
-          {#if item.kind === "matrix"}
-            <MatrixTabCard
-              matrix={item.matrix}
-              items={item.questionCodes.map((c) => ({
-                gtTab: tabs.find((tab) => tab.questionCode === c && tab.by === null)!,
-                crossTabs: tabs.filter((tab) => tab.questionCode === c && tab.by !== null),
-              }))}
-              {viewMode}
-              {tableOpts}
-              {chartOpts}
-            />
-          {:else}
-            <TabCard
-              tab={tabs.find((tab) => tab.questionCode === item.questionCode && tab.by === null)!}
-              crossTabs={tabs.filter((tab) => tab.questionCode === item.questionCode && tab.by !== null)}
-              {viewMode}
-              {tableOpts}
-              {chartOpts}
-            />
-          {/if}
-        {/each}
-      </div>
-      <AIBubble {tabs} {weightCol} />
-    </div>
+<div class="flex min-h-0 flex-col bg-bg" role="region" aria-label={t("section.results")}>
+  {#if errorMsg}
+    <Alert variant="error" class="mx-6 mt-4 shrink-0">
+      {errorMsg}
+    </Alert>
   {/if}
+
+  <div class="min-h-0 flex-1 overflow-y-auto p-6">
+    {#if tabs}
+      <div aria-live="polite">
+        <Toolbar
+          {tabs}
+          {weightCol}
+          currentViewMode={viewMode}
+          currentBasis={basis}
+          {hasCross}
+          {chartOpts}
+          {callbacks}
+          {questions}
+          {crossSelected}
+          {onCrossToggle}
+          {weightColumnName}
+          {weightEnabled}
+          {onWeightToggle}
+        />
+        <div class={gridClass}>
+          {#each renderItems as item (item.kind === "matrix" ? `m:${item.matrix.key}` : `s:${item.questionCode}`)}
+            {#if item.kind === "matrix"}
+              <MatrixTabCard
+                matrix={item.matrix}
+                items={item.questionCodes.map((c) => ({
+                  gtTab: tabs.find((tab) => tab.questionCode === c && tab.by === null)!,
+                  crossTabs: tabs.filter((tab) => tab.questionCode === c && tab.by !== null),
+                }))}
+                {viewMode}
+                {tableOpts}
+                {chartOpts}
+              />
+            {:else}
+              <TabCard
+                tab={tabs.find((tab) => tab.questionCode === item.questionCode && tab.by === null)!}
+                crossTabs={tabs.filter((tab) => tab.questionCode === item.questionCode && tab.by !== null)}
+                {viewMode}
+                {tableOpts}
+                {chartOpts}
+              />
+            {/if}
+          {/each}
+        </div>
+        <AIBubble {tabs} {weightCol} />
+      </div>
+    {/if}
+  </div>
 </div>

--- a/src/components/aggregation/ResultPanel.svelte
+++ b/src/components/aggregation/ResultPanel.svelte
@@ -112,49 +112,53 @@
     </Alert>
   {/if}
 
-  <div class="min-h-0 flex-1 overflow-y-auto p-6">
+  <div class="min-h-0 flex-1 overflow-y-auto">
     {#if tabs}
       <div aria-live="polite">
-        <Toolbar
-          {tabs}
-          {weightCol}
-          currentViewMode={viewMode}
-          currentBasis={basis}
-          {hasCross}
-          {chartOpts}
-          {callbacks}
-          {questions}
-          {crossSelected}
-          {onCrossToggle}
-          {weightColumnName}
-          {weightEnabled}
-          {onWeightToggle}
-        />
-        <div class={gridClass}>
-          {#each renderItems as item (item.kind === "matrix" ? `m:${item.matrix.key}` : `s:${item.questionCode}`)}
-            {#if item.kind === "matrix"}
-              <MatrixTabCard
-                matrix={item.matrix}
-                items={item.questionCodes.map((c) => ({
-                  gtTab: tabs.find((tab) => tab.questionCode === c && tab.by === null)!,
-                  crossTabs: tabs.filter((tab) => tab.questionCode === c && tab.by !== null),
-                }))}
-                {viewMode}
-                {tableOpts}
-                {chartOpts}
-              />
-            {:else}
-              <TabCard
-                tab={tabs.find((tab) => tab.questionCode === item.questionCode && tab.by === null)!}
-                crossTabs={tabs.filter((tab) => tab.questionCode === item.questionCode && tab.by !== null)}
-                {viewMode}
-                {tableOpts}
-                {chartOpts}
-              />
-            {/if}
-          {/each}
+        <div class="sticky top-0 z-10 bg-bg px-6 pt-6 pb-3" data-sticky-toolbar>
+          <Toolbar
+            {tabs}
+            {weightCol}
+            currentViewMode={viewMode}
+            currentBasis={basis}
+            {hasCross}
+            {chartOpts}
+            {callbacks}
+            {questions}
+            {crossSelected}
+            {onCrossToggle}
+            {weightColumnName}
+            {weightEnabled}
+            {onWeightToggle}
+          />
         </div>
-        <AIBubble {tabs} {weightCol} />
+        <div class="px-6 pb-6">
+          <div class={gridClass}>
+            {#each renderItems as item (item.kind === "matrix" ? `m:${item.matrix.key}` : `s:${item.questionCode}`)}
+              {#if item.kind === "matrix"}
+                <MatrixTabCard
+                  matrix={item.matrix}
+                  items={item.questionCodes.map((c) => ({
+                    gtTab: tabs.find((tab) => tab.questionCode === c && tab.by === null)!,
+                    crossTabs: tabs.filter((tab) => tab.questionCode === c && tab.by !== null),
+                  }))}
+                  {viewMode}
+                  {tableOpts}
+                  {chartOpts}
+                />
+              {:else}
+                <TabCard
+                  tab={tabs.find((tab) => tab.questionCode === item.questionCode && tab.by === null)!}
+                  crossTabs={tabs.filter((tab) => tab.questionCode === item.questionCode && tab.by !== null)}
+                  {viewMode}
+                  {tableOpts}
+                  {chartOpts}
+                />
+              {/if}
+            {/each}
+          </div>
+          <AIBubble {tabs} {weightCol} />
+        </div>
       </div>
     {/if}
   </div>

--- a/src/components/aggregation/SettingsPanel.svelte
+++ b/src/components/aggregation/SettingsPanel.svelte
@@ -1,16 +1,20 @@
 <script lang="ts">
-  import type { RawData, LayoutData } from "../../lib/types";
+  import type { Question, RawData, LayoutData } from "../../lib/types";
+  import type { MatrixGroup } from "../../lib/layout";
   import { t } from "../../lib/i18n.svelte";
   import SectionTitle from "../shared/SectionTitle.svelte";
   import Alert from "../shared/Alert.svelte";
+  import Toc from "./Toc.svelte";
 
   interface Props {
     rawData: RawData;
     layout: LayoutData;
+    questions: Question[];
+    matrixGroups: MatrixGroup[];
     dateWarnings: string[];
   }
 
-  let { rawData, layout, dateWarnings }: Props = $props();
+  let { rawData, layout, questions, matrixGroups, dateWarnings }: Props = $props();
 </script>
 
 <div
@@ -52,4 +56,10 @@
       {/each}
     </Alert>
   {/if}
+
+  <!-- Table of Contents -->
+  <section class="flex min-h-0 flex-1 flex-col overflow-hidden p-4">
+    <SectionTitle>{t("section.toc")}</SectionTitle>
+    <Toc {questions} {matrixGroups} />
+  </section>
 </div>

--- a/src/components/aggregation/SettingsPanel.svelte
+++ b/src/components/aggregation/SettingsPanel.svelte
@@ -1,45 +1,16 @@
 <script lang="ts">
-  import type { Question, RawData, LayoutData } from "../../lib/types";
+  import type { RawData, LayoutData } from "../../lib/types";
   import { t } from "../../lib/i18n.svelte";
-  import Button from "../shared/Button.svelte";
-  import ToggleButton from "../shared/ToggleButton.svelte";
-  import ToggleGroup from "../shared/ToggleGroup.svelte";
   import SectionTitle from "../shared/SectionTitle.svelte";
   import Alert from "../shared/Alert.svelte";
-  import type { Layout } from "../../lib/layout";
-  import { countLayoutColumns } from "../../lib/layout";
 
   interface Props {
     rawData: RawData;
     layout: LayoutData;
-    preparedLayout: Layout;
-    questions: Question[];
-    crossSelected: Record<string, boolean>;
-    onCrossToggle: (key: string, checked: boolean) => void;
-    weightCol: string;
-    weightEnabled: boolean;
-    onWeightToggle: (on: boolean) => void;
     dateWarnings: string[];
-    errorMsg: string;
-    onRun: () => void;
   }
 
-  let {
-    rawData,
-    layout,
-    preparedLayout,
-    questions,
-    crossSelected,
-    onCrossToggle,
-    weightCol,
-    weightEnabled,
-    onWeightToggle,
-    dateWarnings,
-    errorMsg,
-    onRun,
-  }: Props = $props();
-
-  let samaQuestions = $derived(questions.filter((q) => q.type !== "NA"));
+  let { rawData, layout, dateWarnings }: Props = $props();
 </script>
 
 <div
@@ -72,75 +43,13 @@
     </div>
   </section>
 
-  <!-- Cross Config -->
-  <section class="flex min-h-0 flex-1 flex-col overflow-hidden border-b border-border p-4">
-    <SectionTitle>{t("section.cross")}</SectionTitle>
-    <div
-      class="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto"
-      role="group"
-      aria-label={t("section.cross.label")}
-    >
-      {#each samaQuestions as q (q.code)}
-        {@const typeTag = q.type === "MA" ? " [MA]" : ""}
-        {@const hasLabel = q.label !== q.code}
-        {@const displayText = hasLabel ? `${q.code}: ${q.label}${typeTag}` : `${q.code}${typeTag}`}
-        <label
-          class="flex min-h-9 cursor-pointer items-center gap-3 rounded-sm px-3 py-2 text-sm transition-colors hover:bg-surface2"
-        >
-          <input
-            type="checkbox"
-            class="size-4.5 cursor-pointer accent-accent"
-            checked={crossSelected[q.code] ?? false}
-            onchange={(e) => {
-              onCrossToggle(q.code, (e.target as HTMLInputElement).checked);
-            }}
-          />
-          {displayText}
-        </label>
-      {/each}
-    </div>
-  </section>
-
-  <!-- Weight Info -->
-  {#if weightCol}
-    <div
-      class="flex shrink-0 items-center gap-3 border-b border-border px-4 py-3 text-sm text-text"
-    >
-      <span>{t("weight.label", { col: weightCol })}</span>
-      <div class="ml-auto flex">
-        <ToggleGroup>
-          <ToggleButton active={weightEnabled} onclick={() => onWeightToggle(true)}>
-            {t("weight.on")}
-          </ToggleButton>
-          <ToggleButton active={!weightEnabled} onclick={() => onWeightToggle(false)}>
-            {t("weight.off")}
-          </ToggleButton>
-        </ToggleGroup>
-      </div>
-    </div>
-  {/if}
-
   <!-- Date Warnings -->
   {#if dateWarnings.length > 0}
-    <Alert variant="warning" role="status" class="mx-4 shrink-0">
+    <Alert variant="warning" role="status" class="mx-4 mt-4 shrink-0">
       {#each dateWarnings as w (w)}
         {@const parts = w.split(":")}
         <p>{t("warn.date.cast", { col: parts[0], count: parts[1] })}</p>
       {/each}
     </Alert>
   {/if}
-
-  <!-- Error Message -->
-  {#if errorMsg}
-    <Alert variant="error" class="mx-4 shrink-0">
-      {errorMsg}
-    </Alert>
-  {/if}
-
-  <!-- Run Button -->
-  <div class="mx-4 my-4 shrink-0">
-    <Button variant="primary" size="lg" fullWidth onclick={onRun}>
-      {t("run.button")}
-    </Button>
-  </div>
 </div>

--- a/src/components/aggregation/TabCard.svelte
+++ b/src/components/aggregation/TabCard.svelte
@@ -25,6 +25,7 @@
 </script>
 
 <div
+  id="card-{tab.questionCode}"
   class="overflow-hidden rounded-xl border border-border bg-surface shadow-sm{hasCross
     ? ' overflow-x-auto'
     : ''}"

--- a/src/components/aggregation/Toc.svelte
+++ b/src/components/aggregation/Toc.svelte
@@ -54,7 +54,10 @@
   }
 
   function jumpTo(targetId: string): void {
-    const el = document.querySelector<HTMLElement>(`#${targetId}`);
+    // Question codes are user-supplied (from the layout file) and may contain
+    // digits, dots or other characters that have special meaning in CSS
+    // selectors. CSS.escape sanitizes the id for use inside `#...`.
+    const el = document.querySelector<HTMLElement>(`#${CSS.escape(targetId)}`);
     if (!el) return;
     const sc = findScrollContainer(el);
     if (!sc) {

--- a/src/components/aggregation/Toc.svelte
+++ b/src/components/aggregation/Toc.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+  import type { Question } from "../../lib/types";
+  import type { MatrixGroup } from "../../lib/layout";
+
+  interface Props {
+    questions: Question[];
+    matrixGroups: MatrixGroup[];
+  }
+
+  let { questions, matrixGroups }: Props = $props();
+
+  type TocItem =
+    | { kind: "single"; targetId: string; code: string; label: string }
+    | { kind: "matrix"; targetId: string; code: string; label: string };
+
+  let items = $derived.by<TocItem[]>(() => {
+    const matrixLabelByKey = new Map(
+      matrixGroups.map((g) => [g.matrixKey, g.matrixLabel] as const),
+    );
+    const emitted = new Set<string>();
+    const result: TocItem[] = [];
+    for (const q of questions) {
+      if (q.matrixKey) {
+        if (emitted.has(q.matrixKey)) continue;
+        emitted.add(q.matrixKey);
+        result.push({
+          kind: "matrix",
+          targetId: `card-matrix-${q.matrixKey}`,
+          code: q.matrixKey,
+          label: matrixLabelByKey.get(q.matrixKey) ?? q.matrixKey,
+        });
+      } else {
+        result.push({
+          kind: "single",
+          targetId: `card-${q.code}`,
+          code: q.code,
+          label: q.label,
+        });
+      }
+    }
+    return result;
+  });
+
+  function findScrollContainer(el: HTMLElement): HTMLElement | null {
+    let p: HTMLElement | null = el.parentElement;
+    while (p) {
+      const oy = getComputedStyle(p).overflowY;
+      if ((oy === "auto" || oy === "scroll") && p.scrollHeight > p.clientHeight) {
+        return p;
+      }
+      p = p.parentElement;
+    }
+    return null;
+  }
+
+  function jumpTo(targetId: string): void {
+    const el = document.querySelector<HTMLElement>(`#${targetId}`);
+    if (!el) return;
+    const sc = findScrollContainer(el);
+    if (!sc) {
+      el.scrollIntoView({ behavior: "smooth", block: "start" });
+      return;
+    }
+    const offset = el.getBoundingClientRect().top - sc.getBoundingClientRect().top + sc.scrollTop;
+    sc.scrollTo({ top: offset, behavior: "smooth" });
+  }
+</script>
+
+<ul class="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto">
+  {#each items as item (item.targetId)}
+    <li>
+      <button
+        type="button"
+        class="flex w-full items-baseline gap-2 rounded-sm px-3 py-2 text-left transition-colors hover:bg-surface2"
+        onclick={() => jumpTo(item.targetId)}
+      >
+        <span class="shrink-0 font-mono text-xs tracking-wide text-muted">{item.code}</span>
+        <span class="truncate text-sm text-text">{item.label}</span>
+      </button>
+    </li>
+  {/each}
+</ul>

--- a/src/components/aggregation/Toc.svelte
+++ b/src/components/aggregation/Toc.svelte
@@ -61,8 +61,11 @@
       el.scrollIntoView({ behavior: "smooth", block: "start" });
       return;
     }
-    const offset = el.getBoundingClientRect().top - sc.getBoundingClientRect().top + sc.scrollTop;
-    sc.scrollTo({ top: offset, behavior: "smooth" });
+    const stickyEl = sc.querySelector<HTMLElement>("[data-sticky-toolbar]");
+    const stickyH = stickyEl?.offsetHeight ?? 0;
+    const offset =
+      el.getBoundingClientRect().top - sc.getBoundingClientRect().top + sc.scrollTop - stickyH;
+    sc.scrollTo({ top: Math.max(0, offset), behavior: "smooth" });
   }
 </script>
 

--- a/src/components/aggregation/Toolbar.svelte
+++ b/src/components/aggregation/Toolbar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { Question, Tab } from "../../lib/types";
   import { t } from "../../lib/i18n.svelte";
+  import { getSamaQuestions } from "../../lib/layout";
   import ExportMenu from "./ExportMenu.svelte";
   import AggSettingsPopover from "./AggSettingsPopover.svelte";
   import ViewSettingsPopover from "./ViewSettingsPopover.svelte";
@@ -43,8 +44,7 @@
   let questionCount = $derived(new Set(tabs.map((tab) => tab.questionCode)).size);
 
   let selectedCrossNames = $derived.by(() => {
-    const samaQuestions = questions.filter((q) => q.type !== "NA");
-    const selected = samaQuestions.filter((q) => crossSelected[q.code]);
+    const selected = getSamaQuestions(questions).filter((q) => crossSelected[q.code]);
     if (selected.length === 0) return "";
     const names = selected.map((q) => (q.label === q.code ? q.code : q.label));
     if (names.length <= 2) return names.join(", ");

--- a/src/components/aggregation/Toolbar.svelte
+++ b/src/components/aggregation/Toolbar.svelte
@@ -1,14 +1,12 @@
 <script lang="ts">
-  import type { Tab } from "../../lib/types";
+  import type { Question, Tab } from "../../lib/types";
   import { t } from "../../lib/i18n.svelte";
-  import ToggleButton from "../shared/ToggleButton.svelte";
-  import ToggleGroup from "../shared/ToggleGroup.svelte";
   import ExportMenu from "./ExportMenu.svelte";
+  import AggSettingsPopover from "./AggSettingsPopover.svelte";
+  import ViewSettingsPopover from "./ViewSettingsPopover.svelte";
   import { executeExport, type ExportAction } from "../../lib/export/export";
-  import type { Basis, ChartOpts, ChartType, ViewMode } from "./viewTypes";
+  import type { Basis, ChartOpts, ViewMode } from "./viewTypes";
   import type { ToolbarCallbacks } from "./toolbarTypes";
-  import { getPaletteBase, getPaletteIds } from "../../lib/chartConfig";
-  import { clickOutside } from "../../lib/dismiss";
 
   interface Props {
     tabs: Tab[];
@@ -18,178 +16,79 @@
     hasCross: boolean;
     chartOpts: ChartOpts;
     callbacks: ToolbarCallbacks;
+    questions: Question[];
+    crossSelected: Record<string, boolean>;
+    onCrossToggle: (key: string, checked: boolean) => void;
+    weightColumnName: string;
+    weightEnabled: boolean;
+    onWeightToggle: (on: boolean) => void;
   }
 
-  let { tabs, weightCol, currentViewMode, currentBasis, hasCross, chartOpts, callbacks }: Props =
-    $props();
+  let {
+    tabs,
+    weightCol,
+    currentViewMode,
+    currentBasis,
+    hasCross,
+    chartOpts,
+    callbacks,
+    questions,
+    crossSelected,
+    onCrossToggle,
+    weightColumnName,
+    weightEnabled,
+    onWeightToggle,
+  }: Props = $props();
 
-  let weightText = $derived(
-    weightCol
-      ? t("result.weight.applied", { col: weightCol })
-      : t("result.weight.none"),
-  );
   let questionCount = $derived(new Set(tabs.map((tab) => tab.questionCode)).size);
 
-  let detailOpen = $state(false);
-  let hasDetailSettings = $derived(hasCross || currentViewMode === "chart");
+  let selectedCrossNames = $derived.by(() => {
+    const samaQuestions = questions.filter((q) => q.type !== "NA");
+    const selected = samaQuestions.filter((q) => crossSelected[q.code]);
+    if (selected.length === 0) return "";
+    const names = selected.map((q) => (q.label === q.code ? q.code : q.label));
+    if (names.length <= 2) return names.join(", ");
+    return t("cross.summary", { names: names.slice(0, 2).join(", "), rest: names.length - 2 });
+  });
+
+  let weightText = $derived(
+    weightColumnName === ""
+      ? ""
+      : weightCol
+        ? t("result.weight.applied")
+        : t("result.weight.none"),
+  );
+
+  let metaText = $derived.by(() => {
+    const parts = [t("result.meta.count", { count: questionCount })];
+    if (selectedCrossNames) parts.push(t("result.meta.cross", { names: selectedCrossNames }));
+    if (weightText) parts.push(weightText);
+    return parts.join(" ・ ");
+  });
 </script>
 
-<div class="mb-6 flex items-center gap-4">
-  <h2 class="text-xl font-bold">{t("result.title.tab")}</h2>
-  <span class="text-xs text-muted">
-    {t("result.meta", { count: questionCount, weight: weightText })}
-  </span>
+<div class="mb-6 flex items-start gap-4">
+  <div class="min-w-0 flex-1">
+    <h2 class="text-xl font-bold">{t("result.title.tab")}</h2>
+    <p class="mt-0.5 text-xs text-muted">{metaText}</p>
+  </div>
 
-  <div class="ml-auto flex items-center gap-4">
-    {#if hasCross}
-      <ToggleGroup>
-        <ToggleButton
-          active={currentViewMode === "table"}
-          onclick={() => currentViewMode !== "table" && callbacks.onViewModeChange("table")}
-        >
-          {t("result.view.table")}
-        </ToggleButton>
-        <ToggleButton
-          active={currentViewMode === "chart"}
-          onclick={() => currentViewMode !== "chart" && callbacks.onViewModeChange("chart")}
-        >
-          {t("result.view.chart")}
-        </ToggleButton>
-      </ToggleGroup>
-    {/if}
-
-    {#if hasDetailSettings}
-    <div
-      class="relative"
-      {@attach clickOutside({ onClose: () => (detailOpen = false) })}
-    >
-      <button
-        class="flex size-9 cursor-pointer items-center justify-center rounded-lg border border-border text-muted transition-colors hover:border-accent hover:text-accent"
-        onclick={() => (detailOpen = !detailOpen)}
-        aria-label={t("display.settings")}
-        title={t("display.settings")}
-      >
-        <svg
-          width="16"
-          height="16"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          aria-hidden="true"
-        >
-          <line x1="4" y1="6" x2="20" y2="6" />
-          <circle cx="8" cy="6" r="2" fill="currentColor" stroke="none" />
-          <line x1="4" y1="12" x2="20" y2="12" />
-          <circle cx="16" cy="12" r="2" fill="currentColor" stroke="none" />
-          <line x1="4" y1="18" x2="20" y2="18" />
-          <circle cx="11" cy="18" r="2" fill="currentColor" stroke="none" />
-        </svg>
-      </button>
-
-      {#if detailOpen}
-        <div
-          class="absolute right-0 z-10 mt-1 w-60 rounded-lg border border-border bg-surface p-3 shadow-lg"
-        >
-          <!-- テーブル設定 -->
-          {#if hasCross}
-            <div class="mb-3">
-              <div class="mb-1 text-xs font-medium tracking-wide text-muted uppercase">
-                {t("display.tableSettings")}
-              </div>
-              <div class="flex items-center justify-between text-xs text-text-secondary">
-                <span>{t("display.pctBasis")}</span>
-                <ToggleGroup>
-                  <ToggleButton
-                    active={currentBasis === "column"}
-                    onclick={() => currentBasis !== "column" && callbacks.onBasisChange("column")}
-                  >
-                    {t("result.pct.column")}
-                  </ToggleButton>
-                  <ToggleButton
-                    active={currentBasis === "row"}
-                    onclick={() => currentBasis !== "row" && callbacks.onBasisChange("row")}
-                  >
-                    {t("result.pct.row")}
-                  </ToggleButton>
-                </ToggleGroup>
-              </div>
-            </div>
-          {/if}
-
-          <!-- チャート設定 -->
-          {#if currentViewMode === "chart"}
-            <div class={["", hasCross && "border-t border-border pt-3"]}>
-              <div class="mb-2 text-xs font-medium tracking-wide text-muted uppercase">
-                {t("display.chartSettings")}
-              </div>
-              <div class="flex flex-col gap-2 text-xs text-text-secondary">
-                <div class="flex items-center justify-between">
-                  <span>{t("display.saType")}</span>
-                  <select
-                    class="cursor-pointer rounded-sm border border-border bg-surface px-2 py-1 text-xs text-text"
-                    value={chartOpts.saChartType}
-                    onchange={(e) =>
-                      callbacks.onSaChartTypeChange(
-                        (e.target as HTMLSelectElement).value as ChartType,
-                      )}
-                  >
-                    <option value="bar-h">{t("chart.barH")}</option>
-                    <option value="bar-v">{t("chart.barV")}</option>
-                    <option value="obi">{t("chart.obi")}</option>
-                  </select>
-                </div>
-                <div class="flex items-center justify-between">
-                  <span>{t("display.maType")}</span>
-                  <select
-                    class="cursor-pointer rounded-sm border border-border bg-surface px-2 py-1 text-xs text-text"
-                    value={chartOpts.maChartType}
-                    onchange={(e) =>
-                      callbacks.onMaChartTypeChange(
-                        (e.target as HTMLSelectElement).value as ChartType,
-                      )}
-                  >
-                    <option value="bar-h">{t("chart.barH")}</option>
-                    <option value="bar-v">{t("chart.barV")}</option>
-                    <option value="obi">{t("chart.obi")}</option>
-                  </select>
-                </div>
-                <div class="flex items-center justify-between">
-                  <span>{t("chart.palette")}</span>
-                  <div
-                    class="flex items-center gap-1.5"
-                    role="radiogroup"
-                    aria-label={t("chart.palette")}
-                  >
-                    {#each getPaletteIds() as id (id)}
-                      {@const isActive = id === chartOpts.paletteId}
-                      {@const base = getPaletteBase(id)}
-                      <button
-                        type="button"
-                        role="radio"
-                        aria-checked={isActive}
-                        aria-label={id}
-                        class="size-5 cursor-pointer rounded-full border-2 transition-shadow {isActive
-                          ? 'border-accent shadow-[0_0_0_1px_var(--accent)]'
-                          : 'border-border hover:border-muted'}"
-                        style={base
-                          ? `background-color: ${base}`
-                          : "background: conic-gradient(#0064d4, #0097a7, #1b7d3a, #e06500, #c62828, #6a1b9a, #0064d4)"}
-                        onclick={() => callbacks.onPaletteChange(id)}
-                      ></button>
-                    {/each}
-                  </div>
-                </div>
-              </div>
-            </div>
-          {/if}
-        </div>
-      {/if}
-    </div>
-  {/if}
-
+  <div class="flex shrink-0 items-center gap-2">
+    <AggSettingsPopover
+      {questions}
+      {crossSelected}
+      {onCrossToggle}
+      {weightColumnName}
+      {weightEnabled}
+      {onWeightToggle}
+    />
+    <ViewSettingsPopover
+      {currentViewMode}
+      {currentBasis}
+      {hasCross}
+      {chartOpts}
+      {callbacks}
+    />
     <ExportMenu onExport={(action: ExportAction) => executeExport(action, tabs, weightCol)} />
   </div>
 </div>

--- a/src/components/aggregation/Toolbar.svelte
+++ b/src/components/aggregation/Toolbar.svelte
@@ -67,7 +67,7 @@
   });
 </script>
 
-<div class="mb-6 flex items-start gap-4">
+<div class="flex items-start gap-4">
   <div class="min-w-0 flex-1">
     <h2 class="text-xl font-bold">{t("result.title.tab")}</h2>
     <p class="mt-0.5 text-xs text-muted">{metaText}</p>

--- a/src/components/aggregation/ViewSettingsPopover.svelte
+++ b/src/components/aggregation/ViewSettingsPopover.svelte
@@ -1,0 +1,187 @@
+<script lang="ts">
+  import { t } from "../../lib/i18n.svelte";
+  import ToggleButton from "../shared/ToggleButton.svelte";
+  import ToggleGroup from "../shared/ToggleGroup.svelte";
+  import { clickOutside } from "../../lib/dismiss";
+  import type { Basis, ChartOpts, ChartType, ViewMode } from "./viewTypes";
+  import type { ToolbarCallbacks } from "./toolbarTypes";
+  import { getPaletteBase, getPaletteIds } from "../../lib/chartConfig";
+
+  interface Props {
+    currentViewMode: ViewMode;
+    currentBasis: Basis;
+    hasCross: boolean;
+    chartOpts: ChartOpts;
+    callbacks: ToolbarCallbacks;
+  }
+
+  let { currentViewMode, currentBasis, hasCross, chartOpts, callbacks }: Props = $props();
+
+  let open = $state(false);
+  let isDisabled = $derived(!hasCross && currentViewMode !== "chart");
+
+  // Auto-close popover when transitioning to disabled (e.g. last cross axis unchecked)
+  $effect(() => {
+    if (isDisabled) open = false;
+  });
+</script>
+
+<div class="relative" {@attach clickOutside({ onClose: () => (open = false) })}>
+  <button
+    type="button"
+    disabled={isDisabled}
+    class="flex items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium transition-colors {isDisabled
+      ? 'cursor-not-allowed border-border text-muted opacity-50'
+      : open
+        ? 'border-accent text-accent'
+        : 'border-border text-text-secondary hover:border-accent hover:text-accent'}"
+    onclick={() => (open = !open)}
+    aria-label={t("display.settings")}
+    aria-expanded={open}
+    aria-haspopup="dialog"
+    title={isDisabled ? t("display.disabled.tooltip") : undefined}
+  >
+    <span>{t("display.settings")}</span>
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      class="transition-transform {!isDisabled && open ? 'rotate-180' : ''}"
+      aria-hidden="true"
+    >
+      <path d="M3 4.5l3 3 3-3" />
+    </svg>
+  </button>
+
+  {#if open}
+    <div
+      class="absolute right-0 top-full z-20 mt-1 w-72 rounded-lg border border-border bg-surface p-3 shadow-lg"
+      role="dialog"
+      aria-label={t("display.settings")}
+    >
+      <!-- View mode (only when cross-tab present; otherwise table-only) -->
+      {#if hasCross}
+        <div class="mb-3 flex items-center justify-between text-xs text-text-secondary">
+          <span class="font-medium uppercase tracking-wide text-muted">
+            {t("display.viewMode")}
+          </span>
+          <ToggleGroup>
+            <ToggleButton
+              active={currentViewMode === "table"}
+              onclick={() =>
+                currentViewMode !== "table" && callbacks.onViewModeChange("table")}
+            >
+              {t("result.view.table")}
+            </ToggleButton>
+            <ToggleButton
+              active={currentViewMode === "chart"}
+              onclick={() =>
+                currentViewMode !== "chart" && callbacks.onViewModeChange("chart")}
+            >
+              {t("result.view.chart")}
+            </ToggleButton>
+          </ToggleGroup>
+        </div>
+      {/if}
+
+      <!-- Table settings (basis applies to both table and chart views when hasCross) -->
+      {#if hasCross}
+        <div class="border-t border-border pt-3">
+          <div class="mb-2 text-xs font-medium uppercase tracking-wide text-muted">
+            {t("display.tableSettings")}
+          </div>
+          <div class="flex items-center justify-between text-xs text-text-secondary">
+            <span>{t("display.pctBasis")}</span>
+            <ToggleGroup>
+              <ToggleButton
+                active={currentBasis === "column"}
+                onclick={() =>
+                  currentBasis !== "column" && callbacks.onBasisChange("column")}
+              >
+                {t("result.pct.column")}
+              </ToggleButton>
+              <ToggleButton
+                active={currentBasis === "row"}
+                onclick={() => currentBasis !== "row" && callbacks.onBasisChange("row")}
+              >
+                {t("result.pct.row")}
+              </ToggleButton>
+            </ToggleGroup>
+          </div>
+        </div>
+      {/if}
+
+      <!-- Chart settings -->
+      {#if currentViewMode === "chart"}
+        <div class={hasCross ? "border-t border-border pt-3" : ""}>
+          <div class="mb-2 text-xs font-medium uppercase tracking-wide text-muted">
+            {t("display.chartSettings")}
+          </div>
+          <div class="flex flex-col gap-2 text-xs text-text-secondary">
+            <div class="flex items-center justify-between">
+              <span>{t("display.saType")}</span>
+              <select
+                class="cursor-pointer rounded-sm border border-border bg-surface px-2 py-1 text-xs text-text"
+                value={chartOpts.saChartType}
+                onchange={(e) =>
+                  callbacks.onSaChartTypeChange(
+                    (e.target as HTMLSelectElement).value as ChartType,
+                  )}
+              >
+                <option value="bar-h">{t("chart.barH")}</option>
+                <option value="bar-v">{t("chart.barV")}</option>
+                <option value="obi">{t("chart.obi")}</option>
+              </select>
+            </div>
+            <div class="flex items-center justify-between">
+              <span>{t("display.maType")}</span>
+              <select
+                class="cursor-pointer rounded-sm border border-border bg-surface px-2 py-1 text-xs text-text"
+                value={chartOpts.maChartType}
+                onchange={(e) =>
+                  callbacks.onMaChartTypeChange(
+                    (e.target as HTMLSelectElement).value as ChartType,
+                  )}
+              >
+                <option value="bar-h">{t("chart.barH")}</option>
+                <option value="bar-v">{t("chart.barV")}</option>
+                <option value="obi">{t("chart.obi")}</option>
+              </select>
+            </div>
+            <div class="flex items-center justify-between">
+              <span>{t("chart.palette")}</span>
+              <div
+                class="flex items-center gap-1.5"
+                role="radiogroup"
+                aria-label={t("chart.palette")}
+              >
+                {#each getPaletteIds() as id (id)}
+                  {@const isActive = id === chartOpts.paletteId}
+                  {@const base = getPaletteBase(id)}
+                  <button
+                    type="button"
+                    role="radio"
+                    aria-checked={isActive}
+                    aria-label={id}
+                    class="size-5 cursor-pointer rounded-full border-2 transition-shadow {isActive
+                      ? 'border-accent shadow-[0_0_0_1px_var(--accent)]'
+                      : 'border-border hover:border-muted'}"
+                    style={base
+                      ? `background-color: ${base}`
+                      : "background: conic-gradient(#0064d4, #0097a7, #1b7d3a, #e06500, #c62828, #6a1b9a, #0064d4)"}
+                    onclick={() => callbacks.onPaletteChange(id)}
+                  ></button>
+                {/each}
+              </div>
+            </div>
+          </div>
+        </div>
+      {/if}
+    </div>
+  {/if}
+</div>

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -233,6 +233,11 @@ export function buildQuestions(layout: Layout): Question[] {
     });
 }
 
+/** SA/MA only — questions usable as a cross-tabulation axis (NA is excluded) */
+export function getSamaQuestions(questions: Question[]): Question[] {
+  return questions.filter((q) => q.type !== "NA");
+}
+
 function buildNAQuestion(e: NALayout): Question {
   return {
     type: "NA",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -58,7 +58,6 @@ const en: Record<string, string> = {
   "weight.off": "OFF",
 
   // Data config bar (cross + weight)
-  "cross.empty": "None",
   "cross.summary": "{names} +{rest}",
   "cross.popover.empty": "No questions available",
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -56,14 +56,19 @@ const en: Record<string, string> = {
   "weight.on": "ON",
   "weight.off": "OFF",
 
-  // Run button
-  "run.button": "▶ Run Aggregation",
+  // Data config bar (cross + weight)
+  "cross.empty": "None",
+  "cross.summary": "{names} +{rest}",
+  "cross.popover.empty": "No questions available",
 
   // Results
   "result.title.tab": "Aggregation Results",
-  "result.meta": "{count} questions  /  {weight}",
-  "result.weight.applied": "Weighted: {col}",
+  "result.meta.count": "{count} questions",
+  "result.meta.cross": "Cross: {names}",
+  "result.weight.applied": "Weighted",
   "result.weight.none": "Unweighted",
+  "agg.settings": "Aggregation",
+  "agg.settings.label": "Open aggregation settings",
   "result.view.table": "Table",
   "result.view.chart": "Chart",
   "result.pct.column": "Col %",
@@ -99,6 +104,7 @@ const en: Record<string, string> = {
 
   // Display settings dropdown
   "display.settings": "Display",
+  "display.disabled.tooltip": "Select a cross-tabulation axis to enable",
   "display.viewMode": "View Mode",
   "display.tableSettings": "Table Settings",
   "display.chartSettings": "Chart Settings",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -49,6 +49,7 @@ const en: Record<string, string> = {
 
   // Aggregation screen
   "section.summary": "Data Summary",
+  "section.toc": "Index",
   "section.cross": "Cross-Tabulation Axes",
   "section.cross.label": "Cross-tabulation axis selection",
   "summary.rows": "{rows} rows {cols} cols",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -58,7 +58,6 @@ const ja: Record<string, string> = {
   "weight.off": "OFF",
 
   // Data config bar (cross + weight)
-  "cross.empty": "未選択",
   "cross.summary": "{names} +{rest}",
   "cross.popover.empty": "選択可能な設問がありません",
 

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -56,14 +56,19 @@ const ja: Record<string, string> = {
   "weight.on": "ON",
   "weight.off": "OFF",
 
-  // Run button
-  "run.button": "▶ 集計を実行",
+  // Data config bar (cross + weight)
+  "cross.empty": "未選択",
+  "cross.summary": "{names} +{rest}",
+  "cross.popover.empty": "選択可能な設問がありません",
 
   // Results
   "result.title.tab": "集計結果",
-  "result.meta": "{count} 問  ／  {weight}",
-  "result.weight.applied": "ウェイトバック適用: {col}",
+  "result.meta.count": "{count}問",
+  "result.meta.cross": "クロス: {names}",
+  "result.weight.applied": "ウェイトバック適用",
   "result.weight.none": "実数集計",
+  "agg.settings": "集計設定",
+  "agg.settings.label": "集計設定を開く",
   "result.view.table": "テーブル",
   "result.view.chart": "チャート",
   "result.pct.column": "縦%",
@@ -99,6 +104,7 @@ const ja: Record<string, string> = {
 
   // Display settings dropdown
   "display.settings": "表示設定",
+  "display.disabled.tooltip": "クロス集計軸を選択すると有効になります",
   "display.viewMode": "表示形式",
   "display.tableSettings": "テーブル設定",
   "display.chartSettings": "チャート設定",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -49,6 +49,7 @@ const ja: Record<string, string> = {
 
   // Aggregation screen
   "section.summary": "データ概要",
+  "section.toc": "目次",
   "section.cross": "クロス集計軸",
   "section.cross.label": "クロス集計軸の選択",
   "summary.rows": "{rows} 行 {cols} 列",


### PR DESCRIPTION
## Summary

集計画面のレイアウトを再設計し、左パネルを「設問への目次」、右パネル上部を「常時アクセスできるツールバー」として整理した。3つの独立したコミットで構成：

- **e16f8de** クロス集計・ウエイトバック・表示設定を popover 2つに集約。「集計を実行」ボタンを廃止し即時集計化
- **54723b3** 左パネルに設問の目次（TOC）を追加。クリックで該当カードへ smooth scroll
- **63f488f** 右パネル上部の Toolbar を sticky 化。スクロール中も常に集計設定 / 表示設定 / Export にアクセスできる

## 主な変更点

### 集計設定ポップオーバー化（e16f8de）
- 左パネルにあった縦に長い「クロス集計軸」リスト + ウエイトバックトグル → 右上 `[Aggregation ▾]` ボタンの popover に集約
- 既存の歯車 popover（テーブル/チャート設定）は `[Display ▾]` に統合し、内部に View Mode (Table/Chart) も移動
- `[Aggregation]` `[Display]` `[Export]` の3ボタン構成に整理
- 「集計を実行」ボタンは廃止し、`\$effect` でクロス選択 / ウエイト切替時に即時集計
- 「集計結果」見出しの下に \`3問 ・ クロス: 性別 ・ ウェイトバック適用\` のような **状態がそのまま読めるメタ行** を表示
- Display ボタンは popover に内容がない時（!hasCross && viewMode==="table"）`disabled` + tooltip 化

### 設問 TOC（54723b3）
- 左パネル下部に設問一覧を表示（Data Summary は上部に維持）
- マトリクスは親エントリ1つで表示（子設問はマトリクスカード内で展開済み）
- クリックで該当カードへ smooth scroll
- 既存の `<caption class="sr-only">` が document の scrollHeight を伸ばす副作用があるため、`scrollIntoView` ではなく明示的に最寄りの overflow-y-auto 親を見つけて `scrollTo` で直接スクロール（Header / 左パネルが固定される）

### Sticky Toolbar（63f488f）
- カードを読み進めている間も Toolbar が常時見えるように sticky 化
- TOC ジャンプ時はカードが sticky の裏に隠れないよう、`[data-sticky-toolbar]` の高さ分を offset から引く

## 動作確認

- 自動 GT 表示、cross-tab トグル → 即時集計、weight ON/OFF → 即時反映
- 全クロス解除時に Display ボタンが disabled 化（tooltip 表示）
- TOC から各設問にジャンプ、document scroll は常に 0、Header / 左パネル / sticky Toolbar が固定
- vp check / vp test run (1862/1862 pass) / vp build 通過
- e2e は popover ベース + 即時集計に書き換え済み

## Test plan

- [ ] 集計画面に入ると Grand Total が自動表示される
- [ ] Aggregation popover でクロス軸を選択 → 即時にクロステーブルが表示される
- [ ] ウエイト ON/OFF を切替 → 即時に再集計される
- [ ] メタ行に「クロス: ...」「ウェイトバック適用」の状態が表示される
- [ ] クロス未選択 + table view のとき Display ボタンが disabled
- [ ] TOC から設問をクリック → 該当カードへスクロール、Header / 左パネルは固定
- [ ] スクロール中も Toolbar が top に貼り付き、ボタンが押せる

🤖 Generated with [Claude Code](https://claude.com/claude-code)