### PR TITLE
feat: LLM向けのllms.txtを追加

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -8,6 +8,9 @@
 /sitemap.xml
   Content-Type: application/xml; charset=utf-8
 
+/llms.txt
+  Content-Type: text/plain; charset=utf-8
+
 /aggy.md
   Content-Type: text/markdown; charset=utf-8
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,21 @@
+# Aggy
+
+> Aggy is a free, browser-based tool for aggregating raw survey data. It performs grand totals, cross-tabulation, weighted aggregation, charts, and exports entirely in the browser without uploading response data to an external server.
+
+Aggy supports Japanese and English. It accepts a response CSV and a layout JSON that defines the survey questions. Aggregation runs locally with DuckDB Wasm.
+
+## Documentation
+
+- [Aggy overview (Japanese)](https://aggy.pages.dev/aggy.md): Features, supported question types, usage, limitations, and frequently asked questions in Japanese.
+- [Aggy overview (English)](https://aggy.pages.dev/aggy.en.md): Features, supported question types, usage, limitations, and frequently asked questions in English.
+- [Layout JSON Schema](https://aggy.pages.dev/schemas/layout.schema.json): Machine-readable schema for the layout JSON accepted by Aggy.
+
+## Main pages
+
+- [Aggy (Japanese)](https://aggy.pages.dev/): Japanese product overview and frequently asked questions.
+- [Aggy (English)](https://aggy.pages.dev/en/): English product overview and frequently asked questions.
+- [Aggy web application](https://aggy.pages.dev/app/): The browser-based survey aggregation application.
+
+## Source code
+
+- [Aggy on GitHub](https://github.com/Yuki-bach/aggy): Source code, releases, and technical documentation.


### PR DESCRIPTION
## 概要

- サイトの目的と主要コンテンツを案内する `public/llms.txt` を追加
- 日英のMarkdown版、ランディングページ、Webアプリ、Layout JSON Schema、GitHubへのリンクを掲載
- Cloudflare Pagesで `/llms.txt` をUTF-8のプレーンテキストとして配信するヘッダーを追加

## 背景

LLMやAIエージェントがAggyの一次情報と主要URLを把握しやすくするため、llms.txtの提案仕様に沿った簡潔なサイトインデックスを公開します。

## 影響

アプリケーションの挙動に変更はありません。デプロイ後、`https://aggy.pages.dev/llms.txt` から取得できます。

## 確認

- `vp build`
- `dist/llms.txt` がソースと一致することを確認
- `dist/_headers` にContent-Type設定が反映されることを確認
- `git diff --check`

<sub>🤖 Written by Codex</sub>