### PR TITLE
refactor(aggregation): extract RecipeStore and AggRunner stores

### DIFF
--- a/src/components/AggregationScreen.svelte
+++ b/src/components/AggregationScreen.svelte
@@ -1,20 +1,15 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import type { RawData, LayoutData, Tab } from "../lib/types";
+  import type { RawData, LayoutData } from "../lib/types";
   import ResultPanel from "./aggregation/ResultPanel.svelte";
   import SettingsPanel from "./aggregation/SettingsPanel.svelte";
   import DerivedRecipePanel from "./aggregation/DerivedRecipePanel.svelte";
-  import {
-    runAggregation,
-    prepareDerivedLayout,
-    dropDerivedColumn,
-  } from "../lib/duckdb.svelte";
   import type { Layout } from "../lib/layout";
-  import { buildQuestions, buildMatrixGroups, findWeightColumn } from "../lib/layout";
   import { t } from "../lib/i18n.svelte";
   import type { DerivedRecipe } from "../lib/derivedRecipe";
-  import { validateRecipes } from "../lib/derivedRecipe";
   import { saveRecipes } from "../lib/opfs";
+  import { RecipeStore } from "../lib/recipeStore.svelte";
+  import { AggRunner } from "../lib/aggRunner.svelte";
 
   interface Props {
     rawData: RawData;
@@ -34,79 +29,37 @@
     folderId,
   }: Props = $props();
 
-  let recipes = $state<DerivedRecipe[]>(initialRecipes);
-  let derivedLayout = $state<Layout>(preparedLayout);
-  let derivedWarnings = $state<string[]>([]);
-
-  let questions = $derived(buildQuestions(derivedLayout));
-  let weightColumnName = $derived(findWeightColumn(derivedLayout));
-  let matrixGroups = $derived(buildMatrixGroups(derivedLayout));
-  let matrixLabels = $derived(
-    Object.fromEntries(matrixGroups.map((g) => [g.matrixKey, g.matrixLabel])),
-  );
-
-  let crossSelected = $state<Record<string, boolean>>({});
-  let weightEnabled = $state(true);
-  let errorMsg = $state("");
-  let aggResult = $state<{ tabs: Tab[]; weightCol: string } | null>(null);
+  const recipeStore = new RecipeStore(preparedLayout, initialRecipes);
+  const aggRunner = new AggRunner();
 
   type ViewMode =
     | { kind: "results" }
     | { kind: "recipe"; mode: "type-select" | "edit"; editCode: string | null };
   let viewMode = $state<ViewMode>({ kind: "results" });
 
-  // Restore derived columns once on mount for OPFS-loaded recipes.
-  // Subsequent recipe mutations go through handleRecipeCommit / handleDeleteRecipe,
-  // which keep derivedLayout in sync explicitly — avoiding the double prepare
-  // an effect-on-recipes would cause right after a commit.
   onMount(() => {
-    if (initialRecipes.length === 0) return;
-    void (async () => {
-      try {
-        const result = await prepareDerivedLayout(preparedLayout, initialRecipes);
-        derivedLayout = result.layout;
-        derivedWarnings = result.warnings;
-      } catch (e) {
-        errorMsg = t("error.aggregation", { msg: (e as Error).message });
-      }
-    })();
+    void recipeStore.restoreInitial();
   });
 
-  // crossSelected starts empty; AggSettingsPopover reads `crossSelected[code] ?? false`
-  // and onCrossToggle adds keys lazily, so we don't need an effect to seed it.
-  // Stale keys for deleted recipes are pruned in handleDeleteRecipe.
-
-  // Increments per scheduled run; only the latest run is allowed to commit results
-  let latestRunId = 0;
-
-  async function handleRunAggregation(runId: number): Promise<void> {
-    const activeWeightCol = weightEnabled ? weightColumnName : "";
-    const crossQuestions = questions.filter((q) => crossSelected[q.code]);
-
-    try {
-      const tabs = await runAggregation(questions, crossQuestions, activeWeightCol, matrixLabels);
-      if (runId !== latestRunId) return;
-      aggResult = { tabs, weightCol: activeWeightCol };
-      errorMsg = "";
-    } catch (e) {
-      if (runId !== latestRunId) return;
-      errorMsg = t("error.aggregation", { msg: (e as Error).message });
-    }
-  }
-
-  // Auto-run aggregation whenever cross selection or weight toggle changes.
-  // A monotonic runId is captured per scheduling; older runs that finish later are dropped.
+  // Auto-run aggregation whenever questions / cross selection / weight toggle change.
+  // The runner's internal runId guards against out-of-order completions.
   $effect(() => {
-    if (questions.length === 0) return;
-    const runId = ++latestRunId;
-    void handleRunAggregation(runId);
+    if (recipeStore.questions.length === 0) return;
+    void aggRunner.run(
+      recipeStore.questions,
+      recipeStore.weightColumnName,
+      recipeStore.matrixLabels,
+    );
   });
 
   // Persist recipes whenever they change. Best-effort.
   $effect(() => {
-    const json = JSON.stringify(recipes);
+    const json = JSON.stringify(recipeStore.recipes);
     void saveRecipes(folderId, json).catch(() => {});
   });
