### PR TITLE
semantic HTMLとアクセシビリティ構造を改善

### DIFF
--- a/src/components/ImportScreen.svelte
+++ b/src/components/ImportScreen.svelte
@@ -237,13 +237,14 @@
 </script>
 
 {#snippet StepIndicator(currentStep: number)}
-  <div class="mb-6 flex items-center justify-center gap-0">
+  <ol class="mb-6 flex items-center justify-center gap-0" aria-label={t("import.title")}>
     {#each STEPS as s, i (s.num)}
       {@const isDone = s.num < currentStep}
       {@const isActive = s.num === currentStep}
-      <div class="flex items-center">
+      <li class="flex items-center" aria-current={isActive ? "step" : undefined}>
         {#if i > 0}
           <div
+            aria-hidden="true"
             class="mx-2 h-px w-8 transition-colors duration-300 {s.num <= currentStep
               ? 'bg-accent'
               : 'bg-border'}"
@@ -269,9 +270,9 @@
             {t(s.labelKey)}
           </span>
         </div>
-      </div>
+      </li>
     {/each}
-  </div>
+  </ol>
 {/snippet}
 
 <div class="flex items-center justify-center p-6">

--- a/src/components/aggregation/AggSettingsPopover.svelte
+++ b/src/components/aggregation/AggSettingsPopover.svelte
@@ -130,7 +130,7 @@
           <span class="truncate text-text" title={weightColumnName}>
             {t("weight.label", { col: weightColumnName })}
           </span>
-          <ToggleGroup>
+          <ToggleGroup role="group" aria-label={t("weight.label", { col: weightColumnName })}>
             <ToggleButton active={weightEnabled} onclick={() => onWeightToggle(true)}>
               {t("weight.on")}
             </ToggleButton>

--- a/src/components/aggregation/BinNAForm.svelte
+++ b/src/components/aggregation/BinNAForm.svelte
@@ -217,7 +217,13 @@
   }
 </script>
 
-<div class="mx-auto flex max-w-[820px] flex-col gap-5">
+<form
+  class="mx-auto flex max-w-[820px] flex-col gap-5"
+  onsubmit={(event) => {
+    event.preventDefault();
+    void handleSave();
+  }}
+>
   <div class="flex flex-col gap-1.5">
     <label for="binNA-source" class="text-sm font-medium text-text">
       {t("derived.binNA.source")}
@@ -292,27 +298,30 @@
     </div>
   {/if}
 
-  <div class="flex flex-col gap-2">
-    <span class="text-sm font-medium text-text">{t("derived.binNA.bins")}</span>
+  <fieldset class="flex flex-col gap-2 border-0 p-0">
+    <legend class="text-sm font-medium text-text">{t("derived.binNA.bins")}</legend>
     <div class="overflow-x-auto rounded-md border border-border bg-surface">
       <table class="w-full text-sm">
+        <caption class="sr-only">{t("derived.binNA.bins")}</caption>
         <thead class="bg-surface2">
           <tr>
-            <th class="w-[20%] px-2 py-2 text-left text-xs font-bold text-muted">
+            <th scope="col" class="w-[20%] px-2 py-2 text-left text-xs font-bold text-muted">
               {t("derived.binNA.bin.code")}
             </th>
-            <th class="w-[28%] px-2 py-2 text-left text-xs font-bold text-muted">
+            <th scope="col" class="w-[28%] px-2 py-2 text-left text-xs font-bold text-muted">
               {t("derived.binNA.bin.label")}
             </th>
-            <th class="w-[20%] px-2 py-2 text-left text-xs font-bold text-muted">
+            <th scope="col" class="w-[20%] px-2 py-2 text-left text-xs font-bold text-muted">
               {t("derived.binNA.bin.min")}
               <span class="font-normal text-muted">({t("derived.binNA.bin.minHint")})</span>
             </th>
-            <th class="w-[20%] px-2 py-2 text-left text-xs font-bold text-muted">
+            <th scope="col" class="w-[20%] px-2 py-2 text-left text-xs font-bold text-muted">
               {t("derived.binNA.bin.max")}
               <span class="font-normal text-muted">({t("derived.binNA.bin.maxHint")})</span>
             </th>
-            <th class="w-[12%] px-2 py-2"></th>
+            <th scope="col" class="w-[12%] px-2 py-2">
+              <span class="sr-only">{t("derived.delete")}</span>
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -321,6 +330,7 @@
               <td class="px-2 py-1.5">
                 <input
                   type="text"
+                  aria-label={`${t("derived.binNA.bin.code")} ${i + 1}`}
                   bind:value={row.code}
                   class="w-full rounded-sm border border-border bg-surface px-2 py-1 font-mono text-xs text-text focus:border-accent focus:outline-none"
                   autocomplete="off"
@@ -330,6 +340,7 @@
               <td class="px-2 py-1.5">
                 <input
                   type="text"
+                  aria-label={`${t("derived.binNA.bin.label")} ${i + 1}`}
                   bind:value={row.label}
                   class="w-full rounded-sm border border-border bg-surface px-2 py-1 text-xs text-text focus:border-accent focus:outline-none"
                   autocomplete="off"
@@ -339,6 +350,7 @@
               <td class="px-2 py-1.5">
                 <input
                   type="text"
+                  aria-label={`${t("derived.binNA.bin.min")} ${i + 1}`}
                   inputmode="decimal"
                   bind:value={row.min}
                   class="w-full rounded-sm border border-border bg-surface px-2 py-1 font-mono text-xs text-text focus:border-accent focus:outline-none"
@@ -349,6 +361,7 @@
               <td class="px-2 py-1.5">
                 <input
                   type="text"
+                  aria-label={`${t("derived.binNA.bin.max")} ${i + 1}`}
                   inputmode="decimal"
                   bind:value={row.max}
                   class="w-full rounded-sm border border-border bg-surface px-2 py-1 font-mono text-xs text-text focus:border-accent focus:outline-none"
@@ -374,7 +387,7 @@
       class="self-start cursor-pointer rounded-md border border-border bg-surface px-3 py-1.5 text-xs text-text-secondary hover:bg-surface2 hover:text-text"
       onclick={addRow}
     >+ {t("derived.binNA.bin.add")}</button>
-  </div>
+  </fieldset>
 
   {#if coverage && naStats}
     {#if coverage.uncoveredCount === 0}
@@ -396,11 +409,11 @@
   {/if}
 
   <div class="flex justify-end gap-2 pt-2">
-    <Button variant="secondary" size="md" onclick={onCancel} disabled={saving}>
+    <Button variant="secondary" size="md" type="button" onclick={onCancel} disabled={saving}>
       {t("derived.cancel")}
     </Button>
-    <Button variant="primary" size="md" onclick={handleSave} disabled={saving}>
+    <Button variant="primary" size="md" type="submit" disabled={saving}>
       {saving ? t("derived.saving") : t("derived.save")}
     </Button>
   </div>
-</div>
+</form>

--- a/src/components/aggregation/ChartCardBody.svelte
+++ b/src/components/aggregation/ChartCardBody.svelte
@@ -4,6 +4,7 @@
   import { Chart, getSeriesColor, getThemeColors, type PaletteId } from "../../lib/chartConfig";
   import type { ChartType } from "./viewTypes";
   import type { ChartConfiguration } from "chart.js";
+  import { t as translate } from "../../lib/i18n.svelte";
 
   interface Props {
     tab: Tab;
@@ -236,6 +237,9 @@
   }
 </script>
 
-<div class="p-4 {isCross ? 'h-[400px]' : 'h-80'}">
-  <canvas bind:this={canvas}></canvas>
-</div>
+<figure class="p-4 {isCross ? 'h-[400px]' : 'h-80'}">
+  <canvas bind:this={canvas} aria-hidden="true"></canvas>
+  <figcaption class="sr-only">
+    {translate("table.caption.cross", { question: tab.label })}
+  </figcaption>
+</figure>

--- a/src/components/aggregation/CombineSAForm.svelte
+++ b/src/components/aggregation/CombineSAForm.svelte
@@ -103,24 +103,30 @@
   }
 </script>
 
-<div class="mx-auto flex max-w-[720px] flex-col gap-5">
-  <div class="flex flex-col gap-1.5">
-    <span class="text-sm font-medium text-text">{t("derived.combineSA.sources")}</span>
+<form
+  class="mx-auto flex max-w-[720px] flex-col gap-5"
+  onsubmit={(event) => {
+    event.preventDefault();
+    void handleSave();
+  }}
+>
+  <fieldset class="flex flex-col gap-1.5 border-0 p-0">
+    <legend class="text-sm font-medium text-text">{t("derived.combineSA.sources")}</legend>
     <div class="flex max-h-64 flex-col gap-0.5 overflow-y-auto rounded-md border border-border bg-surface p-2">
       {#each saQuestions as q (q.key)}
         {@const checked = sources.includes(q.key)}
         {@const order = sources.indexOf(q.key)}
-        <label
-          class="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-surface2"
-        >
-          <input
-            type="checkbox"
-            {checked}
-            onchange={() => toggleSource(q.key)}
-            class="size-4 cursor-pointer accent-accent"
-          />
-          <span class="shrink-0 font-mono text-xs text-muted">{q.key}</span>
-          <span class="flex-1 truncate text-text">{q.label}</span>
+        <div class="flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-surface2">
+          <label class="flex min-w-0 flex-1 cursor-pointer items-center gap-2">
+            <input
+              type="checkbox"
+              {checked}
+              onchange={() => toggleSource(q.key)}
+              class="size-4 cursor-pointer accent-accent"
+            />
+            <span class="shrink-0 font-mono text-xs text-muted">{q.key}</span>
+            <span class="flex-1 truncate text-text">{q.label}</span>
+          </label>
           {#if checked}
             <span class="shrink-0 rounded bg-accent-bg px-1.5 text-xs font-bold text-accent">
               {order + 1}
@@ -146,13 +152,13 @@
               aria-label="Move down"
             >↓</button>
           {/if}
-        </label>
+        </div>
       {/each}
       {#if saQuestions.length === 0}
         <p class="px-2 py-2 text-xs text-muted">No SA questions</p>
       {/if}
     </div>
-  </div>
+  </fieldset>
 
   <div class="flex flex-col gap-1.5">
     <label for="combineSA-sep" class="text-sm font-medium text-text">
@@ -224,11 +230,11 @@
   {/if}
 
   <div class="flex justify-end gap-2 pt-2">
-    <Button variant="secondary" size="md" onclick={onCancel} disabled={saving}>
+    <Button variant="secondary" size="md" type="button" onclick={onCancel} disabled={saving}>
       {t("derived.cancel")}
     </Button>
-    <Button variant="primary" size="md" onclick={handleSave} disabled={saving}>
+    <Button variant="primary" size="md" type="submit" disabled={saving}>
       {saving ? t("derived.saving") : t("derived.save")}
     </Button>
   </div>
-</div>
+</form>

--- a/src/components/aggregation/CrossTable.svelte
+++ b/src/components/aggregation/CrossTable.svelte
@@ -25,9 +25,12 @@
     <caption class="sr-only">{t("table.caption.cross", { question: tab.label })}</caption>
     <thead>
       <tr>
-        <th class="py-3 px-4"></th>
+        <th scope="col" class="py-3 px-4">
+          <span class="sr-only">{t("table.total")}</span>
+        </th>
         {#each tab.codes as code (code)}
           <th
+            scope="col"
             class="{TH_BASE} text-right text-xs whitespace-nowrap border-l border-row-border bg-surface2"
           >
             {tab.labels[code]}
@@ -38,11 +41,12 @@
     <tbody>
       <!-- Tab total row -->
       <tr class="[&_td]:border-b-2 [&_td]:border-border-strong">
-        <td
+        <th
+          scope="row"
           class="{TD_BASE} text-left text-xs font-bold whitespace-nowrap border-r-2 border-r-border-strong bg-tab-bg text-accent"
         >
           {t("table.total")}
-        </td>
+        </th>
         {#each tab.codes as code, i (code)}
           {@const cell = tabSlice.cells[i]}
           <td class="{TD_BASE} {MONO} text-accent bg-tab-bg">
@@ -54,22 +58,23 @@
       <!-- Cross sub rows -->
       {#each crossTabs as ct (ct.by!.code)}
         <tr>
-          <td
+          <th
             colspan={tab.codes.length + 1}
             class="py-3 px-4 bg-cross-bg text-accent2 font-bold text-xs tracking-wide border-b-2 border-border-strong border-t-2 border-t-border-strong"
           >
             {ct.by!.label}
-          </td>
+          </th>
         </tr>
         {#each ct.slices as slice (`${ct.by!.code}-${slice.code}`)}
           <tr>
-            <td
+            <th
+              scope="row"
               class="{TD_BASE} text-left text-xs font-bold whitespace-nowrap border-r-2 border-r-border-strong text-accent2"
             >
               {ct.by!.labels[slice.code!]}
               <br />
               <span class="text-muted text-xs font-normal">n={formatN(slice.n)}</span>
-            </td>
+            </th>
             {#each tab.codes as _code, i (_code)}
               {@const cell = slice.cells[i]}
               <td class="{TD_BASE} {MONO} text-accent2 border-l border-l-row-border">
@@ -87,12 +92,15 @@
     <caption class="sr-only">{t("table.caption.cross", { question: tab.label })}</caption>
     <thead>
       <tr>
-        <th rowspan="2" class="py-3 px-4"></th>
-        <th colspan="2" class="{TH_BASE} text-center bg-tab-bg text-accent">
+        <th scope="col" rowspan="2" class="py-3 px-4">
+          <span class="sr-only">{t("table.option")}</span>
+        </th>
+        <th scope="colgroup" colspan="2" class="{TH_BASE} text-center bg-tab-bg text-accent">
           {t("table.total")}
         </th>
         {#each crossTabs as ct (ct.by!.code)}
           <th
+            scope="colgroup"
             colspan={ct.slices.length}
             class="{TH_BASE} text-center bg-cross-bg border-l border-border text-accent2 {hasMultipleAxes
               ? 'border-l-2 border-l-border-strong'
@@ -108,6 +116,7 @@
         {#each crossTabs as ct, gi (ct.by!.code)}
           {#each ct.slices as slice, si (`${ct.by!.code}-${slice.code}`)}
             <th
+              scope="col"
               class="{TH_BASE} text-right text-xs whitespace-nowrap border-l border-row-border bg-surface2 {hasMultipleAxes &&
               si === 0 &&
               gi > 0
@@ -126,7 +135,7 @@
       {#each tab.codes as code, i (code)}
         {@const tabCell = tabSlice.cells[i]}
         <tr>
-          <Td>{tab.labels[code]}</Td>
+          <th scope="row" class="{TD_BASE} text-left font-normal">{tab.labels[code]}</th>
           <Td right mono>{formatN(tabCell.count)}</Td>
           <Td right mono class="text-muted">
             {tabCell.pct !== null ? tabCell.pct.toFixed(1) + "%" : "-"}

--- a/src/components/aggregation/ExportMenu.svelte
+++ b/src/components/aggregation/ExportMenu.svelte
@@ -27,9 +27,12 @@
 
 <div class="relative" {@attach clickOutside({ onClose: () => (open = false) })}>
   <button
+    type="button"
     class="relative flex size-9 cursor-pointer items-center justify-center rounded-lg border border-border text-muted transition-colors hover:border-accent hover:text-accent"
     onclick={() => (open = !open)}
     aria-label={t("export.label")}
+    aria-expanded={open}
+    aria-haspopup="dialog"
     title={t("export.label")}
   >
     {#if showFeedback}
@@ -66,19 +69,24 @@
   {#if open}
     <div
       class="absolute right-0 z-10 mt-1 min-w-48 rounded-lg border border-border bg-surface shadow-lg"
+      role="dialog"
+      aria-label={t("export.label")}
     >
       <div class="px-3 pt-2.5 pb-1 text-xs font-medium tracking-wide text-muted uppercase">
         {t("export.section.copy")}
       </div>
       <button
+        type="button"
         class="block w-full cursor-pointer px-3 py-1.5 text-left text-xs text-text hover:bg-accent-bg"
         onclick={() => handleAction("copy-tsv")}>TSV</button
       >
       <button
+        type="button"
         class="block w-full cursor-pointer px-3 py-1.5 text-left text-xs text-text hover:bg-accent-bg"
         onclick={() => handleAction("copy-markdown")}>Markdown</button
       >
       <button
+        type="button"
         class="block w-full cursor-pointer px-3 py-1.5 text-left text-xs text-text hover:bg-accent-bg"
         onclick={() => handleAction("copy-json")}>JSON</button
       >
@@ -92,14 +100,17 @@
       </div>
       <div class="pb-1.5">
         <button
+          type="button"
           class="block w-full cursor-pointer px-3 py-1.5 text-left text-xs text-text hover:bg-accent-bg"
           onclick={() => handleAction("download-csv")}>CSV</button
         >
         <button
+          type="button"
           class="block w-full cursor-pointer px-3 py-1.5 text-left text-xs text-text hover:bg-accent-bg"
           onclick={() => handleAction("download-markdown")}>Markdown (.md)</button
         >
         <button
+          type="button"
           class="block w-full cursor-pointer px-3 py-1.5 text-left text-xs text-text hover:bg-accent-bg"
           onclick={() => handleAction("download-json")}>JSON (.json)</button
         >

--- a/src/components/aggregation/MatrixGtChart.svelte
+++ b/src/components/aggregation/MatrixGtChart.svelte
@@ -3,6 +3,7 @@
   import { Chart, getSeriesColor, getThemeColors, type PaletteId } from "../../lib/chartConfig";
   import type { ChartType } from "./viewTypes";
   import type { ChartConfiguration } from "chart.js";
+  import { t as translate } from "../../lib/i18n.svelte";
 
   interface Props {
     tabs: Tab[];
@@ -11,6 +12,12 @@
   }
 
   let { tabs, chartType, paletteId }: Props = $props();
+
+  let accessibleLabel = $derived(
+    translate("table.caption.tab", {
+      question: tabs.map((tab) => tab.label).join(", "),
+    }),
+  );
 
   let canvas: HTMLCanvasElement;
   let chart: Chart | null = null;
@@ -126,6 +133,7 @@
   }
 </script>
 
-<div class="h-[400px] p-4">
-  <canvas bind:this={canvas}></canvas>
-</div>
+<figure class="h-[400px] p-4">
+  <canvas bind:this={canvas} aria-hidden="true"></canvas>
+  <figcaption class="sr-only">{accessibleLabel}</figcaption>
+</figure>

--- a/src/components/aggregation/MatrixGtTable.svelte
+++ b/src/components/aggregation/MatrixGtTable.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
   import type { Tab } from "../../lib/types";
   import { formatN } from "../../lib/format";
+  import { t } from "../../lib/i18n.svelte";
   import Th from "./Th.svelte";
   import Td from "./Td.svelte";
+  import { TD_BASE } from "./tableCellStyles";
 
   interface Props {
     tabs: Tab[];
+    caption: string;
   }
 
-  let { tabs }: Props = $props();
+  let { tabs, caption }: Props = $props();
 
   // All children share the same codes/labels (common-option matrix precondition)
   let codes = $derived(tabs[0].codes);
@@ -16,9 +19,10 @@
 </script>
 
 <table class="w-full border-collapse text-sm tabular-nums">
+  <caption class="sr-only">{caption}</caption>
   <thead>
     <tr>
-      <Th></Th>
+      <Th><span class="sr-only">{t("table.question")}</span></Th>
       <Th right>n</Th>
       {#each codes as code (code)}
         <Th right>{labels[code]}</Th>
@@ -29,7 +33,7 @@
     {#each tabs as tab (tab.questionCode)}
       {@const slice = tab.slices[0]}
       <tr>
-        <Td>{tab.label}</Td>
+        <th scope="row" class="{TD_BASE} text-left font-normal">{tab.label}</th>
         <Td right mono>{formatN(slice.n)}</Td>
         {#each codes as code, i (code)}
           {@const cell = slice.cells[i]}

--- a/src/components/aggregation/MatrixNaGtChart.svelte
+++ b/src/components/aggregation/MatrixNaGtChart.svelte
@@ -11,6 +11,10 @@
 
   let { tabs, paletteId }: Props = $props();
 
+  let accessibleLabel = $derived(
+    t("table.caption.tab", { question: tabs.map((tab) => tab.label).join(", ") }),
+  );
+
   let canvas: HTMLCanvasElement;
   let chart: Chart | null = null;
   let binWidth = $state(0);
@@ -150,7 +154,8 @@
       <span class="w-6 text-center tabular-nums">{binWidth || "–"}</span>
     </div>
   {/if}
-  <div class="relative flex-1 min-h-0">
-    <canvas bind:this={canvas}></canvas>
-  </div>
+  <figure class="relative flex-1 min-h-0">
+    <canvas bind:this={canvas} aria-hidden="true"></canvas>
+    <figcaption class="sr-only">{accessibleLabel}</figcaption>
+  </figure>
 </div>

--- a/src/components/aggregation/MatrixNaGtTable.svelte
+++ b/src/components/aggregation/MatrixNaGtTable.svelte
@@ -4,20 +4,23 @@
   import { t } from "../../lib/i18n.svelte";
   import Th from "./Th.svelte";
   import Td from "./Td.svelte";
+  import { TD_BASE } from "./tableCellStyles";
 
   interface Props {
     tabs: Tab[];
+    caption: string;
   }
 
-  let { tabs }: Props = $props();
+  let { tabs, caption }: Props = $props();
 
   const STAT_KEYS = ["n", "mean", "median", "sd", "min", "max"] as const;
 </script>
 
 <table class="w-full border-collapse text-sm tabular-nums">
+  <caption class="sr-only">{caption}</caption>
   <thead>
     <tr>
-      <Th></Th>
+      <Th><span class="sr-only">{t("table.question")}</span></Th>
       {#each STAT_KEYS as key (key)}
         <Th right>{t(`na.stat.${key}`)}</Th>
       {/each}
@@ -27,7 +30,7 @@
     {#each tabs as tab (tab.questionCode)}
       {@const stats = tab.slices[0].stats!}
       <tr>
-        <Td>{tab.label}</Td>
+        <th scope="row" class="{TD_BASE} text-left font-normal">{tab.label}</th>
         {#each STAT_KEYS as key (key)}
           <Td right mono>{formatStat(key, stats[key])}</Td>
         {/each}

--- a/src/components/aggregation/MatrixTabCard.svelte
+++ b/src/components/aggregation/MatrixTabCard.svelte
@@ -31,15 +31,18 @@
   let chartType = $derived(firstType === "MA" ? chartOpts.maChartType : chartOpts.saChartType);
 </script>
 
-<div
+<article
   id="card-matrix-{matrix.key}"
+  aria-labelledby="card-matrix-title-{matrix.key}"
   class="overflow-hidden rounded-xl border border-border bg-surface shadow-sm{hasCross
     ? ' overflow-x-auto'
     : ''}"
 >
   <div class="flex items-baseline gap-3 border-b border-border p-4">
     <div class="flex min-w-0 flex-col gap-0.5">
-      <span class="text-sm font-bold text-accent">{matrix.label}</span>
+      <h3 id="card-matrix-title-{matrix.key}" class="text-sm font-bold text-accent">
+        {matrix.label}
+      </h3>
       <span class="text-xs tracking-wide text-muted">{matrix.key}</span>
     </div>
     <span class="text-xs tracking-wide text-muted">{firstType} MATRIX</span>
@@ -49,11 +52,14 @@
     {#if hasCross}
       <div class="divide-y divide-border">
         {#each items as it (it.gtTab.questionCode)}
-          <div>
-            <div class="bg-surface2 px-4 py-2 text-xs font-bold text-muted">
+          <section aria-labelledby="matrix-item-title-{it.gtTab.questionCode}">
+            <h4
+              id="matrix-item-title-{it.gtTab.questionCode}"
+              class="bg-surface2 px-4 py-2 text-xs font-bold text-muted"
+            >
               {it.gtTab.label}
               <span class="ml-2 text-muted">({it.gtTab.questionCode})</span>
-            </div>
+            </h4>
             {#if it.gtTab.type === "NA"}
               <NaChartCardBody
                 tab={it.gtTab}
@@ -70,7 +76,7 @@
                 paletteId={chartOpts.paletteId}
               />
             {/if}
-          </div>
+          </section>
         {/each}
       </div>
     {:else if firstType === "NA"}
@@ -81,22 +87,25 @@
   {:else if hasCross}
     <div class="divide-y divide-border">
       {#each items as it (it.gtTab.questionCode)}
-        <div>
-          <div class="bg-surface2 px-4 py-2 text-xs font-bold text-muted">
+        <section aria-labelledby="matrix-table-title-{it.gtTab.questionCode}">
+          <h4
+            id="matrix-table-title-{it.gtTab.questionCode}"
+            class="bg-surface2 px-4 py-2 text-xs font-bold text-muted"
+          >
             {it.gtTab.label}
             <span class="ml-2 text-muted">({it.gtTab.questionCode})</span>
-          </div>
+          </h4>
           {#if it.gtTab.type === "NA"}
             <NaCrossTable tab={it.gtTab} crossTabs={it.crossTabs} />
           {:else}
             <CrossTable tab={it.gtTab} crossTabs={it.crossTabs} basis={tableOpts.basis} />
           {/if}
-        </div>
+        </section>
       {/each}
     </div>
   {:else if firstType === "NA"}
-    <MatrixNaGtTable tabs={gtTabs} />
+    <MatrixNaGtTable tabs={gtTabs} caption={matrix.label} />
   {:else}
-    <MatrixGtTable tabs={gtTabs} />
+    <MatrixGtTable tabs={gtTabs} caption={matrix.label} />
   {/if}
-</div>
+</article>

--- a/src/components/aggregation/NaChartCardBody.svelte
+++ b/src/components/aggregation/NaChartCardBody.svelte
@@ -239,7 +239,10 @@
       <span class="w-6 text-center tabular-nums">{binWidth || "–"}</span>
     </div>
   {/if}
-  <div class="relative flex-1 min-h-0">
-    <canvas bind:this={canvas}></canvas>
-  </div>
+  <figure class="relative flex-1 min-h-0">
+    <canvas bind:this={canvas} aria-hidden="true"></canvas>
+    <figcaption class="sr-only">
+      {t("table.caption.cross", { question: tab.label })}
+    </figcaption>
+  </figure>
 </div>

--- a/src/components/aggregation/NaCrossTable.svelte
+++ b/src/components/aggregation/NaCrossTable.svelte
@@ -27,10 +27,13 @@
   <caption class="sr-only">{t("table.caption.cross", { question: tab.label })}</caption>
   <thead>
     <tr>
-      <th rowspan="2" class="py-3 px-4"></th>
-      <th class="{TH_BASE} text-center bg-tab-bg text-accent">{t("table.total")}</th>
+      <th scope="col" rowspan="2" class="py-3 px-4">
+        <span class="sr-only">{t("table.option")}</span>
+      </th>
+      <th scope="col" class="{TH_BASE} text-center bg-tab-bg text-accent">{t("table.total")}</th>
       {#each crossGroups as group (group.axis.code)}
         <th
+          scope="colgroup"
           colspan={group.tab.slices.length}
           class="{TH_BASE} text-center bg-cross-bg border-l border-border text-accent2 {hasMultipleAxes
             ? 'border-l-2 border-l-border-strong'
@@ -41,10 +44,13 @@
       {/each}
     </tr>
     <tr>
-      <th class="{TH_BASE} text-right text-xs bg-surface2"></th>
+      <th scope="col" class="{TH_BASE} text-right text-xs bg-surface2">
+        <span class="sr-only">{t("table.value")}</span>
+      </th>
       {#each crossGroups as group, gi (group.axis.code)}
         {#each group.tab.slices as slice, si (`${group.axis.code}-${slice.code}`)}
           <th
+            scope="col"
             class="{TH_BASE} text-right text-xs whitespace-nowrap border-l border-row-border bg-surface2 {hasMultipleAxes &&
             si === 0 &&
             gi > 0
@@ -62,7 +68,9 @@
   <tbody class="[&_tr:hover_td]:bg-row-hover [&_tr:last-child_td]:border-b-0">
     {#each STAT_KEYS as key (key)}
       <tr>
-        <td class="{TD_BASE} text-left text-sm">{t(`na.stat.${key}`)}</td>
+        <th scope="row" class="{TD_BASE} text-left text-sm font-normal">
+          {t(`na.stat.${key}`)}
+        </th>
         <td class="{TD_BASE} {MONO} text-accent">{formatStat(key, tabStats[key])}</td>
         {#each crossGroups as group, gi (group.axis.code)}
           {#each group.tab.slices as slice, si (`${group.axis.code}-${slice.code}`)}

--- a/src/components/aggregation/NaTabTable.svelte
+++ b/src/components/aggregation/NaTabTable.svelte
@@ -4,6 +4,7 @@
   import { t } from "../../lib/i18n.svelte";
   import Th from "./Th.svelte";
   import Td from "./Td.svelte";
+  import { TD_BASE } from "./tableCellStyles";
 
   interface Props {
     tab: Tab;
@@ -21,13 +22,13 @@
   <thead>
     <tr>
       <Th>{t("table.option")}</Th>
-      <Th right></Th>
+      <Th right><span class="sr-only">{t("table.value")}</span></Th>
     </tr>
   </thead>
   <tbody class="[&_tr:hover_td]:bg-row-hover [&_tr:last-child_td]:border-b-0">
     {#each STAT_KEYS as key (key)}
       <tr>
-        <Td>{t(`na.stat.${key}`)}</Td>
+        <th scope="row" class="{TD_BASE} text-left font-normal">{t(`na.stat.${key}`)}</th>
         <Td right mono>{formatStat(key, stats[key])}</Td>
       </tr>
     {/each}

--- a/src/components/aggregation/TabCard.svelte
+++ b/src/components/aggregation/TabCard.svelte
@@ -24,15 +24,18 @@
   let isNA = $derived(tab.type === "NA");
 </script>
 
-<div
+<article
   id="card-{tab.questionCode}"
+  aria-labelledby="card-title-{tab.questionCode}"
   class="overflow-hidden rounded-xl border border-border bg-surface shadow-sm{hasCross
     ? ' overflow-x-auto'
     : ''}"
 >
   <div class="flex items-baseline gap-3 border-b border-border p-4">
     <div class="flex min-w-0 flex-col gap-0.5">
-      <span class="text-sm font-bold text-accent">{tab.label}</span>
+      <h3 id="card-title-{tab.questionCode}" class="text-sm font-bold text-accent">
+        {tab.label}
+      </h3>
       <span class="text-xs tracking-wide text-muted">{tab.questionCode}</span>
     </div>
     <span class="text-xs tracking-wide text-muted">{tab.type}</span>
@@ -61,4 +64,4 @@
   {:else}
     <TabTable {tab} />
   {/if}
-</div>
+</article>

--- a/src/components/aggregation/TabTable.svelte
+++ b/src/components/aggregation/TabTable.svelte
@@ -4,6 +4,7 @@
   import { t } from "../../lib/i18n.svelte";
   import Th from "./Th.svelte";
   import Td from "./Td.svelte";
+  import { TD_BASE } from "./tableCellStyles";
 
   interface Props {
     tab: Tab;
@@ -23,9 +24,10 @@
       <Th right>%</Th>
       <th
         class="border-b-2 border-l border-border-strong bg-surface py-3 pr-4 pl-4 align-bottom text-[10px] font-normal text-muted"
-        aria-hidden="true"
+        scope="col"
       >
-        <div class="relative h-3">
+        <span class="sr-only">{t("table.graph")}</span>
+        <div class="relative h-3" aria-hidden="true">
           <span class="absolute top-0 left-0">0</span>
           <span class="absolute top-0 -translate-x-1/2" style:left="20%">20</span>
           <span class="absolute top-0 -translate-x-1/2" style:left="40%">40</span>
@@ -44,7 +46,7 @@
       {@const pct = cell.pct ?? 0}
       {@const barWidthPct = pct.toFixed(1)}
       <tr>
-        <Td>{label}</Td>
+        <th scope="row" class="{TD_BASE} text-left font-normal">{label}</th>
         <Td right mono>{countStr}</Td>
         <Td right mono class="text-muted">
           {cell.pct !== null ? cell.pct.toFixed(1) + "%" : "-"}

--- a/src/components/aggregation/Th.svelte
+++ b/src/components/aggregation/Th.svelte
@@ -11,6 +11,7 @@
 </script>
 
 <th
+  scope="col"
   class="py-3 px-4 text-xs font-bold tracking-wide border-b-2 border-border-strong text-text-secondary bg-surface2 {right
     ? 'text-right'
     : 'text-left'} {cls ?? ''}"

--- a/src/components/aggregation/ViewSettingsPopover.svelte
+++ b/src/components/aggregation/ViewSettingsPopover.svelte
@@ -124,8 +124,9 @@
           </div>
           <div class="flex flex-col gap-2 text-xs text-text-secondary">
             <div class="flex items-center justify-between">
-              <span>{t("display.saType")}</span>
+              <label for="display-sa-type">{t("display.saType")}</label>
               <select
+                id="display-sa-type"
                 class="cursor-pointer rounded-sm border border-border bg-surface px-2 py-1 text-xs text-text"
                 value={chartOpts.saChartType}
                 onchange={(e) =>
@@ -139,8 +140,9 @@
               </select>
             </div>
             <div class="flex items-center justify-between">
-              <span>{t("display.maType")}</span>
+              <label for="display-ma-type">{t("display.maType")}</label>
               <select
+                id="display-ma-type"
                 class="cursor-pointer rounded-sm border border-border bg-surface px-2 py-1 text-xs text-text"
                 value={chartOpts.maChartType}
                 onchange={(e) =>

--- a/src/components/header/ChangelogButton.svelte
+++ b/src/components/header/ChangelogButton.svelte
@@ -16,10 +16,16 @@
   }
 </script>
 
-<Dropdown {open} onclose={() => (open = false)}>
+<Dropdown {open} label={t("changelog.title")} onclose={() => (open = false)}>
   {#snippet trigger()}
     <div class="relative">
-      <IconButton size="md" label={t("changelog.title")} onclick={toggle}>
+      <IconButton
+        size="md"
+        label={t("changelog.title")}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        onclick={toggle}
+      >
         <svg
           width="18"
           height="18"
@@ -29,13 +35,17 @@
           stroke-width="2"
           stroke-linecap="round"
           stroke-linejoin="round"
+          aria-hidden="true"
         >
           <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"></path>
           <path d="M13.73 21a2 2 0 0 1-3.46 0"></path>
         </svg>
       </IconButton>
       {#if hasUnread}
-        <span class="absolute top-0.5 right-0.5 size-2.5 rounded-full bg-red-500"></span>
+        <span
+          class="absolute top-0.5 right-0.5 size-2.5 rounded-full bg-red-500"
+          aria-hidden="true"
+        ></span>
       {/if}
     </div>
   {/snippet}

--- a/src/components/header/SettingsModal.svelte
+++ b/src/components/header/SettingsModal.svelte
@@ -54,7 +54,7 @@
   });
 </script>
 
-<Dropdown {open} onclose={() => (open = false)}>
+<Dropdown {open} label={t("header.settings")} onclose={() => (open = false)}>
   {#snippet trigger()}
     <IconButton
       size="md"
@@ -62,6 +62,8 @@
       label={t("header.settings")}
       data-i18n="header.settings"
       data-i18n-attr="aria-label"
+      aria-expanded={open}
+      aria-haspopup="dialog"
       onclick={handleToggle}
     >
       &#x2699;
@@ -75,6 +77,8 @@
         <div class="flex gap-0.5 rounded-lg bg-surface2 p-0.5" data-seg-name="lang">
           {#each [{ value: "ja", label: "日本語" }, { value: "en", label: "English" }] as o (o.value)}
             <button
+              type="button"
+              aria-pressed={o.value === locale}
               class="flex-1 cursor-pointer whitespace-nowrap rounded-md border-none px-3 py-1 text-xs transition-[background,color,box-shadow] duration-150 hover:text-text {o.value ===
               locale
                 ? 'bg-surface text-text shadow-[0_1px_3px_rgba(0,0,0,0.1)]'
@@ -99,6 +103,8 @@
         <div class="flex gap-0.5 rounded-lg bg-surface2 p-0.5" data-seg-name="theme">
           {#each [{ value: "light", label: t("settings.theme.light") }, { value: "dark", label: t("settings.theme.dark") }, { value: "system", label: t("settings.theme.system") }] as o (o.value)}
             <button
+              type="button"
+              aria-pressed={o.value === theme}
               class="flex-1 cursor-pointer whitespace-nowrap rounded-md border-none px-3 py-1 text-xs transition-[background,color,box-shadow] duration-150 hover:text-text {o.value ===
               theme
                 ? 'bg-surface text-text shadow-[0_1px_3px_rgba(0,0,0,0.1)]'
@@ -124,6 +130,8 @@
           <div class="flex gap-0.5 rounded-lg bg-surface2 p-0.5" data-seg-name="ai">
             {#each [{ value: "on", label: t("settings.ai.on") }, { value: "off", label: t("settings.ai.off") }] as o (o.value)}
               <button
+                type="button"
+                aria-pressed={(aiEnabled ? "on" : "off") === o.value}
                 class="flex-1 cursor-pointer whitespace-nowrap rounded-md border-none px-3 py-1 text-xs transition-[background,color,box-shadow] duration-150 hover:text-text {(aiEnabled ? 'on' : 'off') ===
                 o.value
                   ? 'bg-surface text-text shadow-[0_1px_3px_rgba(0,0,0,0.1)]'

--- a/src/components/import/Dropzone.svelte
+++ b/src/components/import/Dropzone.svelte
@@ -51,9 +51,7 @@
   }
 </script>
 
-<div
-  role="button"
-  tabindex="0"
+<label
   class="relative rounded-lg border-2 border-dashed border-border-strong px-4 py-5 transition-colors hover:border-accent hover:bg-accent-bg{isDragOver
     ? ' drag-over'
     : ''}{isLoaded ? ' loaded' : ''}"
@@ -81,4 +79,4 @@
       <span class="text-sm font-medium text-text-secondary">{text}</span>
     {/if}
   </div>
-</div>
+</label>

--- a/src/components/import/Dropzone.svelte
+++ b/src/components/import/Dropzone.svelte
@@ -52,7 +52,7 @@
 </script>
 
 <label
-  class="relative rounded-lg border-2 border-dashed border-border-strong px-4 py-5 transition-colors hover:border-accent hover:bg-accent-bg{isDragOver
+  class="relative block rounded-lg border-2 border-dashed border-border-strong px-4 py-5 transition-colors hover:border-accent hover:bg-accent-bg{isDragOver
     ? ' drag-over'
     : ''}{isLoaded ? ' loaded' : ''}"
   ondragenter={handleDragEnter}

--- a/src/components/shared/Dropdown.svelte
+++ b/src/components/shared/Dropdown.svelte
@@ -5,11 +5,12 @@
   interface Props {
     open: boolean;
     onclose: () => void;
+    label: string;
     trigger: Snippet;
     children: Snippet;
   }
 
-  let { open, onclose, trigger, children }: Props = $props();
+  let { open, onclose, label, trigger, children }: Props = $props();
 </script>
 
 <div {@attach clickOutside({ onClose: onclose })}>
@@ -17,6 +18,8 @@
   {#if open}
     <div
       class="absolute top-[calc(100%+8px)] right-0 z-100 w-[300px] rounded-xl border border-border bg-surface p-4 shadow-lg"
+      role="dialog"
+      aria-label={label}
     >
       {@render children()}
     </div>

--- a/src/components/shared/ToggleButton.svelte
+++ b/src/components/shared/ToggleButton.svelte
@@ -11,6 +11,8 @@
 </script>
 
 <button
+  type="button"
+  aria-pressed={active}
   class="min-h-7 cursor-pointer border px-3 py-1 font-sans text-xs font-medium transition-[background,color,border-color] duration-150 {active
     ? 'border-accent bg-accent text-accent-contrast'
     : 'border-border bg-surface text-text-secondary'}"

--- a/src/components/shared/ToggleGroup.svelte
+++ b/src/components/shared/ToggleGroup.svelte
@@ -1,16 +1,17 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
+  import type { HTMLAttributes } from "svelte/elements";
 
-  interface Props {
-    class?: string;
+  interface Props extends HTMLAttributes<HTMLDivElement> {
     children: Snippet;
   }
 
-  let { class: cls, children }: Props = $props();
+  let { class: cls, children, ...rest }: Props = $props();
 </script>
 
 <div
   class="flex [&>:first-child]:rounded-l [&>:last-child]:rounded-r [&>:last-child]:border-l-0{cls ? ` ${cls}` : ''}"
+  {...rest}
 >
   {@render children()}
 </div>

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -49,6 +49,8 @@ const en: Record<string, string> = {
 
   // Aggregation screen
   "section.summary": "Data Summary",
+  "section.settings": "Aggregation settings",
+  "section.results": "Aggregation results",
   "section.toc": "Index",
   "section.cross": "Cross-Tabulation Axes",
   "section.cross.label": "Cross-tabulation axis selection",
@@ -121,6 +123,8 @@ const en: Record<string, string> = {
   // Table headers
   "table.option": "Option",
   "table.graph": "Graph",
+  "table.value": "Value",
+  "table.question": "Question",
   "table.total": "Total",
   "table.caption.tab": "Aggregation results for {question}",
   "table.caption.cross": "Cross-tabulation results for {question}",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -49,6 +49,8 @@ const ja: Record<string, string> = {
 
   // Aggregation screen
   "section.summary": "データ概要",
+  "section.settings": "集計設定",
+  "section.results": "集計結果",
   "section.toc": "目次",
   "section.cross": "クロス集計軸",
   "section.cross.label": "クロス集計軸の選択",
@@ -121,6 +123,8 @@ const ja: Record<string, string> = {
   // Table headers
   "table.option": "選択肢",
   "table.graph": "グラフ",
+  "table.value": "値",
+  "table.question": "設問",
   "table.total": "全体",
   "table.caption.tab": "{question} の集計結果",
   "table.caption.cross": "{question} のクロス集計結果",


### PR DESCRIPTION
## 概要

画面全体のsemantic HTMLを見直し、キーボード操作および支援技術で構造を把握しやすくしました。

## 背景

表示上は問題なく利用できる一方で、ファイル選択領域の操作要素重複、集計表の行・列見出しの関連付け不足、派生設問フォームのグループ構造不足、カードやグラフの意味付け不足がありました。

## 主な変更

- ファイル選択領域をネイティブなラベル構造に変更
- 派生設問編集画面を `form` / `fieldset` / `legend` で構造化
- 集計カードを `article`、質問名を見出し要素に変更
- 集計表へ `caption` と適切な `scope` を追加
- グラフを `figure` / `figcaption` で説明
- トグルとポップオーバーへ選択状態・開閉状態を追加
- インポート手順を順序付きリストとして表現
- 集計設定・集計結果ランドマークの日英ラベルを追加

## 影響

見た目と既存の集計処理を維持しつつ、スクリーンリーダーの見出し移動、表の読み上げ、フォームグループの把握、ポップオーバーの状態確認を改善します。

## 確認

- `vp build`
- `vp lint`
- `vp test run`（23ファイル、1907テスト成功）
- ローカルブラウザでレンダリング後DOMを確認
- ブラウザコンソールエラーなし

<sub>🤖 Written by Codex</sub>