### PR TITLE
feat(seo): AEO向けのクロール基盤と404処理を整備

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="canonical" href="https://aggy.pages.dev/app/" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Aggy App — アンケート集計</title>
     <meta

--- a/index.html
+++ b/index.html
@@ -374,8 +374,10 @@
       {
         "@context": "https://schema.org",
         "@type": "WebApplication",
+        "@id": "https://aggy.pages.dev/#web-application",
         "name": "Aggy",
         "url": "https://aggy.pages.dev/",
+        "sameAs": "https://github.com/Yuki-bach/aggy",
         "applicationCategory": "BusinessApplication",
         "operatingSystem": "Web browser",
         "inLanguage": ["ja", "en"],

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, follow" />
+    <meta name="theme-color" content="#071b3f" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <title>ページが見つかりません — Aggy</title>
+    <style>
+      :root {
+        color: #14213d;
+        background: #f7f8fb;
+        font-family:
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          sans-serif;
+      }
+
+      body {
+        display: grid;
+        min-height: 100vh;
+        min-height: 100svh;
+        margin: 0;
+        place-items: center;
+      }
+
+      main {
+        max-width: 36rem;
+        padding: 2rem;
+        text-align: center;
+      }
+
+      p:first-child {
+        margin: 0;
+        color: #315ee7;
+        font-size: 4rem;
+        font-weight: 800;
+        line-height: 1;
+      }
+
+      h1 {
+        margin: 1rem 0 0;
+        font-size: clamp(1.75rem, 5vw, 2.5rem);
+      }
+
+      p {
+        line-height: 1.7;
+      }
+
+      nav {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        justify-content: center;
+        margin-top: 2rem;
+      }
+
+      a {
+        border-radius: 999px;
+        padding: 0.75rem 1.25rem;
+        color: white;
+        background: #315ee7;
+        font-weight: 700;
+        text-decoration: none;
+      }
+
+      a:last-child {
+        border: 1px solid #315ee7;
+        color: #315ee7;
+        background: transparent;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p aria-hidden="true">404</p>
+      <h1>ページが見つかりません</h1>
+      <p>URLが変更されたか、ページが削除された可能性があります。</p>
+      <nav aria-label="移動先">
+        <a href="/">Aggyトップへ</a>
+        <a href="/app/">集計を始める</a>
+      </nav>
+    </main>
+  </body>
+</html>

--- a/public/_headers
+++ b/public/_headers
@@ -1,3 +1,15 @@
 /*
   Cross-Origin-Opener-Policy: same-origin
   Cross-Origin-Embedder-Policy: require-corp
+
+/robots.txt
+  Content-Type: text/plain; charset=utf-8
+
+/sitemap.xml
+  Content-Type: application/xml; charset=utf-8
+
+/aggy.md
+  Content-Type: text/markdown; charset=utf-8
+
+/aggy.en.md
+  Content-Type: text/markdown; charset=utf-8

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
+
+Sitemap: https://aggy.pages.dev/sitemap.xml

--- a/public/schemas/layout.schema.json
+++ b/public/schemas/layout.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://aggy.app/schemas/layout.schema.json",
+  "$id": "https://aggy.pages.dev/schemas/layout.schema.json",
   "title": "Aggy Layout",
   "description": "アンケートローデータのレイアウト定義。CSV列の種別（SA/MA/WEIGHT/DATE）と選択肢ラベルを指定する。",
   "type": "array",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://aggy.pages.dev/</loc>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://aggy.pages.dev/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://aggy.pages.dev/en/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aggy.pages.dev/" />
+  </url>
+  <url>
+    <loc>https://aggy.pages.dev/en/</loc>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://aggy.pages.dev/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://aggy.pages.dev/en/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aggy.pages.dev/" />
+  </url>
+  <url>
+    <loc>https://aggy.pages.dev/app/</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## 概要

- Aggyの正規ホストを `https://aggy.pages.dev` に統一
- 構造化データへ一意なIDとGitHubリポジトリの関連付けを追加
- 検索・AI入力・モデル学習を許可する `robots.txt` を追加
- 日本語・英語ランディングページをhreflang付きで `sitemap.xml` に掲載
- Cloudflare Pagesのsoft 404を防ぐため、トップレベルの `404.html` を追加
- robots、sitemap、日本語・英語MarkdownのContent-Typeを明示

## 背景

本番環境では、`/robots.txt`や`/sitemap.xml`などの存在しないパスが、トップページのHTMLをステータス200で返していました。

また、レイアウトJSON SchemaのIDが、別サービスで使用されている`aggy.app`を参照しており、検索クローラやLLMがAggyのエンティティを誤認する可能性がありました。

## PR #275との関係

PR #275で追加された英語ランディングページを取り込んだ上で、以下を追加しています。

- `/en/`をsitemapへ掲載
- 日本語版と英語版のhreflangを設定
- `/aggy.en.md`のContent-Typeを設定

## AIクローラ向けポリシー

検索、リアルタイム回答、モデル学習のすべてを許可します。

```text
Content-Signal: search=yes, ai-input=yes, ai-train=yes