### PR TITLE
feat: LPにData Cinematic演出を追加

### DIFF
--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Data Cinematic landing page", () => {
+  test("日本語LPの主要導線と装飾Canvasを表示する", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page.getByRole("heading", { level: 1 })).toContainText("手元のデータを高速集計");
+    await expect(page.getByRole("link", { name: /無料で集計を始める/ })).toHaveAttribute(
+      "href",
+      "/app/",
+    );
+    await expect(page.locator('.site-nav a[href="#how-it-works"]')).toBeVisible();
+    await expect(page.locator("canvas[data-data-flow]")).toHaveAttribute("aria-hidden", "true");
+    await expect(page.locator(".steps-grid > li")).toHaveCount(3);
+  });
+
+  test("英語LPも同じ構造と英語導線を持つ", async ({ page }) => {
+    await page.goto("/en/");
+
+    await expect(page.getByRole("heading", { level: 1 })).toContainText("Turn raw data into");
+    await expect(page.getByRole("link", { name: /Start aggregating for free/ })).toHaveAttribute(
+      "href",
+      "/app/?lang=en",
+    );
+    await expect(page.locator(".steps-grid > li")).toHaveCount(3);
+    await expect(page.locator("canvas[data-data-flow]")).toHaveAttribute("aria-hidden", "true");
+  });
+
+  test("WebGLコンテキスト喪失時に静的フォールバックへ切り替える", async ({ page }) => {
+    await page.goto("/");
+    const canvas = page.locator("canvas[data-data-flow]");
+    await canvas.dispatchEvent("webglcontextlost");
+
+    await expect(page.locator("html")).toHaveClass(/webgl-fallback/);
+    await expect(page.getByRole("link", { name: /無料で集計を始める/ })).toBeVisible();
+  });
+
+  test("モーション低減設定では完成状態を静的に表示する", async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.goto("/");
+
+    await expect(page.locator("html")).toHaveClass(/motion-static/);
+    await expect(page.locator("canvas[data-data-flow]")).toBeHidden();
+    await expect(page.getByRole("heading", { name: "3ステップで集計完了。" })).toBeVisible();
+  });
+});

--- a/en/index.html
+++ b/en/index.html
@@ -31,6 +31,7 @@
     <link rel="alternate" hreflang="x-default" href="https://aggy.pages.dev/" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <script src="/landing-locale.js"></script>
+    <script type="module" src="/src/landing.ts"></script>
     <link rel="stylesheet" href="/src/landing.css" />
     <title>Aggy — Fast, private survey data aggregation</title>
   </head>
@@ -60,11 +61,18 @@
     </header>
 
     <main id="main">
-      <section class="hero">
+      <section class="hero" data-hero>
+        <canvas class="data-flow-canvas" data-data-flow aria-hidden="true"></canvas>
+        <div class="hero-data-field" aria-hidden="true">
+          <span>10001, 34, Tokyo, satisfied, continue</span>
+          <span>10002, 28, Osaka, somewhat, recommend</span>
+          <span>10003, 45, Aichi, satisfied, continue</span>
+          <span>10004, 31, Fukuoka, neutral, undecided</span>
+        </div>
         <div class="hero-grid shell">
           <div class="hero-copy">
             <p class="eyebrow"><span></span>SURVEY AGGREGATION, ENTIRELY IN YOUR BROWSER</p>
-            <h1>Turn raw data into<em>answers—fast</em></h1>
+            <h1>Turn raw data <em>into answers—fast</em></h1>
             <p class="hero-lead">
               Load a CSV and a layout JSON, then move from grand totals and cross-tabs to charts and
               exports—all in one place.

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
     <link rel="alternate" hreflang="x-default" href="https://aggy.pages.dev/" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <script src="/landing-locale.js"></script>
+    <script type="module" src="/src/landing.ts"></script>
     <link rel="stylesheet" href="/src/landing.css" />
     <title>Aggy — ローデータを外に出さない、高速アンケート集計</title>
   </head>
@@ -60,7 +61,14 @@
     </header>
 
     <main id="main">