+
+  // Surface either the recipe-side or aggregation-side error on the result screen.
+  let resultError = $derived(aggRunner.error || recipeStore.error);
 
   function handleAddRecipe(): void {
     viewMode = { kind: "recipe", mode: "type-select", editCode: null };
@@ -118,33 +71,14 @@
 
   async function handleDeleteRecipe(code: string): Promise<void> {
     if (!confirm(t("derived.delete.confirm", { code }))) return;
-    try {
-      await dropDerivedColumn(code);
-    } catch {
-      // Best-effort: column may not exist if previous prepare failed
-    }
-    if (crossSelected[code]) {
-      const next = { ...crossSelected };
-      delete next[code];
-      crossSelected = next;
-    }
-    derivedLayout = derivedLayout.filter((q) => q.key !== code);
-    recipes = recipes.filter((r) => r.code !== code);
+    await recipeStore.remove(code);
+    aggRunner.pruneCode(code);
   }
 
   async function handleRecipeCommit(next: DerivedRecipe[]): Promise<string | null> {
-    const errs = validateRecipes(next, preparedLayout);
-    if (errs.length > 0) return errs[0];
-    try {
-      const result = await prepareDerivedLayout(preparedLayout, next);
-      derivedLayout = result.layout;
-      derivedWarnings = result.warnings;
-      recipes = next;
-      viewMode = { kind: "results" };
-      return null;
-    } catch (e) {
-      return (e as Error).message;
-    }
+    const err = await recipeStore.commit(next);
+    if (err === null) viewMode = { kind: "results" };
+    return err;
   }
 
   function handleRecipeCancel(): void {
@@ -155,10 +89,10 @@
 <SettingsPanel
   {rawData}
   {layout}
-  {questions}
-  {matrixGroups}
-  dateWarnings={[...dateWarnings, ...derivedWarnings]}
-  {recipes}
+  questions={recipeStore.questions}
+  matrixGroups={recipeStore.matrixGroups}
+  dateWarnings={[...dateWarnings, ...recipeStore.derivedWarnings]}
+  recipes={recipeStore.recipes}
   onAddRecipe={handleAddRecipe}
   onEditRecipe={handleEditRecipe}
   onDeleteRecipe={handleDeleteRecipe}
@@ -166,9 +100,9 @@
 
 {#if viewMode.kind === "recipe"}
   <DerivedRecipePanel
-    {recipes}
+    recipes={recipeStore.recipes}
     baseLayout={preparedLayout}
-    {derivedLayout}
+    derivedLayout={recipeStore.derivedLayout}
     initialMode={viewMode.mode}
     initialEditCode={viewMode.editCode}
     onCommit={handleRecipeCommit}
@@ -176,15 +110,15 @@
   />
 {:else}
   <ResultPanel
-    tabs={aggResult?.tabs ?? null}
-    weightCol={aggResult?.weightCol ?? ""}
-    {questions}
-    {crossSelected}
-    onCrossToggle={(key, checked) => (crossSelected = { ...crossSelected, [key]: checked })}
-    {weightColumnName}
-    {weightEnabled}
-    onWeightToggle={(on) => (weightEnabled = on)}
-    {errorMsg}
+    tabs={aggRunner.result?.tabs ?? null}
+    weightCol={aggRunner.result?.weightCol ?? ""}
+    questions={recipeStore.questions}
+    crossSelected={aggRunner.crossSelected}
+    onCrossToggle={(key, checked) => aggRunner.toggleCross(key, checked)}
+    weightColumnName={recipeStore.weightColumnName}
+    weightEnabled={aggRunner.weightEnabled}
+    onWeightToggle={(on) => aggRunner.toggleWeight(on)}
+    errorMsg={resultError}
     onAddDerived={handleAddRecipe}
   />
 {/if}

--- a/src/lib/aggRunner.svelte.ts
+++ b/src/lib/aggRunner.svelte.ts
@@ -1,0 +1,49 @@
+import type { Question, Tab } from "./types";
+import { runAggregation } from "./duckdb.svelte";
+import { t } from "./i18n.svelte";
+
+export class AggRunner {
+  crossSelected = $state<Record<string, boolean>>({});
+  weightEnabled = $state(true);
+  result = $state<{ tabs: Tab[]; weightCol: string } | null>(null);
+  error = $state("");
+
+  // Increments per scheduled run; only the latest run is allowed to commit results.
+  private latestRunId = 0;
+
+  toggleCross(code: string, on: boolean): void {
+    this.crossSelected = { ...this.crossSelected, [code]: on };
+  }
+
+  toggleWeight(on: boolean): void {
+    this.weightEnabled = on;
+  }
+
+  /** Drop a code from crossSelected — call after RecipeStore.remove(code). */
+  pruneCode(code: string): void {
+    if (!(code in this.crossSelected)) return;
+    const next = { ...this.crossSelected };
+    delete next[code];
+    this.crossSelected = next;
+  }
+
+  async run(
+    questions: Question[],
+    weightColumnName: string,
+    matrixLabels: Record<string, string>,
+  ): Promise<void> {
+    const runId = ++this.latestRunId;
+    const activeWeightCol = this.weightEnabled ? weightColumnName : "";
+    const crossQuestions = questions.filter((q) => this.crossSelected[q.code]);
+
+    try {
+      const tabs = await runAggregation(questions, crossQuestions, activeWeightCol, matrixLabels);
+      if (runId !== this.latestRunId) return;
+      this.result = { tabs, weightCol: activeWeightCol };
+      this.error = "";
+    } catch (e) {
+      if (runId !== this.latestRunId) return;
+      this.error = t("error.aggregation", { msg: (e as Error).message });
+    }
+  }
+}

--- a/src/lib/aggRunner.svelte.ts
+++ b/src/lib/aggRunner.svelte.ts
@@ -3,6 +3,10 @@ import { runAggregation } from "./duckdb.svelte";
 import { t } from "./i18n.svelte";
 
 export class AggRunner {
+  // Starts empty and is populated lazily by toggleCross. Consumers read
+  // `crossSelected[code] ?? false`, so missing keys mean "off" — no seeding
+  // effect needed when the question set changes. Stale keys for removed
+  // recipes are dropped via pruneCode().
   crossSelected = $state<Record<string, boolean>>({});
   weightEnabled = $state(true);
   result = $state<{ tabs: Tab[]; weightCol: string } | null>(null);

--- a/src/lib/recipeStore.svelte.ts
+++ b/src/lib/recipeStore.svelte.ts
@@ -38,6 +38,7 @@ export class RecipeStore {
       const result = await prepareDerivedLayout(this.baseLayout, this.recipes);
       this.derivedLayout = result.layout;
       this.derivedWarnings = result.warnings;
+      this.error = "";
     } catch (e) {
       this.error = t("error.aggregation", { msg: (e as Error).message });
     }
@@ -52,6 +53,7 @@ export class RecipeStore {
       this.derivedLayout = result.layout;
       this.derivedWarnings = result.warnings;
       this.recipes = next;
+      this.error = "";
       return null;
     } catch (e) {
       return (e as Error).message;
@@ -73,5 +75,6 @@ export class RecipeStore {
     }
     this.derivedLayout = this.derivedLayout.filter((q) => q.key !== code);
     this.recipes = this.recipes.filter((r) => r.code !== code);
+    this.error = "";
   }
 }

--- a/src/lib/recipeStore.svelte.ts
+++ b/src/lib/recipeStore.svelte.ts
@@ -1,0 +1,77 @@
+import type { Layout } from "./layout";
+import { buildQuestions, buildMatrixGroups, findWeightColumn } from "./layout";
+import type { DerivedRecipe } from "./derivedRecipe";
+import { validateRecipes } from "./derivedRecipe";
+import { prepareDerivedLayout, dropDerivedColumn } from "./duckdb.svelte";
+import { t } from "./i18n.svelte";
+
+export class RecipeStore {
+  recipes = $state<DerivedRecipe[]>([]);
+  derivedLayout = $state<Layout>([]);
+  derivedWarnings = $state<string[]>([]);
+  error = $state("");
+
+  questions = $derived(buildQuestions(this.derivedLayout));
+  weightColumnName = $derived(findWeightColumn(this.derivedLayout));
+  matrixGroups = $derived(buildMatrixGroups(this.derivedLayout));
+  matrixLabels = $derived(
+    Object.fromEntries(this.matrixGroups.map((g) => [g.matrixKey, g.matrixLabel])),
+  );
+
+  constructor(
+    private readonly baseLayout: Layout,
+    initial: DerivedRecipe[],
+  ) {
+    this.recipes = initial;
+    this.derivedLayout = baseLayout;
+  }
+
+  /**
+   * Run prepareDerivedLayout once for OPFS-restored recipes.
+   * Subsequent recipe mutations go through commit() / remove(), which keep
+   * derivedLayout in sync explicitly — avoiding the double prepare an
+   * effect-on-recipes would cause right after a commit.
+   */
+  async restoreInitial(): Promise<void> {
+    if (this.recipes.length === 0) return;
+    try {
+      const result = await prepareDerivedLayout(this.baseLayout, this.recipes);
+      this.derivedLayout = result.layout;
+      this.derivedWarnings = result.warnings;
+    } catch (e) {
+      this.error = t("error.aggregation", { msg: (e as Error).message });
+    }
+  }
+
+  /** Returns null on success, an error message string on validation/prepare failure. */
+  async commit(next: DerivedRecipe[]): Promise<string | null> {
+    const errs = validateRecipes(next, this.baseLayout);
+    if (errs.length > 0) return errs[0];
+    try {
+      const result = await prepareDerivedLayout(this.baseLayout, next);
+      this.derivedLayout = result.layout;
+      this.derivedWarnings = result.warnings;
+      this.recipes = next;
+      return null;
+    } catch (e) {
+      return (e as Error).message;
+    }
+  }
+
+  /**
+   * Remove a recipe and drop its derived column. Caller is responsible for
+   * pruning any UI state keyed by `code` (e.g. cross-tab selections).
+   * The DROP COLUMN must happen before the recipes array shrinks because
+   * prepareDerivedLayout only DROPs columns for currently-listed recipes —
+   * a removed recipe's column would otherwise linger on the survey table.
+   */
+  async remove(code: string): Promise<void> {
+    try {
+      await dropDerivedColumn(code);
+    } catch {
+      // Best-effort: column may not exist if a previous prepare failed
+    }
+    this.derivedLayout = this.derivedLayout.filter((q) => q.key !== code);
+    this.recipes = this.recipes.filter((r) => r.code !== code);
+  }
+}


### PR DESCRIPTION
## Summary
- Split `AggregationScreen` 状態を 2 つの reactive class に抽出
  - `RecipeStore` (`src/lib/recipeStore.svelte.ts`) — recipes / derivedLayout / derivedWarnings / レイアウト由来の `$derived` を保持。`restoreInitial` / `commit` / `remove` を公開
  - `AggRunner` (`src/lib/aggRunner.svelte.ts`) — crossSelected / weightEnabled / result と runId ガード付き `run()` を保持
- `AggregationScreen.svelte` は薄い glue に（~190 → ~120 行）。store 2 つ、`$effect` 2 本（auto-run + OPFS 永続化）、`viewMode` のみコンポーネントローカル
- エラーをドメイン別に分割：`recipeStore.error`（onMount 復元失敗）と `aggRunner.error`（集計失敗）を `$derived` で union して ResultPanel に渡す
- 既存の良い性質は維持：失敗時ロールバック（commit は prepare 成功後に recipes 差し替え）、`dropDerivedColumn` を recipes 縮小前に呼ぶ不変条件、`runId` による古い結果破棄

## Test plan
- [x] `vp check` — 0 errors
- [x] `vp test run` — 1894 / 1894 passed
- [ ] 派生設問の追加 / 編集 / 削除で結果が更新される
- [ ] クロス集計トグルとウェイトトグルで結果が更新される
- [ ] 保存済みフォルダを再読込して、レシピと派生列がエラーなく復元される

🤖 Generated with [Claude Code](https://claude.com/claude-code)