-      <section class="hero">
+      <section class="hero" data-hero>
+        <canvas class="data-flow-canvas" data-data-flow aria-hidden="true"></canvas>
+        <div class="hero-data-field" aria-hidden="true">
+          <span>10001, 34, 東京都, 満足, 継続意向あり</span>
+          <span>10002, 28, 大阪府, やや満足, 推奨</span>
+          <span>10003, 45, 愛知県, 満足, 継続意向あり</span>
+          <span>10004, 31, 福岡県, どちらでもない</span>
+        </div>
         <div class="hero-grid shell">
           <div class="hero-copy">
             <p class="eyebrow"><span></span>ブラウザ完結のアンケート集計ツール</p>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const previewPort = Number(process.env.PLAYWRIGHT_PORT ?? 4173);
+
 export default defineConfig({
   testDir: "./e2e",
   timeout: 60_000,
@@ -8,14 +10,14 @@ export default defineConfig({
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI ? [["html"], ["github"]] : [["html"]],
   use: {
-    baseURL: "http://localhost:4173",
+    baseURL: `http://localhost:${previewPort}`,
     locale: "ja-JP",
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
   },
   webServer: {
-    command: "vp build && vp preview --port 4173 --strictPort",
-    url: "http://localhost:4173",
+    command: `vp build && vp preview --port ${previewPort} --strictPort`,
+    url: `http://localhost:${previewPort}`,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
   },

--- a/src/landing.css
+++ b/src/landing.css
@@ -1510,3 +1510,226 @@ a {
     transition-duration: 0.01ms !important;
   }
 }
+
+/* Data Cinematic landing experience */
+.hero {
+  min-height: 820px;
+  background:
+    radial-gradient(circle at 76% 34%, rgba(20, 116, 222, 0.24), transparent 27%),
+    radial-gradient(circle at 44% 55%, rgba(35, 211, 231, 0.08), transparent 25%),
+    linear-gradient(118deg, #020a18 0%, #06152d 52%, #071a36 100%);
+}
+
+.hero::before {
+  z-index: 1;
+  opacity: 0.16;
+  background-size: 48px 48px;
+  mask-image: linear-gradient(90deg, transparent 0%, black 48%, transparent 100%);
+}
+
+.hero::after {
+  z-index: 1;
+  right: -240px;
+  bottom: -410px;
+  width: 820px;
+  height: 820px;
+  border-color: rgba(68, 212, 231, 0.1);
+}
+
+.data-flow-canvas {
+  position: absolute;
+  z-index: 1;
+  inset: 82px 0 0;
+  width: 100%;
+  height: calc(100% - 82px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 700ms ease;
+}
+
+.webgl-ready .data-flow-canvas {
+  opacity: 0.78;
+}
+
+.webgl-fallback .data-flow-canvas,
+.motion-static .data-flow-canvas {
+  display: none;
+}
+
+.hero-data-field {
+  position: absolute;
+  z-index: 1;
+  top: 51%;
+  left: max(18px, calc((100vw - 1160px) / 2 - 56px));
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  color: rgba(81, 202, 245, 0.19);
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: var(--text-micro);
+  letter-spacing: 0.02em;
+  transform: rotate(-2deg);
+}
+
+.hero-data-field span:nth-child(2) {
+  transform: translateX(22px);
+}
+
+.hero-data-field span:nth-child(3) {
+  transform: translateX(-12px);
+}
+
+.hero-data-field span:nth-child(4) {
+  transform: translateX(34px);
+}
+
+.hero-grid {
+  z-index: 3;
+}
+
+.hero-copy {
+  position: relative;
+}
+
+.hero h1 em {
+  color: #79f7d0;
+  text-shadow: 0 0 32px rgba(70, 235, 198, 0.18);
+}
+
+html[lang="en"] .hero h1 {
+  font-size: clamp(42px, 4vw, 58px);
+}
+
+.button-primary,
+.button-lime {
+  color: #061225;
+  background: #a8f44a;
+  box-shadow: 0 14px 36px rgba(151, 239, 59, 0.2);
+}
+
+.button-primary:hover,
+.button-lime:hover {
+  background: #bbff65;
+}
+
+.product-stage::before {
+  position: absolute;
+  z-index: -1;
+  inset: 9% -10% 2% 10%;
+  border-radius: 50%;
+  background: rgba(28, 120, 238, 0.18);
+  content: "";
+  filter: blur(60px);
+}
+
+.app-window {
+  border-color: rgba(119, 174, 232, 0.3);
+  color: #c9d8ea;
+  background: #071426;
+  box-shadow:
+    0 42px 90px rgba(0, 0, 0, 0.54),
+    0 0 0 1px rgba(62, 148, 235, 0.08) inset;
+}
+
+.window-bar {
+  border-color: rgba(111, 151, 194, 0.18);
+  background: #09182d;
+}
+
+.window-brand b,
+.mock-title,
+.tr b {
+  color: #e9f2fd;
+}
+
+.window-brand span,
+.status,
+.mock-sidebar > span,
+.mock-sidebar li,
+.tr > *,
+.mini-chart div {
+  color: #71859e;
+}
+
+.window-body {
+  background: #071426;
+}
+
+.mock-sidebar {
+  border-color: rgba(111, 151, 194, 0.15);
+  background: #08172b;
+}
+
+.mock-sidebar small {
+  color: #60738c;
+}
+
+.mock-sidebar li.active,
+.view-toggle b,
+.tr .hot {
+  color: #6eddf2;
+  background: rgba(43, 115, 236, 0.16);
+}
+
+.axis-pill {
+  border-color: rgba(49, 145, 230, 0.28);
+  color: #70c9f4;
+  background: rgba(25, 104, 195, 0.13);
+}
+
+.view-toggle,
+.mock-table,
+.mini-chart {
+  border-color: rgba(111, 151, 194, 0.17);
+  background: #091a31;
+}
+
+.tr,
+.tr > * {
+  border-color: rgba(111, 151, 194, 0.12);
+}
+
+.tr.th {
+  background: #0d213d;
+}
+
+.mini-chart b {
+  color: #9eafc2;
+}
+
+.speed-note,
+.local-note {
+  border-color: rgba(100, 198, 237, 0.2);
+  background: rgba(2, 12, 27, 0.9);
+}
+
+.feature-section {
+  border-top: 1px solid rgba(93, 158, 216, 0.12);
+}
+
+@media (max-width: 1040px) {
+  .hero {
+    min-height: auto;
+  }
+}
+
+@media (max-width: 800px) {
+  .data-flow-canvas {
+    inset: 70px 0 0;
+    height: calc(100% - 70px);
+    opacity: 0.46;
+  }
+
+  .hero-data-field {
+    display: none;
+  }
+}
+
+@media (max-width: 560px) {
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .data-flow-canvas {
+    display: none;
+  }
+}

--- a/src/landing.ts
+++ b/src/landing.ts
@@ -1,0 +1,47 @@
+import { createDataFlow, type DataFlowController } from "./lib/dataFlowWebgl";
+
+interface NavigatorWithConnection extends Navigator {
+  connection?: { saveData?: boolean };
+}
+
+const root = document.documentElement;
+const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+const saveData = (navigator as NavigatorWithConnection).connection?.saveData === true;
+const staticMotion = reducedMotion || saveData;
+
+function initializeDataFlow(): () => void {
+  const canvas = document.querySelector<HTMLCanvasElement>("[data-data-flow]");
+  const hero = document.querySelector<HTMLElement>("[data-hero]");
+  if (!canvas || !hero || staticMotion) {
+    root.classList.add("motion-static");
+    return () => {};
+  }
+
+  let controller: DataFlowController;
+  try {
+    controller = createDataFlow(canvas, window.matchMedia("(max-width: 800px)").matches);
+    root.classList.add("webgl-ready");
+  } catch {
+    root.classList.add("webgl-fallback");
+    return () => {};
+  }
+
+  const observer = new IntersectionObserver(
+    ([entry]) => controller.setActive(entry?.isIntersecting),
+    { rootMargin: "100px" },
+  );
+  observer.observe(hero);
+  return () => {
+    observer.disconnect();
+    controller.destroy();
+  };
+}
+
+const cleanups = [initializeDataFlow()];
+window.addEventListener(
+  "pagehide",
+  () => {
+    for (const cleanup of cleanups) cleanup();
+  },
+  { once: true },
+);

--- a/src/lib/dataFlowWebgl.ts
+++ b/src/lib/dataFlowWebgl.ts
@@ -1,0 +1,188 @@
+export interface DataFlowController {
+  setActive: (active: boolean) => void;
+  destroy: () => void;
+}
+
+const vertexSource = `
+  attribute vec4 a_particle;
+  uniform float u_time;
+  uniform float u_point_size;
+  uniform bool u_points;
+  varying float v_alpha;
+  varying float v_progress;
+
+  void main() {
+    float progress = fract(a_particle.x + u_time * a_particle.z - a_particle.w * 0.024);
+    float spread = mix(0.72, 0.11, smoothstep(0.08, 0.72, progress));
+    float wave = sin(progress * 18.0 + a_particle.y * 7.0) * 0.026;
+    float x = mix(-1.18, 1.18, progress);
+    float y = a_particle.y * spread + wave;
+
+    gl_Position = vec4(x, y, 0.0, 1.0);
+    gl_PointSize = u_points ? u_point_size * mix(0.65, 1.35, progress) : 1.0;
+    v_progress = progress;
+    v_alpha = mix(0.08, 0.8, 1.0 - a_particle.w);
+  }
+`;
+
+const fragmentSource = `
+  precision mediump float;
+  uniform bool u_points;
+  varying float v_alpha;
+  varying float v_progress;
+
+  void main() {
+    float edge = smoothstep(0.0, 0.08, v_progress) * (1.0 - smoothstep(0.9, 1.0, v_progress));
+    float alpha = v_alpha * edge;
+    if (u_points) {
+      float distanceToCenter = distance(gl_PointCoord, vec2(0.5));
+      if (distanceToCenter > 0.5) discard;
+      alpha *= smoothstep(0.5, 0.08, distanceToCenter);
+    }
+    vec3 cyan = mix(vec3(0.08, 0.43, 0.92), vec3(0.25, 0.95, 1.0), v_progress);
+    gl_FragColor = vec4(cyan, alpha);
+  }
+`;
+
+function compileShader(gl: WebGLRenderingContext, type: number, source: string): WebGLShader {
+  const shader = gl.createShader(type);
+  if (!shader) throw new Error("Unable to create WebGL shader");
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    const message = gl.getShaderInfoLog(shader) ?? "Unknown shader error";
+    gl.deleteShader(shader);
+    throw new Error(message);
+  }
+  return shader;
+}
+
+function createProgram(gl: WebGLRenderingContext): WebGLProgram {
+  const program = gl.createProgram();
+  if (!program) throw new Error("Unable to create WebGL program");
+  const vertexShader = compileShader(gl, gl.VERTEX_SHADER, vertexSource);
+  const fragmentShader = compileShader(gl, gl.FRAGMENT_SHADER, fragmentSource);
+  gl.attachShader(program, vertexShader);
+  gl.attachShader(program, fragmentShader);
+  gl.linkProgram(program);
+  gl.deleteShader(vertexShader);
+  gl.deleteShader(fragmentShader);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    throw new Error(gl.getProgramInfoLog(program) ?? "Unable to link WebGL program");
+  }
+  return program;
+}
+
+function createParticleData(count: number, includeTrails: boolean): Float32Array {
+  const verticesPerParticle = includeTrails ? 2 : 1;
+  const data = new Float32Array(count * verticesPerParticle * 4);
+  for (let index = 0; index < count; index += 1) {
+    const seed = Math.random();
+    const vertical = Math.random() * 2 - 1;
+    const speed = 0.035 + Math.random() * 0.045;
+    const base = index * verticesPerParticle * 4;
+    data.set([seed, vertical, speed, 0], base);
+    if (includeTrails) data.set([seed, vertical, speed, 1], base + 4);
+  }
+  return data;
+}
+
+function createBuffer(gl: WebGLRenderingContext, data: Float32Array): WebGLBuffer {
+  const buffer = gl.createBuffer();
+  if (!buffer) throw new Error("Unable to create WebGL buffer");
+  gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+  gl.bufferData(gl.ARRAY_BUFFER, data, gl.STATIC_DRAW);
+  return buffer;
+}
+
+export function createDataFlow(canvas: HTMLCanvasElement, compact: boolean): DataFlowController {
+  const gl = canvas.getContext("webgl", {
+    alpha: true,
+    antialias: false,
+    depth: false,
+    powerPreference: "low-power",
+    premultipliedAlpha: true,
+  });
+  if (!gl) throw new Error("WebGL is unavailable");
+
+  const particleCount = compact ? 180 : 480;
+  const trailData = createParticleData(particleCount, true);
+  const pointData = createParticleData(Math.round(particleCount * 0.55), false);
+  const trailBuffer = createBuffer(gl, trailData);
+  const pointBuffer = createBuffer(gl, pointData);
+  const program = createProgram(gl);
+  const particleAttribute = gl.getAttribLocation(program, "a_particle");
+  const timeUniform = gl.getUniformLocation(program, "u_time");
+  const pointSizeUniform = gl.getUniformLocation(program, "u_point_size");
+  const pointsUniform = gl.getUniformLocation(program, "u_points");
+  let active = true;
+  let frame = 0;
+  let destroyed = false;
+
+  gl.useProgram(program);
+  gl.enable(gl.BLEND);
+  gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
+  gl.enableVertexAttribArray(particleAttribute);
+
+  const resize = () => {
+    const ratio = Math.min(window.devicePixelRatio || 1, 1.5);
+    const width = Math.max(1, Math.round(canvas.clientWidth * ratio));
+    const height = Math.max(1, Math.round(canvas.clientHeight * ratio));
+    if (canvas.width !== width || canvas.height !== height) {
+      canvas.width = width;
+      canvas.height = height;
+      gl.viewport(0, 0, width, height);
+    }
+  };
+
+  const bind = (buffer: WebGLBuffer) => {
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+    gl.vertexAttribPointer(particleAttribute, 4, gl.FLOAT, false, 0, 0);
+  };
+
+  const render = (timestamp: number) => {
+    if (destroyed) return;
+    if (active && document.visibilityState === "visible") {
+      resize();
+      gl.clearColor(0, 0, 0, 0);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+      gl.uniform1f(timeUniform, timestamp * 0.001);
+      gl.uniform1f(pointSizeUniform, compact ? 2.2 : 3.2);
+
+      bind(trailBuffer);
+      gl.uniform1i(pointsUniform, 0);
+      gl.drawArrays(gl.LINES, 0, trailData.length / 4);
+
+      bind(pointBuffer);
+      gl.uniform1i(pointsUniform, 1);
+      gl.drawArrays(gl.POINTS, 0, pointData.length / 4);
+    }
+    frame = requestAnimationFrame(render);
+  };
+
+  const onContextLost = (event: Event) => {
+    event.preventDefault();
+    active = false;
+    document.documentElement.classList.add("webgl-fallback");
+  };
+  canvas.addEventListener("webglcontextlost", onContextLost);
+  const resizeObserver = new ResizeObserver(resize);
+  resizeObserver.observe(canvas);
+  resize();
+  frame = requestAnimationFrame(render);
+
+  return {
+    setActive(nextActive) {
+      active = nextActive;
+    },
+    destroy() {
+      destroyed = true;
+      cancelAnimationFrame(frame);
+      resizeObserver.disconnect();
+      canvas.removeEventListener("webglcontextlost", onContextLost);
+      gl.deleteBuffer(trailBuffer);
+      gl.deleteBuffer(pointBuffer);
+      gl.deleteProgram(program);
+    },
+  };
+}


### PR DESCRIPTION
## 概要

日本語・英語LPのヒーローをData Cinematicの方向性へ刷新し、軽量なWebGLによるデータフロー演出を追加します。

## 変更内容

- 濃紺背景、シアンのデータフロー、ライム系CTAを用いたヒーローへ刷新
- CSVの行・粒子が製品画面へ流れ込むWebGLアニメーションを追加
- AggyのHTML製品モックを暗色化し、集計画面を精緻化
- 日本語版と英語版で同じ構造・演出を適用
- `prefers-reduced-motion`、通信量節約設定、WebGL初期化失敗時の静的フォールバックを実装
- 非表示タブ・画面外で描画を停止し、DPRとモバイルの粒子数を制限
- LP用Playwrightテストを追加
- Playwrightのプレビュー用ポートを環境変数で変更可能に調整

## 影響範囲

LPのみの変更です。公開API、アプリ本体、データ形式、DuckDBによる集計処理には変更ありません。主要コピー、CTA、canonical、hreflang、FAQ、セマンティクス、`/app/`への導線は維持しています。

## 確認内容

- `vp build`
- `vp test run`（23ファイル・1,894テスト）
- LP Playwright E2E（Chromium / Firefox / WebKit、12テスト）
- Chromiumでデスクトップ・モバイル表示を目視確認
- 新規LP JavaScript gzip：約1.97KB

`vp check`は、現行`develop`にも存在する既知のエラー・警告があるため全体では完了していません。今回追加したTypeScript・E2Eファイルのlintとformatは通過しています。

## 今後の検討

セクション構成の整理と、Product Demoを中心とした追加演出は別の差分として検討します。

<sub>🤖 Written by Codex</sub>
